### PR TITLE
Add rust-toolchain file.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.57"


### PR DESCRIPTION
Because we've started using the 2021 Edition in some crates, peoples'
build will mysteriously fail with an older toolchain.

Fixes #53.