### PR TITLE
Support Hubris targets with a 32-bit kernel-side restart count.

### DIFF
--- a/src/cmd/tasks.rs
+++ b/src/cmd/tasks.rs
@@ -155,7 +155,7 @@ fn tasks(
 
         println!("system time = {}", ticks);
 
-        println!("{:2} {:15} {:3} {:3} {:9}",
+        println!("{:2} {:15} {:>8} {:3} {:9}",
             "ID", "TASK", "GEN", "PRI", "STATE");
 
         let mut any_names_truncated = false;
@@ -194,8 +194,11 @@ fn tasks(
                     any_names_truncated = true;
                 }
                 print!(
-                    "{:2} {:15} {:3} {:3} ",
-                    i, modname, task.generation.0, task.priority.0
+                    "{:2} {:15} {:>8} {:3} ",
+                    i,
+                    modname,
+                    u32::from(task.generation),
+                    task.priority.0
                 );
             }
             explain_state(


### PR DESCRIPTION
Motivation in https://github.com/oxidecomputer/hubris/issues/208

This change makes Humility task parsing compatible with traditional 6-bits-in-a-`u8` counters and also 32-bit counters. It's required to make sense of Hubris dumps after https://github.com/oxidecomputer/hubris/pull/222 (which I plan to merge _after_ this).