### PR TITLE
Check license headers in a GitHub Action

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,9 @@
+name: license-check
+on: pull_request
+jobs:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Check License Header
+      uses: apache/skywalking-eyes@main  

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,12 @@
+header:
+  license:
+    spdx-id: MPL-2.0
+
+    content: |
+      This Source Code Form is subject to the terms of the Mozilla Public
+      License, v. 2.0. If a copy of the MPL was not distributed with this
+      file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  paths:
+    - '**/*.rs'
+
+  comment: on-failure


### PR DESCRIPTION
This is in contrast to https://github.com/oxidecomputer/hubris/pull/270 and https://github.com/oxidecomputer/hubris/pull/279, where I implemented a script in Rust to check for it.

This GitHub Action is used by the Apache Software Foundation to ensure compliance in all of their projects, so it seems much better to rely on that rather than port over my little thing. Will probably also move Hubris over if everyone prefers.