### PR TITLE
Implement the `vsc7448` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,7 @@ dependencies = [
  "humility-cmd-tasks",
  "humility-cmd-test",
  "humility-cmd-trace",
+ "humility-cmd-vsc7448",
  "humility-core",
  "humility-cortex",
  "indexmap",
@@ -573,8 +574,6 @@ dependencies = [
  "spd",
  "structopt",
  "toml",
- "vsc7448-info",
- "vsc7448-types",
 ]
 
 [[package]]
@@ -909,6 +908,22 @@ dependencies = [
  "humility-core",
  "humility-cortex",
  "structopt",
+]
+
+[[package]]
+name = "humility-cmd-vsc7448"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hif",
+ "humility-cmd",
+ "humility-cmd-spi",
+ "humility-core",
+ "log",
+ "parse_int",
+ "structopt",
+ "vsc7448-info",
+ "vsc7448-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#c265da66a666efebd0a1b7e1d806c1293cfe330b"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#7ee43474d4f41649470cf58b3898ce7d33ebff8e"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#c265da66a666efebd0a1b7e1d806c1293cfe330b"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#7ee43474d4f41649470cf58b3898ce7d33ebff8e"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "spd",
  "structopt",
  "toml",
+ "vsc7448-info",
 ]
 
 [[package]]
@@ -1756,6 +1757,20 @@ checksum = "0d67cb4616d99b940db1d6bd28844ff97108b498a6ca850e5b6191a532063286"
 dependencies = [
  "vcell",
 ]
+
+[[package]]
+name = "vsc7448-info"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#28efdc29a3db9f5a0c0948b581a99909c494fa09"
+dependencies = [
+ "lazy_static",
+ "vsc7448-types",
+]
+
+[[package]]
+name = "vsc7448-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#28efdc29a3db9f5a0c0948b581a99909c494fa09"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,6 +1397,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1761,16 +1772,18 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#28efdc29a3db9f5a0c0948b581a99909c494fa09"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#7e34ad3cdca75f2b1fbc2d06fc753c654f23cfed"
 dependencies = [
  "lazy_static",
+ "regex",
+ "thiserror",
  "vsc7448-types",
 ]
 
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#28efdc29a3db9f5a0c0948b581a99909c494fa09"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#7e34ad3cdca75f2b1fbc2d06fc753c654f23cfed"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#c44418e5621bd26062eb6c6d91229043dc525541"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#8befe808bc35eb11c059e4cd4754c9c7ddc7bc8b"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#c44418e5621bd26062eb6c6d91229043dc525541"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#8befe808bc35eb11c059e4cd4754c9c7ddc7bc8b"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#35fb0797afcaf7a921db40a9839feedfef3d2ad4"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c265da66a666efebd0a1b7e1d806c1293cfe330b"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#35fb0797afcaf7a921db40a9839feedfef3d2ad4"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c265da66a666efebd0a1b7e1d806c1293cfe330b"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "structopt",
  "toml",
  "vsc7448-info",
+ "vsc7448-types",
 ]
 
 [[package]]
@@ -1772,7 +1773,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#8befe808bc35eb11c059e4cd4754c9c7ddc7bc8b"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#35fb0797afcaf7a921db40a9839feedfef3d2ad4"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1783,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#8befe808bc35eb11c059e4cd4754c9c7ddc7bc8b"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#35fb0797afcaf7a921db40a9839feedfef3d2ad4"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,7 +1772,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#7e34ad3cdca75f2b1fbc2d06fc753c654f23cfed"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c44418e5621bd26062eb6c6d91229043dc525541"
 dependencies = [
  "lazy_static",
  "regex",
@@ -1783,7 +1783,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#7e34ad3cdca75f2b1fbc2d06fc753c654f23cfed"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c44418e5621bd26062eb6c6d91229043dc525541"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "cmd/tasks",
     "cmd/test",
     "cmd/trace",
+    "cmd/vsc7448",
 ]
 
 [profile.release]
@@ -74,6 +75,7 @@ cmd-stmsecure = { path = "./cmd/stmsecure", package = "humility-cmd-stmsecure" }
 cmd-tasks = { path = "./cmd/tasks", package = "humility-cmd-tasks" }
 cmd-test = { path = "./cmd/test", package = "humility-cmd-test" }
 cmd-trace = { path = "./cmd/trace", package = "humility-cmd-trace" }
+cmd-vsc7448 = { path = "./cmd/vsc7448", package = "humility-cmd-vsc7448" }
 
 fallible-iterator = "0.2.0"
 log = {version = "0.4.8", features = ["std"]}
@@ -93,5 +95,3 @@ scroll = "0.10"
 indicatif = "0.15"
 colored = "2.0.0"
 indexmap = { version = "1.7", features = ["serde-1"] }
-vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
-vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,4 @@ scroll = "0.10"
 indicatif = "0.15"
 colored = "2.0.0"
 indexmap = { version = "1.7", features = ["serde-1"] }
+vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,4 @@ indicatif = "0.15"
 colored = "2.0.0"
 indexmap = { version = "1.7", features = ["serde-1"] }
 vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -169,7 +169,7 @@ fn gpio(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
 
     if subargs.input {
         let mut header = false;

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -9,7 +9,7 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 use std::thread;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use std::time::Duration;
 use structopt::clap::App;
@@ -73,23 +73,11 @@ fn gpio(
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
 
-    let func = |name, nargs| {
-        let f = funcs
-            .get(name)
-            .ok_or_else(|| anyhow!("did not find {} function", name))?;
-
-        if f.args.len() != nargs {
-            bail!("mismatched function signature on {}", name);
-        }
-
-        Ok(f)
-    };
-
-    let gpio_toggle = func("GpioToggle", 2)?;
-    let gpio_set = func("GpioSet", 2)?;
-    let gpio_reset = func("GpioReset", 2)?;
-    let gpio_input = func("GpioInput", 1)?;
-    let gpio_configure = func("GpioConfigure", 7)?;
+    let gpio_toggle = funcs.get("GpioToggle", 2)?;
+    let gpio_set = funcs.get("GpioSet", 2)?;
+    let gpio_reset = funcs.get("GpioReset", 2)?;
+    let gpio_input = funcs.get("GpioInput", 1)?;
+    let gpio_configure = funcs.get("GpioConfigure", 7)?;
     let mut configure_args = vec![];
 
     let target = if subargs.toggle {

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -7,11 +7,9 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
-use std::thread;
 
 use anyhow::{bail, Result};
 use hif::*;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -171,17 +169,7 @@ fn gpio(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
 
     if subargs.input {
         let mut header = false;

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -44,7 +44,7 @@ fn hiffy(
 
     byid.resize(funcs.len(), None);
 
-    for (name, func) in &funcs {
+    for (name, func) in &funcs.0 {
         let ndx = func.id.0 as usize;
 
         if ndx >= byid.len() {

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -9,7 +9,6 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::printmem;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-
 use structopt::clap::App;
 use structopt::StructOpt;
 

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -9,8 +9,7 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::printmem;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use std::thread;
-use std::time::Duration;
+
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -509,17 +508,8 @@ fn i2c(
             ops.push(Op::BranchGreaterThan(Target(0)));
             ops.push(Op::Done);
 
-            context.execute(core, ops.as_slice(), Some(&buf))?;
-
-            loop {
-                if context.done(core)? {
-                    break;
-                }
-
-                thread::sleep(Duration::from_millis(100));
-            }
-
-            let results = context.results(core)?;
+            let results =
+                context.execute_blocking(core, ops.as_slice(), Some(&buf))?;
 
             bar.set_position(offset.into());
 
@@ -639,17 +629,7 @@ fn i2c(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
 
     i2c_done(&subargs, &hargs, &results, func)?;
 

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
@@ -378,13 +378,7 @@ fn i2c(
     };
 
     let funcs = context.functions()?;
-    let func = funcs
-        .get(fname)
-        .ok_or_else(|| anyhow!("did not find {} function", fname))?;
-
-    if func.args.len() != args {
-        bail!("mismatched function signature on {}", fname);
-    }
+    let func = funcs.get(fname, args)?;
 
     let hargs = humility_cmd::i2c::I2cArgs::parse(
         hubris,
@@ -440,8 +434,7 @@ fn i2c(
         let mut file = File::open(filename)?;
         let mut last = false;
 
-        let sleep =
-            funcs.get("Sleep").ok_or_else(|| anyhow!("did not find Sleep"))?;
+        let sleep = funcs.get("Sleep", 1)?;
 
         let started = Instant::now();
         let bar = ProgressBar::new(filelen as u64);

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -508,8 +508,7 @@ fn i2c(
             ops.push(Op::BranchGreaterThan(Target(0)));
             ops.push(Op::Done);
 
-            let results =
-                context.execute_blocking(core, ops.as_slice(), Some(&buf))?;
+            let results = context.run(core, ops.as_slice(), Some(&buf))?;
 
             bar.set_position(offset.into());
 
@@ -629,7 +628,7 @@ fn i2c(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
 
     i2c_done(&subargs, &hargs, &results, func)?;
 

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -10,7 +10,7 @@ use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::thread;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use indexmap::IndexMap;
 use pmbus::commands::*;
@@ -1353,21 +1353,8 @@ fn pmbus(
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let func = funcs
-        .get("I2cRead")
-        .ok_or_else(|| anyhow!("did not find I2cRead function"))?;
-
-    if func.args.len() != 7 {
-        bail!("mismatched function signature on I2cRead");
-    }
-
-    let write_func = funcs
-        .get("I2cWrite")
-        .ok_or_else(|| anyhow!("did not find I2cWrite function"))?;
-
-    if write_func.args.len() != 8 {
-        bail!("mismatched function signature on I2cWrite");
-    }
+    let func = funcs.get("I2cRead", 7)?;
+    let write_func = funcs.get("I2cWrite", 8)?;
 
     if subargs.summarize {
         summarize(&subargs, hubris, core, &mut context, func, write_func)?;

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -759,7 +759,7 @@ fn summarize(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
     let mut base = 0;
 
     print!("{:13} {:16} {:3} {:4}", "DEVICE", "RAIL", "PG?", "#FLT");
@@ -1104,7 +1104,7 @@ fn writes(
     // Now go back through our devices checking results -- and creating our
     // next batch of work, if any.
     //
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
     let mut ndx = 0;
     let mut additional = false;
 
@@ -1246,7 +1246,7 @@ fn writes(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
     let mut ndx = 0;
 
     //
@@ -1559,7 +1559,7 @@ fn pmbus(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
 
     let base = if setrail {
         match results[0] {

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -8,7 +8,6 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use std::thread;
 
 use anyhow::{bail, Result};
 use hif::*;
@@ -17,7 +16,6 @@ use pmbus::commands::*;
 use pmbus::*;
 use std::collections::HashMap;
 use std::fmt::Write;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -761,17 +759,7 @@ fn summarize(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
     let mut base = 0;
 
     print!("{:13} {:16} {:3} {:4}", "DEVICE", "RAIL", "PG?", "#FLT");
@@ -1112,23 +1100,12 @@ fn writes(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
     //
     // Now go back through our devices checking results -- and creating our
     // next batch of work, if any.
     //
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
     let mut ndx = 0;
-
     let mut additional = false;
 
     let success = |harg, rail: &Option<u8>, cmd| {
@@ -1269,17 +1246,7 @@ fn writes(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
     let mut ndx = 0;
 
     //
@@ -1592,17 +1559,7 @@ fn pmbus(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
 
     let base = if setrail {
         match results[0] {

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -173,8 +173,7 @@ fn qspi(
 
             info!("erasing {} bytes...", filelen);
 
-            let results =
-                context.execute_blocking(core, ops.as_slice(), None)?;
+            let results = context.run(core, ops.as_slice(), None)?;
             let f = qspi_sector_erase;
 
             for (i, block_result) in results.iter().enumerate() {
@@ -250,8 +249,7 @@ fn qspi(
                 Op::Done,
             ];
 
-            let results =
-                context.execute_blocking(core, ops.as_slice(), Some(&buf))?;
+            let results = context.run(core, ops.as_slice(), Some(&buf))?;
 
             bar.set_position((offset + len).into());
 
@@ -309,7 +307,7 @@ fn qspi(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(
+    let results = context.run(
         core,
         ops.as_slice(),
         match data {

--- a/cmd/renbb/src/lib.rs
+++ b/cmd/renbb/src/lib.rs
@@ -9,7 +9,7 @@ use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::thread;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
@@ -92,21 +92,8 @@ fn renbb(
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let i2c_read = funcs
-        .get("I2cRead")
-        .ok_or_else(|| anyhow!("did not find I2cRead function"))?;
-
-    if i2c_read.args.len() != 7 {
-        bail!("mismatched function signature on I2cRead");
-    }
-
-    let i2c_write = funcs
-        .get("I2cWrite")
-        .ok_or_else(|| anyhow!("did not find I2cWrite function"))?;
-
-    if i2c_write.args.len() != 8 {
-        bail!("mismatched function signature on I2cWrite");
-    }
+    let i2c_read = funcs.get("I2cRead", 7)?;
+    let i2c_write = funcs.get("I2cWrite", 8)?;
 
     let hargs = match (&subargs.rail, &subargs.device) {
         (Some(rail), None) => {

--- a/cmd/renbb/src/lib.rs
+++ b/cmd/renbb/src/lib.rs
@@ -251,8 +251,7 @@ fn renbb(
             //
             ops.push(Op::Done);
 
-            let results =
-                context.execute_blocking(core, ops.as_slice(), None)?;
+            let results = context.run(core, ops.as_slice(), None)?;
 
             let start = if lap == 0 {
                 match results[0] {

--- a/cmd/renbb/src/lib.rs
+++ b/cmd/renbb/src/lib.rs
@@ -7,7 +7,6 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use std::thread;
 
 use anyhow::{bail, Result};
 use hif::*;
@@ -15,7 +14,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -253,17 +251,8 @@ fn renbb(
             //
             ops.push(Op::Done);
 
-            context.execute(core, ops.as_slice(), None)?;
-
-            loop {
-                if context.done(core)? {
-                    break;
-                }
-
-                thread::sleep(Duration::from_millis(100));
-            }
-
-            let results = context.results(core)?;
+            let results =
+                context.execute_blocking(core, ops.as_slice(), None)?;
 
             let start = if lap == 0 {
                 match results[0] {

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -11,7 +11,7 @@ use std::thread;
 
 use itertools::Itertools;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use std::collections::HashMap;
 use std::time::Duration;
@@ -86,21 +86,8 @@ fn rencm(
     let modules = modules();
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let read_func = funcs
-        .get("I2cRead")
-        .ok_or_else(|| anyhow!("did not find I2cRead function"))?;
-
-    if read_func.args.len() != 7 {
-        bail!("mismatched function signature on I2cRead");
-    }
-
-    let write_func = funcs
-        .get("I2cWrite")
-        .ok_or_else(|| anyhow!("did not find I2cWrite function"))?;
-
-    if write_func.args.len() != 8 {
-        bail!("mismatched function signature on I2cWrite");
-    }
+    let read_func = funcs.get("I2cRead", 7)?;
+    let write_func = funcs.get("I2cWrite", 8)?;
 
     let hargs = I2cArgs::parse(
         hubris,

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -342,7 +342,7 @@ fn rencm(
         //
         ops.push(Op::Done);
 
-        let results = context.execute_blocking(core, ops.as_slice(), None)?;
+        let results = context.run(core, ops.as_slice(), None)?;
 
         if results.len() != calls.len() {
             bail!(

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -7,14 +7,12 @@ use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use std::thread;
 
 use itertools::Itertools;
 
 use anyhow::{bail, Result};
 use hif::*;
 use std::collections::HashMap;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -344,17 +342,7 @@ fn rencm(
         //
         ops.push(Op::Done);
 
-        context.execute(core, ops.as_slice(), None)?;
-
-        loop {
-            if context.done(core)? {
-                break;
-            }
-
-            thread::sleep(Duration::from_millis(100));
-        }
-
-        let results = context.results(core)?;
+        let results = context.execute_blocking(core, ops.as_slice(), None)?;
 
         if results.len() != calls.len() {
             bail!(

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -264,7 +264,7 @@ fn spd(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(core, ops.as_slice(), None)?;
+    let results = context.run(core, ops.as_slice(), None)?;
     let mut header = true;
 
     if let Err(err) = results[0] {
@@ -322,8 +322,7 @@ fn spd(
 
             ops.push(Op::Done);
 
-            let results =
-                context.execute_blocking(core, ops.as_slice(), None)?;
+            let results = context.run(core, ops.as_slice(), None)?;
 
             //
             // If that succeeded, we'll have four buffers that should add up

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -8,11 +8,9 @@ use humility_cmd::hiffy::*;
 use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
-use std::thread;
 
 use anyhow::{bail, Result};
 use hif::*;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -266,17 +264,7 @@ fn spd(
 
     ops.push(Op::Done);
 
-    context.execute(core, ops.as_slice(), None)?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
+    let results = context.execute_blocking(core, ops.as_slice(), None)?;
     let mut header = true;
 
     if let Err(err) = results[0] {
@@ -334,17 +322,8 @@ fn spd(
 
             ops.push(Op::Done);
 
-            context.execute(core, ops.as_slice(), None)?;
-
-            loop {
-                if context.done(core)? {
-                    break;
-                }
-
-                thread::sleep(Duration::from_millis(100));
-            }
-
-            let results = context.results(core)?;
+            let results =
+                context.execute_blocking(core, ops.as_slice(), None)?;
 
             //
             // If that succeeded, we'll have four buffers that should add up

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -10,7 +10,7 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 use std::thread;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use std::time::Duration;
 use structopt::clap::App;
@@ -221,17 +221,8 @@ fn spd(
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
 
-    let i2c_read = funcs
-        .get("I2cRead")
-        .ok_or_else(|| anyhow!("did not find I2cRead function"))?;
-
-    let i2c_write = funcs
-        .get("I2cWrite")
-        .ok_or_else(|| anyhow!("did not find I2cWrite function"))?;
-
-    if i2c_read.args.len() != 7 {
-        bail!("mismatched function signature on I2cRead");
-    }
+    let i2c_read = funcs.get("I2cRead", 7)?;
+    let i2c_write = funcs.get("I2cWrite", 8)?;
 
     let hargs = I2cArgs::parse(
         hubris,

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -75,7 +75,7 @@ struct SpiArgs {
 /// hint to disambiguate).
 pub fn spi_task(
     hubris: &HubrisArchive,
-    peripheral: Option<u8>
+    peripheral: Option<u8>,
 ) -> Result<HubrisTask> {
     let lookup = |peripheral| {
         let spi = format!("spi{}", peripheral);

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -10,11 +10,9 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 
 use std::convert::TryInto;
 use std::str;
-use std::thread;
 
 use anyhow::{bail, Result};
 use hif::*;
-use std::time::Duration;
 use structopt::clap::App;
 use structopt::StructOpt;
 
@@ -236,7 +234,7 @@ fn spi(
 
     ops.push(Op::Done);
 
-    context.execute(
+    let results = context.execute_blocking(
         core,
         ops.as_slice(),
         match data {
@@ -244,16 +242,6 @@ fn spi(
             _ => None,
         },
     )?;
-
-    loop {
-        if context.done(core)? {
-            break;
-        }
-
-        thread::sleep(Duration::from_millis(100));
-    }
-
-    let results = context.results(core)?;
 
     if subargs.read {
         if let Ok(results) = &results[0] {

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -234,7 +234,7 @@ fn spi(
 
     ops.push(Op::Done);
 
-    let results = context.execute_blocking(
+    let results = context.run(
         core,
         ops.as_slice(),
         match data {

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -11,7 +11,7 @@ use std::convert::TryInto;
 use std::str;
 use std::thread;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use hif::*;
 use std::time::Duration;
 use structopt::clap::App;
@@ -82,20 +82,8 @@ fn spi(
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
 
-    let func = |name, nargs| {
-        let f = funcs
-            .get(name)
-            .ok_or_else(|| anyhow!("did not find {} function", name))?;
-
-        if f.args.len() != nargs {
-            bail!("mismatched function signature on {}", name);
-        }
-
-        Ok(f)
-    };
-
-    let spi_read = func("SpiRead", 3)?;
-    let spi_write = func("SpiWrite", 2)?;
+    let spi_read = funcs.get("SpiRead", 3)?;
+    let spi_write = funcs.get("SpiWrite", 2)?;
 
     let lookup = |peripheral| {
         let spi = format!("spi{}", peripheral);

--- a/cmd/vsc7448/Cargo.toml
+++ b/cmd/vsc7448/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "humility-cmd-vsc7448"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { version = "1.0.44", features = ["backtrace"] }
+hif = { path = "../../hif" }
+humility = { path = "../../humility-core", package = "humility-core" }
+humility-cmd = { path = "../../humility-cmd" }
+humility-cmd-spi = { path = "../spi" }
+log = {version = "0.4.8", features = ["std"]}
+parse_int = "0.4.0"
+structopt = "0.3"
+vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -1,15 +1,14 @@
-/*
- * Copyright 2021 Oxide Computer Company
- */
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use crate::cmd::{Archive, Attach, Validate};
 use humility::core::Core;
-use humility_cmd::hiffy::{HiffyContext, HiffyFunctions};
 use humility::hubris::*;
-use cmd_spi::spi_task;
-use crate::Args;
+use humility_cmd::hiffy::{HiffyContext, HiffyFunctions};
+use humility_cmd::{Archive, Args, Attach, Validate};
+use humility_cmd_spi::spi_task;
 
 use anyhow::{anyhow, bail, Result};
 use hif::*;
@@ -446,13 +445,13 @@ fn vsc7448_get_info(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (crate::cmd::Command, App<'a, 'b>) {
+pub fn init<'a, 'b>() -> (humility_cmd::Command, App<'a, 'b>) {
     // We do a bonus parse of the command-line arguments here to see if we're
     // doing a `vsc7448 info` subcommand, which doesn't require a Hubris image
     // or attached device; skipping those steps improves runtime (especially
     // in debug builds)
     let subcmd_attached = (
-        crate::cmd::Command::Attached {
+        humility_cmd::Command::Attached {
             name: "vsc7448",
             archive: Archive::Required,
             attach: Attach::LiveOnly,
@@ -462,7 +461,7 @@ pub fn init<'a, 'b>() -> (crate::cmd::Command, App<'a, 'b>) {
         Vsc7448Args::clap(),
     );
     let subcmd_unattached = (
-        crate::cmd::Command::Unattached {
+        humility_cmd::Command::Unattached {
             name: "vsc7448",
             archive: Archive::Ignored,
             run: vsc7448_get_info,

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -113,7 +113,10 @@ pub struct HiffyFunctions(pub HashMap<String, HiffyFunction>);
 
 impl HiffyFunctions {
     pub fn get(&self, name: &str, nargs: usize) -> Result<&HiffyFunction> {
-        let f = self.0.get(name).ok_or_else(|| anyhow!("did not find {} function", name))?;
+        let f = self
+            .0
+            .get(name)
+            .ok_or_else(|| anyhow!("did not find {} function", name))?;
         if f.args.len() != nargs {
             bail!("mismatched function signature on {}", name);
         }

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -9,7 +9,8 @@ use humility::hubris::*;
 use postcard::{take_from_bytes, to_slice};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+use std::thread;
 
 #[derive(Debug, PartialEq)]
 enum State {
@@ -364,6 +365,19 @@ impl<'a> HiffyContext<'a> {
 
         core.run()?;
 
+        Ok(())
+    }
+
+    pub fn execute_blocking(
+        &mut self,
+        core: &mut dyn Core,
+        ops: &[Op],
+        data: Option<&[u8]>,
+    ) -> Result<()> {
+        self.execute(core, ops, data)?;
+        while !self.done(core)? {
+            thread::sleep(Duration::from_millis(100));
+        }
         Ok(())
     }
 

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -305,7 +305,9 @@ impl<'a> HiffyContext<'a> {
         Ok(HiffyFunctions(rval))
     }
 
-    pub fn execute(
+    /// Begins HIF execution.  This is non-blocking with respect to the HIF
+    /// program, so you will need to poll [Self::done] to check for completion.
+    pub fn start(
         &mut self,
         core: &mut dyn Core,
         ops: &[Op],
@@ -375,7 +377,7 @@ impl<'a> HiffyContext<'a> {
         ops: &[Op],
         data: Option<&[u8]>,
     ) -> Result<Vec<Result<Vec<u8>, u32>>> {
-        self.execute(core, ops, data)?;
+        self.start(core, ops, data)?;
         while !self.done(core)? {
             thread::sleep(Duration::from_millis(100));
         }

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -369,7 +369,7 @@ impl<'a> HiffyContext<'a> {
     }
 
     /// Blocking execution of a program, returning the results
-    pub fn execute_blocking(
+    pub fn run(
         &mut self,
         core: &mut dyn Core,
         ops: &[Op],

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -9,8 +9,8 @@ use humility::hubris::*;
 use postcard::{take_from_bytes, to_slice};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::time::{Duration, Instant};
 use std::thread;
+use std::time::{Duration, Instant};
 
 #[derive(Debug, PartialEq)]
 enum State {
@@ -368,17 +368,18 @@ impl<'a> HiffyContext<'a> {
         Ok(())
     }
 
+    /// Blocking execution of a program, returning the results
     pub fn execute_blocking(
         &mut self,
         core: &mut dyn Core,
         ops: &[Op],
         data: Option<&[u8]>,
-    ) -> Result<()> {
+    ) -> Result<Vec<Result<Vec<u8>, u32>>> {
         self.execute(core, ops, data)?;
         while !self.done(core)? {
             thread::sleep(Duration::from_millis(100));
         }
-        Ok(())
+        self.results(core)
     }
 
     pub fn done(&mut self, core: &mut dyn Core) -> Result<bool> {

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -63,9 +63,14 @@ pub enum Subcommand {
 #[allow(dead_code)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Archive {
+    /// Load a Hubris archive, failing if one is not present
     Required,
+    /// Load a Hubris archive if available (as either a command-line flag or
+    /// environmental variable); continue to run if no archive is present
     Optional,
-    Prohibited,
+    /// Do not load a Hubris archive, even if the command-line flag or
+    /// environmental variable is set.  This saves a small amount of start-up
+    /// time for subcommands which don't require a Hubris archive.
     Ignored,
 }
 

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -61,11 +61,12 @@ pub enum Subcommand {
 }
 
 #[allow(dead_code)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Archive {
     Required,
     Optional,
     Prohibited,
+    Ignored,
 }
 
 #[allow(dead_code)]

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3686,6 +3686,17 @@ impl HubrisTask {
             HubrisTask::Task(id) => format!("{}", id),
         }
     }
+    /// Returns the inner `u32` from a `Task` variant.
+    ///
+    /// # Panics
+    /// Panics if this is `HubrisTask::Kernel`
+    pub fn task(&self) -> u32 {
+        if let HubrisTask::Task(u) = self {
+            *u
+        } else {
+            panic!("Cannot get task id of kernel");
+        }
+    }
 }
 
 impl fmt::Display for HubrisTask {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,13 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod vsc7448;
-
+use anyhow::{bail, Context, Result};
 use humility::hubris::*;
 use humility_cmd::Args;
 use humility_cmd::{attach_dump, attach_live};
 use humility_cmd::{Archive, Attach, Command, Validate};
-use anyhow::{bail, Context, Result};
 use std::collections::HashMap;
 use structopt::clap::App;
 
@@ -46,7 +44,7 @@ pub fn init<'a, 'b>(
         cmd_test::init,
         cmd_trace::init,
         cmd_stmsecure::init,
-        vsc7448::init,
+        cmd_vsc7448::init,
     ];
 
     for dcmd in &dcmds {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod vsc7448;
+
 use anyhow::{bail, Result};
 use humility::hubris::*;
 use humility_cmd::Args;
@@ -44,6 +46,7 @@ pub fn init<'a, 'b>(
         cmd_test::init,
         cmd_trace::init,
         cmd_stmsecure::init,
+        vsc7448::init,
     ];
 
     for dcmd in &dcmds {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -84,16 +84,8 @@ pub fn subcommand(
             }
         }
 
-        match (archive, hubris.loaded()) {
-            (Archive::Required, false) => {
-                bail!("must provide a Hubris archive or dump");
-            }
-
-            (Archive::Prohibited, true) => {
-                bail!("does not operate on a Hubris archive or dump");
-            }
-
-            (_, _) => {}
+        if *archive == Archive::Required && !hubris.loaded() {
+            bail!("must provide a Hubris archive or dump");
         }
 
         match command {

--- a/src/cmd/vsc7448.rs
+++ b/src/cmd/vsc7448.rs
@@ -1,8 +1,8 @@
 /*
  * Copyright 2021 Oxide Computer Company
  */
-use std::convert::TryInto;
 use std::collections::HashMap;
+use std::convert::TryInto;
 
 use crate::cmd::{Archive, Attach, Validate};
 use humility::core::Core;
@@ -16,8 +16,8 @@ use hif::*;
 use log::info;
 use structopt::clap::App;
 use structopt::StructOpt;
-use vsc7448_types::{Field};
-use vsc7448_info::parse::{TargetRegister, PhyRegister};
+use vsc7448_info::parse::{PhyRegister, TargetRegister};
+use vsc7448_types::Field;
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "spi", about = "SPI reading and writing")]
@@ -41,9 +41,11 @@ impl Vsc7448Args {
     /// Checks whether the given subcommand requires an attached target
     /// (i.e. a microcontroller running Hubris, connected through a debugger)
     fn requires_target(&self) -> bool {
-        !matches!(&self.cmd,
-            Command::Info { .. } |
-            Command::Phy { cmd: PhyCommand::Info { .. }, .. })
+        !matches!(
+            &self.cmd,
+            Command::Info { .. }
+                | Command::Phy { cmd: PhyCommand::Info { .. }, .. }
+        )
     }
 }
 
@@ -102,12 +104,8 @@ fn pretty_print_fields(value: u32, fields: &HashMap<&str, Field<&str>>) {
     println!("  bits |    value   | field");
     for f in field_keys {
         let field = &fields[*f];
-        let bits =
-            (value & ((1u64 << field.hi) - 1) as u32) >> field.lo;
-        println!(
-            " {:>2}:{:<2} | 0x{:<8x} | {}",
-            field.hi, field.lo, bits, f
-        );
+        let bits = (value & ((1u64 << field.hi) - 1) as u32) >> field.lo;
+        println!(" {:>2}:{:<2} | 0x{:<8x} | {}", field.hi, field.lo, bits, f);
     }
 }
 
@@ -232,26 +230,34 @@ impl<'a> Vsc7448<'a> {
         }
     }
 
-    fn miim_read(&mut self, phy: PhyAddr, reg: &PhyRegister) -> Result<u16> {
+    fn miim_read(&mut self, phy: &PhyAddr, page: u16, reg: u8) -> Result<u16> {
         if phy.phy >= 32 {
             bail!("Invalid phy address {} (must be < 32)", phy.phy);
         }
-        let reg_addr = reg.reg_addr();
-        if reg_addr >= 32 {
-            bail!("Invalid register address {} (must be < 32)", reg_addr);
+        if reg >= 32 {
+            bail!("Invalid register address {} (must be < 32)", reg);
         }
-        if reg.page_addr() != 0 {
-            unimplemented!("Non-default pages are not yet supported")
-        }
+        // Switch pages every time, since it's cheap and easier than restoring
+        // the page when done _or_ whenever exiting early
+        info!("Switching to page {}", page);
+        self.miim_write_inner(
+            phy,
+            0,  // STANDARD
+            31, // PAGE
+            page.try_into().unwrap(),
+            false,
+        )?;
         let data = (1 << 31) | // MIIM_CMD_VLD
             ((phy.phy as u32) << 25) | // MIIM_CMD_PHYAD
-            ((reg_addr as u32) << 20) | // MIIM_CMD_PHYAD
+            ((reg as u32) << 20) | // MIIM_CMD_PHYAD
             (0b10 << 1); // MIIM_CMD_OPR_FIELD (read)
 
-        let mii_cmd = format!("MIIM[{}]:MII_CMD", phy.miim).parse::<TargetRegister>()?;
+        let mii_cmd =
+            format!("MIIM[{}]:MII_CMD", phy.miim).parse::<TargetRegister>()?;
         self.write(mii_cmd.address(), data)?;
 
-        let mii_data = format!("MIIM[{}]:MII_DATA", phy.miim).parse::<TargetRegister>()?;
+        let mii_data =
+            format!("MIIM[{}]:MII_DATA", phy.miim).parse::<TargetRegister>()?;
         let out = self.read(mii_data.address())?;
 
         if ((out >> 16) & 3) == 3 {
@@ -259,25 +265,52 @@ impl<'a> Vsc7448<'a> {
         }
         Ok((out & 0xFFFF) as u16)
     }
-    fn miim_write(&mut self, phy: PhyAddr, reg: &PhyRegister, data: u16) -> Result<()> {
+
+    fn miim_write_inner(
+        &mut self,
+        phy: &PhyAddr,
+        page: u16,
+        reg: u8,
+        data: u16,
+        switch_page: bool,
+    ) -> Result<()> {
         if phy.phy >= 32 {
             bail!("Invalid phy address {} (must be < 32)", phy.phy);
         }
-        let reg_addr = reg.reg_addr();
-        if reg_addr >= 32 {
-            bail!("Invalid register address {} (must be < 32)", reg_addr);
+        if reg >= 32 {
+            bail!("Invalid register address {} (must be < 32)", reg);
         }
-        if reg.page_addr() != 0 {
-            unimplemented!("Non-default pages are not yet supported")
+        // Switch pages every time, since it's cheap and easier than restoring
+        // the page when done _or_ whenever exiting early
+        if switch_page {
+            info!("Switching to page {}", page);
+            self.miim_write_inner(
+                phy,
+                0,  // STANDARD
+                31, // PAGE
+                page.try_into().unwrap(),
+                false,
+            )?;
         }
         let data = (1 << 31) | // MIIM_CMD_VLD
             ((phy.phy as u32) << 25) | // MIIM_CMD_PHYAD
-            ((reg_addr as u32) << 20) | // MIIM_CMD_PHYAD
+            ((reg as u32) << 20) | // MIIM_CMD_PHYAD
             ((data as u32) << 4) | // MIIM_CMD_WRDATA
             (0b01 << 1); // MIIM_CMD_OPR_FIELD (write)
 
-        let mii_cmd = format!("MIIM[{}]:MII_CMD", phy.miim).parse::<TargetRegister>()?;
+        let mii_cmd =
+            format!("MIIM[{}]:MII_CMD", phy.miim).parse::<TargetRegister>()?;
         self.write(mii_cmd.address(), data)
+    }
+
+    fn miim_write(
+        &mut self,
+        phy: &PhyAddr,
+        page: u16,
+        reg: u8,
+        data: u16,
+    ) -> Result<()> {
+        self.miim_write_inner(phy, page, reg, data, true)
     }
 }
 
@@ -313,23 +346,81 @@ fn vsc7448(
 
             vsc.write(addr, value)?;
         }
-        Command::Phy { cmd } => match cmd {
-            PhyCommand::Write { addr, reg, value } => {
-                let reg: PhyRegister = reg.parse()?;
-                println!("Writing 0x{:x} to {} at MIIM{}:{}", value, reg, addr.miim, addr.phy);
-                pretty_print_fields(value as u32, reg.fields());
-                vsc.set_miim_gpios(addr.miim)?;
-                vsc.miim_write(addr, &reg, value)?;
-            },
-            PhyCommand::Read { addr, reg } => {
-                let reg: PhyRegister = reg.parse()?;
-                vsc.set_miim_gpios(addr.miim)?;
-                println!("Reading from {} at MIIM{}:{}", reg, addr.miim, addr.phy);
-                let out = vsc.miim_read(addr, &reg)?;
-                println!("Got result 0x{:x}", out);
-                pretty_print_fields(out as u32, reg.fields());
-            },
-            _ => panic!("Invalid PHY command"),
+        Command::Phy { cmd } => {
+            let dummy_fields = HashMap::new();
+            let reg = match &cmd {
+                PhyCommand::Write { reg, .. }
+                | PhyCommand::Read { reg, .. } => reg,
+                _ => panic!("Invalid PHY command"),
+            };
+
+            // Attempt to parse to known registers, then do a last-chance parse
+            // where we just attempt to read numbers, e.g. 5:13 (as page:reg).
+            //
+            // This is necessary because the SDK PHY headers don't necessarily
+            // include every register in every PHY, and even lack some registers
+            // in the Microchip PHY that's on the dev kit (!!)
+            let parsed = reg.parse::<PhyRegister>();
+            let (page, reg, name, fields) = if let Ok(reg) = parsed {
+                (
+                    reg.page_addr().try_into().unwrap(),
+                    reg.reg_addr().try_into().unwrap(),
+                    format!("{}", reg),
+                    reg.fields(),
+                )
+            } else {
+                if let Ok(nums) = reg
+                    .split(':')
+                    .map(|s| s.parse::<u16>())
+                    .collect::<Result<Vec<_>, _>>()
+                {
+                    match nums.len() {
+                        1 => (
+                            0,
+                            nums[0].try_into().unwrap(),
+                            format!("0:{}", nums[0]),
+                            &dummy_fields,
+                        ),
+                        2 => (
+                            nums[0],
+                            nums[1].try_into().unwrap(),
+                            format!("{}:{}", nums[0], nums[1]),
+                            &dummy_fields,
+                        ),
+                        _ => {
+                            Err(vsc7448_info::parse::ParseError::TooManyItems)?
+                        }
+                    }
+                } else {
+                    // If the last-change parse failed, then just return the
+                    // previous parse error.
+                    assert!(parsed.is_err());
+                    parsed?;
+                    unreachable!()
+                }
+            };
+            match cmd {
+                PhyCommand::Write { addr, value, .. } => {
+                    println!(
+                        "Writing 0x{:x} to {} at MIIM{}:{}",
+                        value, name, addr.miim, addr.phy
+                    );
+                    pretty_print_fields(value as u32, fields);
+                    vsc.set_miim_gpios(addr.miim)?;
+                    vsc.miim_write(&addr, page, reg, value)?;
+                }
+                PhyCommand::Read { addr, .. } => {
+                    println!(
+                        "Reading from {} at MIIM{}:{}",
+                        name, addr.miim, addr.phy
+                    );
+                    vsc.set_miim_gpios(addr.miim)?;
+                    let out = vsc.miim_read(&addr, page, reg)?;
+                    println!("Got result 0x{:x}", out);
+                    pretty_print_fields(out as u32, fields);
+                }
+                _ => panic!("Invalid PHY command"),
+            }
         }
     };
     Ok(())
@@ -346,11 +437,11 @@ fn vsc7448_get_info(
         Command::Info { reg } => {
             let reg: TargetRegister = reg.parse()?;
             println!("Register address: {:x}", reg.address());
-        },
+        }
         Command::Phy { cmd: PhyCommand::Info { reg } } => {
             let reg: PhyRegister = reg.parse()?;
             println!("PHY register: {}", reg);
-        },
+        }
         _ => panic!("Called vsc7448_get_info without info subcommand"),
     }
     Ok(())

--- a/src/cmd/vsc7448.rs
+++ b/src/cmd/vsc7448.rs
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2021 Oxide Computer Company
+ */
+use crate::cmd::{Archive, Attach, Validate};
+use humility::core::Core;
+use humility_cmd::hiffy::{HiffyContext, HiffyFunctions};
+use humility::hubris::*;
+use cmd_spi::spi_task;
+use crate::Args;
+
+use anyhow::{anyhow, bail, Result};
+use hif::*;
+use structopt::clap::App;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+#[structopt(name = "spi", about = "SPI reading and writing")]
+struct Vsc7448Args {
+    /// sets timeout
+    #[structopt(
+        long, short = "T", default_value = "5000", value_name = "timeout_ms",
+        parse(try_from_str = parse_int::parse)
+    )]
+    timeout: u32,
+
+    /// SPI peripheral on which to operate
+    #[structopt(long, short, value_name = "peripheral")]
+    peripheral: Option<u8>,
+
+    #[structopt(long, short, parse(try_from_str = parse_int::parse), value_name = "addr")]
+    addr: u32,
+}
+
+struct Vsc7448<'a> {
+    core: &'a mut dyn Core,
+    context: HiffyContext<'a>,
+
+    task: HubrisTask,
+    funcs: HiffyFunctions,
+}
+
+impl<'a> Vsc7448<'a> {
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        core: &'a mut dyn Core,
+        args: Vsc7448Args,
+    ) -> Result<Self> {
+        let mut context = HiffyContext::new(hubris, core, args.timeout)?;
+        let funcs = context.functions()?;
+
+        let task = spi_task(hubris, args.peripheral)?;
+        Ok(Self { core, context, task, funcs })
+    }
+
+    // Writes a single 32-bit register
+    fn write(&mut self, addr: u32, data: u32) -> Result<()> {
+        let spi_write = self.funcs.get("SpiWrite", 2)?;
+
+        // Write 7 bytes from the data array over SPI
+        let ops = [
+            Op::Push32(self.task.task()),
+            Op::Push32(0x7), // Write size
+            Op::Call(spi_write.id),
+            Op::Done,
+        ];
+
+        if !(0x71000000..=0x72000000).contains(&addr) {
+            bail!("Address must be in Switch Core Register Bus (0x71000000)");
+        }
+        let addr = (addr & 0x00FFFFFF) >> 2;
+        let data = [
+            // 24-bit address, with high bit set to mark write
+            ((addr >> 16) & 0xFF) as u8 | 0x80,
+            ((addr >> 8) & 0xFF) as u8,
+            (addr & 0xFF) as u8,
+            // 32-bit data word
+            ((data >> 24) & 0xFF) as u8,
+            ((data >> 16) & 0xFF) as u8,
+            ((data >> 8) & 0xFF) as u8,
+            (data & 0xFF) as u8,
+        ];
+        self.context.execute_blocking(self.core, &ops, Some(&data))?;
+        Ok(())
+    }
+
+    // Reads a single 32-bit register
+    fn read(&mut self, addr: u32) -> Result<u32> {
+        let spi_read = self.funcs.get("SpiRead", 3)?;
+
+        // Write 3 bytes of address, and read 8 bytes back in total
+        // (3 address bytes, 1 padding byte, 4 bytes of result)
+        let ops = [
+            Op::Push32(self.task.task()),
+            Op::Push32(0x3), // Write size
+            Op::Push32(0x8), // Read size
+            Op::Call(spi_read.id),
+            Op::Done,
+        ];
+        if !(0x71000000..=0x72000000).contains(&addr) {
+            bail!("Address must be in Switch Core Register Bus (0x71000000)");
+        }
+        let addr = (addr & 0x00FFFFFF) >> 2;
+        let data = [
+            // 24-bit address, with high bit cleared for a read
+            ((addr >> 16) & 0xFF) as u8,
+            ((addr >> 8) & 0xFF) as u8,
+            (addr & 0xFF) as u8,
+        ];
+        let results =
+            self.context.execute_blocking(self.core, &ops, Some(&data))?;
+        let r = results[0]
+            .as_ref()
+            .map_err(|e| anyhow!("Got error code: {}", e))?;
+        if r.len() != 8 {
+            bail!("wrong length read: {:x?}", r);
+        }
+        Ok(((r[4] as u32) << 24)
+            | ((r[5] as u32) << 16)
+            | ((r[6] as u32) << 8)
+            | r[7] as u32)
+    }
+
+    fn init(&mut self) -> Result<()> {
+        // Set DEVCPU_ORG:DEVCPU_ORG:IF_CTRL to 1
+        // (using a special write pattern to be unambiguous regardless of
+        // endianness or bit order; see the register manual for details)
+        self.write(0x71000000, 0x81818181)?;
+
+        // Set IF_CFGSTAT = 1 (to add one padding byte to read outputs)
+        self.write(0x71000004, 0x1)?;
+
+        // Read DEVCPU_GCB:CHIP_REGS:CHIP_ID to confirm we're happy
+        let chip_id_reg = self.read(0x71010000)?;
+        if chip_id_reg != 0x374680E9 {
+            bail!("Invalid chip ID register: {}", chip_id_reg);
+        }
+        Ok(())
+    }
+}
+
+fn vsc7448(
+    hubris: &mut HubrisArchive,
+    core: &mut dyn Core,
+    _args: &Args,
+    subargs: &Vec<String>,
+) -> Result<()> {
+    let subargs = Vsc7448Args::from_iter_safe(subargs)?;
+    let mut vsc = Vsc7448::new(hubris, core, subargs)?;
+    vsc.init()?;
+    Ok(())
+}
+
+pub fn init<'a, 'b>() -> (crate::cmd::Command, App<'a, 'b>) {
+    (
+        crate::cmd::Command::Attached {
+            name: "vsc7448",
+            archive: Archive::Required,
+            attach: Attach::LiveOnly,
+            validate: Validate::Booted,
+            run: vsc7448,
+        },
+        Vsc7448Args::clap(),
+    )
+}

--- a/src/cmd/vsc7448.rs
+++ b/src/cmd/vsc7448.rs
@@ -158,7 +158,7 @@ impl<'a> Vsc7448<'a> {
             ((data >> 8) & 0xFF) as u8,
             (data & 0xFF) as u8,
         ];
-        self.context.execute_blocking(self.core, &ops, Some(&data))?;
+        self.context.run(self.core, &ops, Some(&data))?;
         Ok(())
     }
 
@@ -185,8 +185,7 @@ impl<'a> Vsc7448<'a> {
             ((addr >> 8) & 0xFF) as u8,
             (addr & 0xFF) as u8,
         ];
-        let results =
-            self.context.execute_blocking(self.core, &ops, Some(&data))?;
+        let results = self.context.run(self.core, &ops, Some(&data))?;
         let r = results[0]
             .as_ref()
             .map_err(|e| anyhow!("Got error code: {}", e))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use humility::hubris::*;
 use humility_cmd::{Args, Subcommand};
 
 use structopt::StructOpt;
@@ -96,25 +95,9 @@ fn main() {
         HumilityLog { level: log::LevelFilter::Info }.enable();
     }
 
-    let mut hubris = HubrisArchive::new()
-        .map_err(|err| {
-            fatal!("failed to initialize: {}", err);
-        })
-        .unwrap();
-
-    if let Some(archive) = &args.archive {
-        if let Err(err) = hubris.load(archive) {
-            fatal!("failed to load archive: {:#}", err);
-        }
-    } else if let Some(dump) = &args.dump {
-        if let Err(err) = hubris.load_dump(dump) {
-            fatal!("failed to load dump: {:#}", err);
-        }
-    }
-
     match &args.cmd {
         Subcommand::Other(ref subargs) => {
-            match cmd::subcommand(&commands, &mut hubris, &args, subargs) {
+            match cmd::subcommand(&commands, &args, subargs) {
                 Err(err) => fatal!("{} failed: {:?}", subargs[0], err),
                 _ => std::process::exit(0),
             }


### PR DESCRIPTION
This PR implements the `humility vsc7448` subcommand, which lets a Hubris system talk over SPI to a VSC7448 ethernet switch IC.

It also includes a handful of drive-by changes:
- Adds `Archive::Ignored` and refactors some code to avoid loading a Hubris archive if it isn't needed, saving 1-2 seconds of startup time.
- Moves get-a-function-from-HIF into a standalone function in a new `struct HiffyFunctions`, to get rid of some duplicated code.
- Adds `HiffyContext::execute_blocking`, which is just `execute` + wait until the core is done + return the result.
- Move which-task-is-SPI into a standalone helper function, since it's now used in both `humility spi` and `humility vsc7448`.