### PR TITLE
Update submodules to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "hif"]
 	path = hif
-	url = git@github.com:oxidecomputer/hif.git
+	url = https://github.com/oxidecomputer/hif
 [submodule "pmbus"]
 	path = pmbus
-	url = git@github.com:oxidecomputer/pmbus.git
+	url = https://github.com/oxidecomputer/pmbus
 [submodule "spd"]
 	path = spd
-	url = git@github.com:oxidecomputer/spd.git
+	url = https://github.com/oxidecomputer/spd
 [submodule "idt8a3xxxx"]
 	path = idt8a3xxxx
-	url = git@github.com:oxidecomputer/idt8a3xxxx.git
+	url = https://github.com/oxidecomputer/idt8a3xxxx


### PR DESCRIPTION
We had these via git@ because they were private, now that they're
public, let's use the more usual URL.