### PR TITLE
Search harder for TICKS, CLOCK_FREQ_KHZ

### DIFF
--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -132,7 +132,14 @@ fn tasks(
     let base = core.read_word_32(hubris.lookup_symword("TASK_TABLE_BASE")?)?;
     let task_count =
         core.read_word_32(hubris.lookup_symword("TASK_TABLE_SIZE")?)?;
-    let ticks = core.read_word_64(hubris.lookup_variable("TICKS")?.addr)?;
+    let (ticks_addr, ticks_size) = hubris
+        .lookup_variable("TICKS")
+        .map(|var| (var.addr, var.size as u32))
+        .or_else(|_| hubris.lookup_symbol("kern::arch::arm_m::TICKS"))?;
+    if ticks_size != 8 {
+        bail!("TICKS not u64 sized");
+    }
+    let ticks = core.read_word_64(ticks_addr)?;
 
     let task_t = hubris.lookup_struct_byname("Task")?;
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3654,15 +3654,20 @@ impl HubrisArchive {
 
         trace!("determining clock requency via {}", name);
 
-        match self.variables.get(name) {
-            Some(variable) => {
-                if variable.size != 4 {
+        let variable = self
+            .variables
+            .get(name)
+            .map(|variable| (variable.addr, variable.size as u32))
+            .or_else(|| self.esyms_byname.get(name).map(|t| *t));
+        match variable {
+            Some((addr, size)) => {
+                if size != 4 {
                     Err(anyhow!(
                         "{} has wrong size (expected 4, found {})",
-                        name, variable.size
+                        name, size
                     ))
                 } else {
-                    Ok(Some(core.read_word_32(variable.addr)?))
+                    Ok(Some(core.read_word_32(addr)?))
                 }
             }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -1648,7 +1648,7 @@ impl HubrisArchive {
             let dem = format!("{:#}", demangle(name));
 
             self.esyms_byname
-                .insert(name.to_string(), (val, sym.st_size as u32));
+                .insert(dem.to_string(), (val, sym.st_size as u32));
             self.esyms.insert(val, (dem, sym.st_size as u32));
         }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2211,6 +2211,14 @@ impl HubrisArchive {
         }
     }
 
+    /// Look up a symbol, returning it's address and length as a tuple
+    pub fn lookup_symbol(&self, name: &str) -> Result<(u32, u32)> {
+        match self.esyms_byname.get(name) {
+            Some(sym) => Ok(*sym),
+            None => Err(anyhow!("expected symbol {} not found", name)),
+        }
+    }
+
     pub fn lookup_variable(&self, name: &str) -> Result<&HubrisVariable> {
         match self.variables.get(name) {
             Some(variable) => Ok(variable),


### PR DESCRIPTION
In my builds of hubris, the `TICKS` and `CLOCK_FREQ_KHZ` variables were both not included in `HubrisArchive`'s `variables` member. Instead, they showed up in the `esyms` and `esyms_byname` members. So I made humility search a bit harder for them by also looking in the `esyms_byname` member. There may be more of these that I have yet to find, and this makes humulity's trace and tasks subcommands work for me.