### PR TITLE
Turn on overflow checks in release builds.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[profile.release]
+overflow-checks = true


### PR DESCRIPTION
There's some lurking bug in Humility that results in a crash from
indexing off the end of a slice -- but the _real_ issue is an integer
overflow somewhere, and this should help us find it.