### PR TITLE
Improvements to stacktrace robustness.

### DIFF
--- a/src/cmd/tasks.rs
+++ b/src/cmd/tasks.rs
@@ -214,12 +214,11 @@ fn tasks(
                 let regs = hubris.registers(core, t)?;
 
                 if subargs.stack {
-                    if let Ok(stack) =
-                        hubris.stack(core, t, desc.initial_stack, &regs)
-                    {
-                        print_stack(hubris, &stack, &subargs);
-                    } else {
-                        println!("   (stack unwind info unavailable for task)");
+                    match hubris.stack(core, t, desc.initial_stack, &regs) {
+                        Ok(stack) => print_stack(hubris, &stack, &subargs),
+                        Err(e) => {
+                            println!("   stack unwind failed: {:?} ", e);
+                        }
                     }
                 }
 


### PR DESCRIPTION
- Stack traces are a lot less likely to panic or enter an infinite loop.

- If it _does_ enter an infinite loop, a check will fire and we'll
  record a coredump.

- We can now correctly generate stack traces for tasks that are
  interrupted by an ISR other than SVC.