### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ humility: reading at 0x11d00 for 100 bytes
 ```
 
 Both arguments can be in either hex, decimal, octal or binary (addresses
-and contents will always be prented in hex):
+and contents will always be printed in hex):
 
 ```console
 humility readmem 0o216401 0b110


### PR DESCRIPTION
fix typo: prented -> printed

Incidentally, I also had trouble understanding this sentence in `humility map`, but I wasn't sure how to fix it, perhaps due to my unfamiliarity with embedded systems:

> This can happen, for example, because the task attempted to access device memory that was not allocated to it in the build description, because it exceeded the device memory allocated to it, or because it allocated the memory allocated to it, e.g., because of a stack overflow.

Specifically, "because it allocated the memory allocated to it" doesn't sound like a problem.  Should this be something like, "because it allocated *past* the memory allocated to it"?