### PR TITLE
hubris: fix compile error (missing format arg)

### DIFF
--- a/src/hubris.rs
+++ b/src/hubris.rs
@@ -3909,7 +3909,7 @@ impl HubrisEnum {
             }
         } else {
             if self.variants.is_empty() {
-                bail!("enum {} has no variants");
+                bail!("enum {} has no variants", self.goff);
             }
 
             if self.variants.len() > 1 {


### PR DESCRIPTION
Fixes this compile error
```
❯ cargo install --path .
  Installing humility v0.5.0 (/Users/stro/humility)
    Updating crates.io index
    Updating git repository `https://github.com/oxidecomputer/probe-rs.git`
   Compiling humility v0.5.0 (/Users/stro/humility)
error: 1 positional argument in format string, but no arguments were given
    --> src/hubris.rs:3912:29
     |
3912 |                 bail!("enum {} has no variants");
     |                             ^^

error: failed to compile `humility v0.5.0 (/Users/stro/humility)`, intermediate artifacts can be found at `/Users/stro/humility/target`

Caused by:
  could not compile `humility` due to previous error

```
