### PR TITLE
Add in MSRV job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,9 +3,29 @@ on: [push, pull_request]
 name: Continuous integration
 
 env:
+  MSRV: 1.58.0
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too
 
 jobs:
+  check-msrv:
+    name: Check (MSRV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install libusb-1.0-0-dev libftdi1-dev
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.MSRV }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --profile=ci
   check:
     name: Check
     runs-on: ubuntu-latest
@@ -18,7 +38,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -38,7 +58,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: ${{ env.MSRV }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -58,7 +78,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: ${{ env.MSRV }}
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -83,9 +83,7 @@ fn readmem(
     let rval = core.read_8(addr, &mut bytes);
     core.run()?;
 
-    if rval.is_err() {
-        return rval;
-    }
+    rval?;
 
     if subargs.symbol {
         for offs in (0..length).step_by(size) {

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -187,9 +187,7 @@ fn spd(
         let rval = core.read_8(spd_data.addr, &mut bytes);
         core.run()?;
 
-        if rval.is_err() {
-            return rval;
-        }
+        rval?;
 
         let mut header = true;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.57"
+channel = "1.58.0"


### PR DESCRIPTION
I'm so used to libraries requiring nightly that I forgot: since this builds on stable, you should at least build MSRV + current stable.