### PR TITLE
Add support for STM32G0x1 (Cortex-M0+)

### DIFF
--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -74,7 +74,17 @@ fn probecmd(
 
     print(
         "chip",
-        if coreinfo.vendor == Vendor::ST && part == ARMCore::CortexM4 {
+        if coreinfo.vendor == Vendor::ARM && part == ARMCore::CortexM0Plus {
+            if let Ok(idc) = STM32G0X1_DBGMCU_IDCODE::read(core) {
+                format!(
+                    "{}, revision 0x{:x}",
+                    stm32_chipname(idc.dev_id()),
+                    idc.rev_id()
+                )
+            } else {
+                format!("<unknown ARM part 0x{:x}>", coreinfo.manufacturer_part)
+            }
+        } else if coreinfo.vendor == Vendor::ST && part == ARMCore::CortexM4 {
             if let Ok(idc) = STM32F4_DBGMCU_IDCODE::read(core) {
                 format!(
                     "{}, revision 0x{:x}",

--- a/humility-arch-cortex/src/debug.rs
+++ b/humility-arch-cortex/src/debug.rs
@@ -276,6 +276,55 @@ register!(STM32F4_DBGMCU_CR, 0xe004_2004,
     pub dbg_sleep, _: 1;
 );
 
+register!(STM32G0X1_DBGMCU_IDCODE, 0x4001_5800,
+    #[derive(Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    pub struct STM32G0X1_DBGMCU_IDCODE(u32);
+    impl Debug;
+    pub rev_id, _: 31, 16;
+    pub dev_id, _: 11, 0;
+);
+
+register!(STM32G0X1_DBGMCU_CR, 0x4001_5804,
+    #[derive(Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    pub struct STM32G0X1_DBGMCU_CR(u32);
+    impl Debug;
+    pub dbg_standby, _: 2;
+    pub dbg_stop, _: 1;
+);
+
+register!(STM32G0X1_DBGMCU_APBFZ1, 0x4001_5808,
+    #[derive(Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    pub struct STM32G0X1_DBGMCU_APBFZ1(u32);
+    impl Debug;
+    pub dbg_lptim1_stop, _: 31;
+    pub dbg_lptim2_stop, _: 30;
+    pub dbg_i2c2_smbus_timeout, _: 22;
+    pub dbg_i2c1_smbus_timeout, _: 21;
+    pub dbg_iwdg_stop, _: 12;
+    pub dbg_wwdg_stop, _: 11;
+    pub dbg_rtc_stop, _: 10;
+    pub dbg_tim7_stop, _: 5;
+    pub dbg_tim6_stop, _: 4;
+    pub dbg_tim4_stop, _: 2;
+    pub dbg_tim3_stop, _: 1;
+    pub dbg_tim2_stop, _: 0;
+);
+
+register!(STM32G0X1_DBGMCU_APBFZ2, 0x4001_580C,
+    #[derive(Copy, Clone)]
+    #[allow(non_camel_case_types)]
+    pub struct STM32G0X1_DBGMCU_APBFZ2(u32);
+    impl Debug;
+    pub dbg_tim17_stop, _: 18;
+    pub dbg_tim16_stop, _: 17;
+    pub dbg_tim15_stop, _: 16;
+    pub dbg_tim14_stop, _: 15;
+    pub dbg_tim1_stop, _: 11;
+);
+
 register!(STM32H7_DBGMCU_IDC, 0x5c00_1000,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -498,6 +547,7 @@ pub fn stm32_chipname(partno: u32) -> String {
         0x463 => "STM32F413",
         0x464 => "STM32L412/STM32L422",
         0x466 => "STM32G0x0",
+        0x467 => "STM32G0x1",
         0x468 => "STM32G4xxx6/STM32G4xxx8/STM32G4xxxB",
         0x469 => "STM32G4xxxC/STM32G4xxxE",
         0x470 => "STM32L4R/STM32L4S",

--- a/humility-arch-cortex/src/scs.rs
+++ b/humility-arch-cortex/src/scs.rs
@@ -395,6 +395,7 @@ register!(CPUID, 0xe000_ed00,
 pub enum Vendor {
     ST,
     NXP,
+    ARM,
     Other,
 }
 
@@ -432,6 +433,7 @@ impl CoreInfo {
         let vendor = match m.get() {
             Some("STMicroelectronics") => Vendor::ST,
             Some("NXP (Philips)") => Vendor::NXP,
+            Some("ARM Ltd") => Vendor::ARM,
             _ => Vendor::Other,
         };
 


### PR DESCRIPTION
Hi Bryan,

This adds initial support for STM32G0x1 devices.  Running `probe` against my G0B1RE which I'm working on a port of Hubris to:

```
humility: attached via OpenOCD
humility:        probe => OpenOCD
humility: probe serial => -
humility:         core => Cortex-M0+
humility: manufacturer => ARM Ltd
humility:         chip => STM32G0x1, revision 0x1000
humility:       status => halted, vector catch, breakpoint, debug halt
humility:  debug units => BPU DWT SCS
humility:          BPU => 0xe0002000
humility:          DWT => 0xe0001000
humility:          SCS => 0xe000e000
humility:   ITM status => absent
humility:           R0 => 0xffffffff 
humility:           R1 => 0xffffffff 
humility:           R2 => 0xffffffff 
humility:           R3 => 0xffffffff 
humility:           R4 => 0xffffffff 
humility:           R5 => 0xffffffff 
humility:           R6 => 0xffffffff 
humility:           R7 => 0xffffffff 
humility:           R8 => 0xffffffff 
humility:           R9 => 0xffffffff 
humility:          R10 => 0xffffffff 
humility:          R11 => 0xffffffff 
humility:          R12 => 0xffffffff 
humility:           SP => 0x200003f8 
humility:           LR => 0xffffffff 
humility:           PC => 0x80000ca   <- Reset+0x2
humility:         xPSR => 0xf1000000 
humility:          MSP => 0x200003f8 
humility:          PSP => 0xfffffffc 
humility:          SPR => 0x0        
```

It's somewhat unfortunate that the board appears to identify as an ARM Ltd device rather than ST, I'm assuming because it's a lot more limited than the other Cortex-M boards currently ported to, but it's possible I missed something.