### PR TITLE
Move from structopt to clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,17 +252,32 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -406,7 +412,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -548,12 +554,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -641,7 +644,6 @@ dependencies = [
  "scroll",
  "serde",
  "spd",
- "structopt",
  "toml",
 ]
 
@@ -660,7 +662,6 @@ dependencies = [
  "log",
  "parse_int",
  "postcard",
- "structopt",
 ]
 
 [[package]]
@@ -668,9 +669,9 @@ name = "humility-cmd-apptable"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
- "structopt",
 ]
 
 [[package]]
@@ -678,6 +679,7 @@ name = "humility-cmd-dashboard"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossterm",
  "hif",
  "humility-cmd",
@@ -686,7 +688,6 @@ dependencies = [
  "indexmap",
  "log",
  "parse_int",
- "structopt",
  "tui",
 ]
 
@@ -695,10 +696,10 @@ name = "humility-cmd-diagnose"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -706,10 +707,10 @@ name = "humility-cmd-dump"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "log",
- "structopt",
 ]
 
 [[package]]
@@ -717,13 +718,13 @@ name = "humility-cmd-etm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "csv",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -731,11 +732,11 @@ name = "humility-cmd-gpio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -743,6 +744,7 @@ name = "humility-cmd-hiffy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -750,7 +752,6 @@ dependencies = [
  "indexmap",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -758,13 +759,13 @@ name = "humility-cmd-i2c"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
  "indicatif",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -772,13 +773,13 @@ name = "humility-cmd-itm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "csv",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -786,11 +787,11 @@ name = "humility-cmd-jefe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -798,11 +799,11 @@ name = "humility-cmd-lpc55gpio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -810,9 +811,9 @@ name = "humility-cmd-manifest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
- "structopt",
 ]
 
 [[package]]
@@ -820,9 +821,9 @@ name = "humility-cmd-map"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
- "structopt",
 ]
 
 [[package]]
@@ -830,6 +831,7 @@ name = "humility-cmd-pmbus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "colored",
  "hif",
  "humility-cmd",
@@ -838,7 +840,6 @@ dependencies = [
  "log",
  "parse_int",
  "pmbus",
- "structopt",
 ]
 
 [[package]]
@@ -846,12 +847,12 @@ name = "humility-cmd-probe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
  "log",
  "num-traits",
- "structopt",
 ]
 
 [[package]]
@@ -859,13 +860,13 @@ name = "humility-cmd-qspi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
  "indicatif",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -873,10 +874,10 @@ name = "humility-cmd-readmem"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -884,9 +885,9 @@ name = "humility-cmd-readvar"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
- "structopt",
 ]
 
 [[package]]
@@ -894,6 +895,7 @@ name = "humility-cmd-renbb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -901,7 +903,6 @@ dependencies = [
  "log",
  "parse_int",
  "pmbus",
- "structopt",
 ]
 
 [[package]]
@@ -909,6 +910,7 @@ name = "humility-cmd-rencm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "csv",
  "hif",
  "humility-cmd",
@@ -920,7 +922,6 @@ dependencies = [
  "serde",
  "serde-xml-rs",
  "serde_derive",
- "structopt",
 ]
 
 [[package]]
@@ -928,10 +929,10 @@ name = "humility-cmd-ringbuf"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "log",
- "structopt",
 ]
 
 [[package]]
@@ -939,6 +940,7 @@ name = "humility-cmd-sensors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -946,7 +948,6 @@ dependencies = [
  "indexmap",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -954,6 +955,7 @@ name = "humility-cmd-spd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -961,7 +963,6 @@ dependencies = [
  "log",
  "parse_int",
  "spd",
- "structopt",
 ]
 
 [[package]]
@@ -969,12 +970,12 @@ name = "humility-cmd-spi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-core",
  "log",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -982,9 +983,9 @@ name = "humility-cmd-stackmargin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
- "structopt",
 ]
 
 [[package]]
@@ -992,10 +993,10 @@ name = "humility-cmd-stmsecure"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "parse_int",
- "structopt",
 ]
 
 [[package]]
@@ -1003,10 +1004,10 @@ name = "humility-cmd-tasks"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "num-traits",
- "structopt",
 ]
 
 [[package]]
@@ -1014,10 +1015,10 @@ name = "humility-cmd-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
- "structopt",
 ]
 
 [[package]]
@@ -1025,10 +1026,10 @@ name = "humility-cmd-trace"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
- "structopt",
 ]
 
 [[package]]
@@ -1036,13 +1037,13 @@ name = "humility-cmd-vsc7448"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "hif",
  "humility-cmd",
  "humility-cmd-spi",
  "humility-core",
  "log",
  "parse_int",
- "structopt",
  "vsc7448-info",
  "vsc7448-types",
 ]
@@ -1407,6 +1408,15 @@ name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1958,39 +1968,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "svg"
@@ -2027,6 +2007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,12 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 
 [[package]]
 name = "thiserror"
@@ -2135,12 +2121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,7 +2226,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "structopt",
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,11 +91,10 @@ cmd-vsc7448 = { path = "./cmd/vsc7448", package = "humility-cmd-vsc7448" }
 fallible-iterator = "0.2.0"
 log = {version = "0.4.8", features = ["std"]}
 bitfield = "0.13.2"
-clap = "2.33.0"
+clap = "3.0.12"
 csv = "1.1.3"
 serde = "1.0.126"
 parse_int = "0.4.0"
-structopt = "0.3"
 multimap = "0.8.1"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/cmd/apptable/Cargo.toml
+++ b/cmd/apptable/Cargo.toml
@@ -7,5 +7,5 @@ description = "print Hubris apptable"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
+clap = { version = "3.0.12", features = ["derive", "env"] }

--- a/cmd/apptable/src/lib.rs
+++ b/cmd/apptable/src/lib.rs
@@ -10,18 +10,15 @@
 //!
 
 use anyhow::{bail, Result};
+use clap::{App, AppSettings, IntoApp, Parser};
 use humility::hubris::{HubrisArchive, HubrisPrintFormat};
 use humility_cmd::{Archive, Args, Command};
 use std::convert::TryInto;
-use structopt::clap::{App, AppSettings};
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "apptable", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "apptable", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ApptableArgs {
-    #[structopt(
-        help = "path to kernel ELF object (in lieu of Hubris archive)"
-    )]
+    #[clap(help = "path to kernel ELF object (in lieu of Hubris archive)")]
     kernel: Option<String>,
 }
 
@@ -31,7 +28,7 @@ fn apptablecmd(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = ApptableArgs::from_iter_safe(subargs)?;
+    let subargs = ApptableArgs::try_parse_from(subargs)?;
 
     if !hubris.loaded() {
         if let Some(ref kernel) = subargs.kernel {
@@ -155,13 +152,13 @@ fn apptablecmd(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Unattached {
             name: "apptable",
             archive: Archive::Optional,
             run: apptablecmd,
         },
-        ApptableArgs::clap().setting(AppSettings::Hidden),
+        ApptableArgs::into_app().setting(AppSettings::Hidden),
     )
 }

--- a/cmd/dashboard/Cargo.toml
+++ b/cmd/dashboard/Cargo.toml
@@ -8,7 +8,7 @@ description = "dashboard for Hubris sensor data"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 indexmap = "1.7"

--- a/cmd/diagnose/Cargo.toml
+++ b/cmd/diagnose/Cargo.toml
@@ -7,6 +7,6 @@ description = "analyze a system to detect common problems"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/dump/Cargo.toml
+++ b/cmd/dump/Cargo.toml
@@ -7,6 +7,6 @@ description = "generate Hubris dump"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 log = {version = "0.4.8", features = ["std"]}

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -52,14 +52,13 @@
 extern crate log;
 
 use anyhow::Result;
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "dump", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "dump", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct DumpArgs {
     dumpfile: Option<String>,
 }
@@ -70,7 +69,7 @@ fn dumpcmd(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = DumpArgs::from_iter_safe(subargs)?;
+    let subargs = DumpArgs::try_parse_from(subargs)?;
 
     let _info = core.halt()?;
     info!("core halted");
@@ -83,7 +82,7 @@ fn dumpcmd(
     rval
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "dump",
@@ -92,6 +91,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: dumpcmd,
         },
-        DumpArgs::clap(),
+        DumpArgs::into_app(),
     )
 }

--- a/cmd/etm/Cargo.toml
+++ b/cmd/etm/Cargo.toml
@@ -8,7 +8,7 @@ description = "commands for ARM's Embedded Trace Macrocell (ETM)"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 csv = "1.1.3"
 parse_int = "0.4.0"

--- a/cmd/gpio/Cargo.toml
+++ b/cmd/gpio/Cargo.toml
@@ -8,6 +8,6 @@ description = "GPIO pin manipulation"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/hiffy/Cargo.toml
+++ b/cmd/hiffy/Cargo.toml
@@ -8,7 +8,7 @@ description = "manipulate HIF execution"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 indexmap = "1.7"

--- a/cmd/i2c/Cargo.toml
+++ b/cmd/i2c/Cargo.toml
@@ -8,7 +8,7 @@ description = "scan for and read I2C devices"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 indicatif = "0.15"

--- a/cmd/itm/Cargo.toml
+++ b/cmd/itm/Cargo.toml
@@ -8,7 +8,7 @@ description = "commands for ARM's Instrumentation Trace Macrocell (ITM)"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 csv = "1.1.3"
 parse_int = "0.4.0"

--- a/cmd/jefe/Cargo.toml
+++ b/cmd/jefe/Cargo.toml
@@ -7,7 +7,7 @@ description = "influence jefe externally"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 log = {version = "0.4.8", features = ["std"]}

--- a/cmd/lpc55gpio/Cargo.toml
+++ b/cmd/lpc55gpio/Cargo.toml
@@ -8,6 +8,6 @@ description = "LPC55 GPIO pin manipulation"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -9,62 +9,58 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use hif::*;
-use structopt::clap::App;
-use structopt::StructOpt;
 
 use std::convert::TryInto;
 
-#[derive(StructOpt, Debug)]
-#[structopt(
-    name = "lpc55gpio",
-    about = "GPIO pin manipulation (lpc55 variant)"
-)]
+#[derive(Parser, Debug)]
+#[clap(name = "lpc55gpio", about = "GPIO pin manipulation (lpc55 variant)")]
 struct GpioArgs {
     /// sets timeout
-    #[structopt(
-        long, short = "T", default_value = "5000", value_name = "timeout_ms",
+    #[clap(
+        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,
 
     /// toggle specified pins
-    #[structopt(
+    #[clap(
         long, short,
         conflicts_with_all = &["toggle", "set", "reset", "configure"]
     )]
     input: bool,
 
     /// toggle specified pins
-    #[structopt(
+    #[clap(
         long, short, requires = "pins",
         conflicts_with_all = &["set", "reset", "configure"]
     )]
     toggle: bool,
 
     /// sets specified pins
-    #[structopt(
+    #[clap(
         long, short, requires = "pins",
         conflicts_with_all = &["reset", "configure"]
     )]
     set: bool,
 
     /// resets specified pins
-    #[structopt(
+    #[clap(
         long, short, requires = "pins",
          conflicts_with_all = &["configure"])]
     reset: bool,
 
     /// configures specified pins
-    #[structopt(long, short, requires = "pins")]
+    #[clap(long, short, requires = "pins")]
     configure: Option<String>,
 
     /// configures specified pins
-    #[structopt(long, short, requires = "pins")]
+    #[clap(long, short, requires = "pins")]
     direction: Option<String>,
 
     /// specifies GPIO pins on which to operate
-    #[structopt(long, short, value_name = "pins")]
+    #[clap(long, short, value_name = "pins")]
     pins: Option<Vec<String>>,
 }
 
@@ -74,7 +70,7 @@ fn gpio(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = GpioArgs::from_iter_safe(subargs)?;
+    let subargs = GpioArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
 
@@ -219,7 +215,7 @@ fn gpio(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "lpc55gpio",
@@ -228,6 +224,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: gpio,
         },
-        GpioArgs::clap(),
+        GpioArgs::into_app(),
     )
 }

--- a/cmd/manifest/Cargo.toml
+++ b/cmd/manifest/Cargo.toml
@@ -7,5 +7,5 @@ description = "print archive manifest"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -41,13 +41,12 @@
 //! `humility manifest` can operate on either an archive or on a dump.
 
 use anyhow::Result;
+use clap::{App, IntoApp, Parser};
 use humility::hubris::HubrisArchive;
 use humility_cmd::{Archive, Args, Command};
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "manifest", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "manifest", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ManifestArgs {}
 
 fn manifestcmd(
@@ -59,13 +58,13 @@ fn manifestcmd(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Unattached {
             name: "manifest",
             archive: Archive::Required,
             run: manifestcmd,
         },
-        ManifestArgs::clap(),
+        ManifestArgs::into_app(),
     )
 }

--- a/cmd/map/Cargo.toml
+++ b/cmd/map/Cargo.toml
@@ -7,5 +7,5 @@ description = "print memory map, with association of regions to tasks"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/map/src/lib.rs
+++ b/cmd/map/src/lib.rs
@@ -62,14 +62,13 @@
 //! we can see from the `map` output has been sized to only 256 bytes.)
 
 use anyhow::Result;
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "map", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "map", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct MapArgs {}
 
 fn mapcmd(
@@ -113,7 +112,7 @@ fn mapcmd(
 }
 
 /// This is some init right here
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "map",
@@ -122,6 +121,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: mapcmd,
         },
-        MapArgs::clap(),
+        MapArgs::into_app(),
     )
 }

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -9,7 +9,7 @@ humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 colored = "2.0.0"
 indexmap = { version = "1.7", features = ["serde-1"] }

--- a/cmd/probe/Cargo.toml
+++ b/cmd/probe/Cargo.toml
@@ -8,7 +8,7 @@ description = "probe for any attached devices"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 log = {version = "0.4.8", features = ["std"]}
 num-traits = "0.2"

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -87,6 +87,9 @@
 //! ```
 
 use anyhow::Result;
+use clap::App;
+use clap::IntoApp;
+use clap::Parser;
 use humility::arch::ARMRegister;
 use humility::core::Core;
 use humility::hubris::*;
@@ -94,14 +97,12 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use humility_cortex::debug::*;
 use humility_cortex::itm::*;
 use humility_cortex::scs::*;
-use structopt::clap::App;
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate log;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "probe", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "probe", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ProbeArgs {}
 
 #[rustfmt::skip::macros(format)]
@@ -372,7 +373,7 @@ fn probecmd(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "probe",
@@ -381,6 +382,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Match,
             run: probecmd,
         },
-        ProbeArgs::clap(),
+        ProbeArgs::into_app(),
     )
 }

--- a/cmd/qspi/Cargo.toml
+++ b/cmd/qspi/Cargo.toml
@@ -8,7 +8,7 @@ description = "QSPI status, reading and writing"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 indicatif = "0.15"

--- a/cmd/readmem/Cargo.toml
+++ b/cmd/readmem/Cargo.toml
@@ -7,6 +7,6 @@ description = "read and display memory region"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -112,33 +112,32 @@
 //!
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Dumper, Validate};
 use std::convert::TryInto;
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "readmem", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "readmem", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ReadmemArgs {
     /// print out as halfwords instead of as bytes
-    #[structopt(long, short, conflicts_with_all = &["word", "symbol"])]
+    #[clap(long, short, conflicts_with_all = &["word", "symbol"])]
     halfword: bool,
 
     /// print out as words instead of as bytes
-    #[structopt(long, short, conflicts_with_all = &["symbol"])]
+    #[clap(long, short, conflicts_with_all = &["symbol"])]
     word: bool,
 
     /// print out as symbols
-    #[structopt(long, short)]
+    #[clap(long, short)]
     symbol: bool,
 
     /// address to read
     address: String,
 
     /// length to read
-    #[structopt(parse(try_from_str = parse_int::parse))]
+    #[clap(parse(try_from_str = parse_int::parse))]
     length: Option<usize>,
 }
 
@@ -148,7 +147,7 @@ fn readmem(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = ReadmemArgs::from_iter_safe(subargs)?;
+    let subargs = ReadmemArgs::try_parse_from(subargs)?;
     let max = humility::core::CORE_MAX_READSIZE;
     let size = if subargs.word || subargs.symbol {
         4
@@ -229,7 +228,7 @@ fn readmem(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "readmem",
@@ -238,6 +237,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::None,
             run: readmem,
         },
-        ReadmemArgs::clap(),
+        ReadmemArgs::into_app(),
     )
 }

--- a/cmd/readvar/Cargo.toml
+++ b/cmd/readvar/Cargo.toml
@@ -7,5 +7,5 @@ description = "read and display a specified Hubris variable"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -37,22 +37,21 @@
 //!
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "readvar", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "readvar", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ReadvarArgs {
     /// values in decimal instead of hex
-    #[structopt(long, short)]
+    #[clap(long, short)]
     decimal: bool,
     /// list variables
-    #[structopt(long, short)]
+    #[clap(long, short)]
     list: bool,
-    #[structopt(conflicts_with = "list")]
+    #[clap(conflicts_with = "list")]
     variable: Option<String>,
 }
 
@@ -90,7 +89,7 @@ fn readvar(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = ReadvarArgs::from_iter_safe(subargs)?;
+    let subargs = ReadvarArgs::try_parse_from(subargs)?;
 
     if subargs.list {
         return hubris.list_variables();
@@ -108,7 +107,7 @@ fn readvar(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "readvar",
@@ -117,6 +116,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Match,
             run: readvar,
         },
-        ReadvarArgs::clap(),
+        ReadvarArgs::into_app(),
     )
 }

--- a/cmd/renbb/Cargo.toml
+++ b/cmd/renbb/Cargo.toml
@@ -9,7 +9,7 @@ humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 indicatif = "0.15"
 log = {version = "0.4.8", features = ["std"]}

--- a/cmd/rencm/Cargo.toml
+++ b/cmd/rencm/Cargo.toml
@@ -9,7 +9,7 @@ humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 itertools = "0.10.1"
 parse_int = "0.4.0"

--- a/cmd/ringbuf/Cargo.toml
+++ b/cmd/ringbuf/Cargo.toml
@@ -7,6 +7,6 @@ description = "read and display a specified ring buffer"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 log = {version = "0.4.8", features = ["std"]}

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -33,25 +33,24 @@
 //! documentation](https://github.com/oxidecomputer/hubris/blob/master/lib/ringbuf/src/lib.rs) for more details.
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::doppel::{Ringbuf, StaticCell};
 use humility_cmd::reflect::{self, Format, Load, Value};
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use structopt::clap::App;
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate log;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "ringbuf", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "ringbuf", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct RingbufArgs {
     /// list variables
-    #[structopt(long, short)]
+    #[clap(long, short)]
     list: bool,
     /// print only a single ringbuffer by name
-    #[structopt(conflicts_with = "list")]
+    #[clap(conflicts_with = "list")]
     variable: Option<String>,
 }
 
@@ -126,7 +125,7 @@ fn ringbuf(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = RingbufArgs::from_iter_safe(subargs)?;
+    let subargs = RingbufArgs::try_parse_from(subargs)?;
 
     let mut ringbufs = vec![];
 
@@ -181,7 +180,7 @@ fn ringbuf(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "ringbuf",
@@ -190,6 +189,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Match,
             run: ringbuf,
         },
-        RingbufArgs::clap(),
+        RingbufArgs::into_app(),
     )
 }

--- a/cmd/sensors/Cargo.toml
+++ b/cmd/sensors/Cargo.toml
@@ -8,7 +8,7 @@ description = "query sensors and sensor data"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 indexmap = "1.7"

--- a/cmd/spd/Cargo.toml
+++ b/cmd/spd/Cargo.toml
@@ -9,7 +9,7 @@ humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 spd = { git = "https://github.com/oxidecomputer/spd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 jep106 = "0.2"
 parse_int = "0.4.0"

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -10,45 +10,44 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use hif::*;
-use structopt::clap::App;
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate log;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "spd", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "spd", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct SpdArgs {
     /// sets timeout
-    #[structopt(
+    #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,
 
     /// verbose output
-    #[structopt(long, short)]
+    #[clap(long, short)]
     verbose: bool,
 
     /// specifies an I2C controller
-    #[structopt(long, short, value_name = "controller",
+    #[clap(long, short, value_name = "controller",
         parse(try_from_str = parse_int::parse),
     )]
     controller: Option<u8>,
 
     /// specifies an I2C bus by name
-    #[structopt(long, short, value_name = "bus",
+    #[clap(long, short, value_name = "bus",
         conflicts_with_all = &["port", "controller"]
     )]
     bus: Option<String>,
 
     /// specifies an I2C controller port
-    #[structopt(long, short, value_name = "port")]
+    #[clap(long, short, value_name = "port")]
     port: Option<String>,
 
     /// specifies I2C multiplexer and segment
-    #[structopt(long, short, value_name = "mux:segment")]
+    #[clap(long, short, value_name = "mux:segment")]
     mux: Option<String>,
 }
 
@@ -153,7 +152,7 @@ fn spd(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = SpdArgs::from_iter_safe(subargs)?;
+    let subargs = SpdArgs::try_parse_from(subargs)?;
 
     //
     // If we have been given no device-related arguments, we will attempt
@@ -354,7 +353,7 @@ fn spd(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "spd",
@@ -363,6 +362,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: spd,
         },
-        SpdArgs::clap(),
+        SpdArgs::into_app(),
     )
 }

--- a/cmd/spi/Cargo.toml
+++ b/cmd/spi/Cargo.toml
@@ -8,7 +8,7 @@ description = "SPI reading and writing"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"
 log = {version = "0.4.8", features = ["std"]}

--- a/cmd/stackmargin/Cargo.toml
+++ b/cmd/stackmargin/Cargo.toml
@@ -7,5 +7,5 @@ description = "calculate and print stack margins by task"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -28,15 +28,14 @@
 //!
 
 use anyhow::{bail, Result};
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::convert::TryInto;
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "stackmargin", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "stackmargin", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct StackmarginArgs {}
 
 #[rustfmt::skip::macros(println, bail)]
@@ -117,7 +116,7 @@ fn stackmargin(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "stackmargin",
@@ -126,6 +125,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: stackmargin,
         },
-        StackmarginArgs::clap(),
+        StackmarginArgs::into_app(),
     )
 }

--- a/cmd/stmsecure/Cargo.toml
+++ b/cmd/stmsecure/Cargo.toml
@@ -7,6 +7,6 @@ description = "change secure region settings on the stm32h7"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -28,12 +28,11 @@
 //! ```
 
 use anyhow::{anyhow, Result};
+use clap::{App, IntoApp, Parser};
 use humility::arch::ARMRegister;
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
-use structopt::clap::App;
-use structopt::StructOpt;
 
 const FLASH_OPT_KEY1: u32 = 0x0819_2A3B;
 const FLASH_OPT_KEY2: u32 = 0x4C5D_6E7F;
@@ -51,8 +50,8 @@ const FLASH_OPTSR_PRG: u32 = 0x5200_2020;
 const FLASH_SCAR_CUR1: u32 = 0x5200_2030;
 const FLASH_SCAR_PRG1: u32 = 0x5200_2034;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "stmsecure", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "stmsecure", about = env!("CARGO_PKG_DESCRIPTION"))]
 enum StmSecureArgs {
     /// Show status about secure region settings
     Status,
@@ -71,11 +70,11 @@ enum StmSecureArgs {
     /// region before this is programmed otherwise you will brick the device
     /// !!!
     SetSecureRegion {
-        #[structopt(parse(try_from_str = parse_int::parse))]
+        #[clap(parse(try_from_str = parse_int::parse))]
         address: u32,
-        #[structopt(parse(try_from_str = parse_int::parse))]
+        #[clap(parse(try_from_str = parse_int::parse))]
         size: u32,
-        #[structopt(long)]
+        #[clap(long)]
         doit: bool,
     },
     /// Unset the secure region. Read out protection must be enabled.
@@ -301,7 +300,7 @@ fn stmsecure(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = StmSecureArgs::from_iter_safe(subargs)?;
+    let subargs = StmSecureArgs::try_parse_from(subargs)?;
 
     match subargs {
         StmSecureArgs::Status => stmsecure_status(core),
@@ -317,7 +316,7 @@ fn stmsecure(
     }
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "stmsecure",
@@ -326,6 +325,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::None,
             run: stmsecure,
         },
-        StmSecureArgs::clap(),
+        StmSecureArgs::into_app(),
     )
 }

--- a/cmd/tasks/Cargo.toml
+++ b/cmd/tasks/Cargo.toml
@@ -7,6 +7,6 @@ description = "list Hubris tasks"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 num-traits = "0.2"

--- a/cmd/test/Cargo.toml
+++ b/cmd/test/Cargo.toml
@@ -8,5 +8,5 @@ description = "run Hubristest suite and parse results"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -108,6 +108,7 @@
 //!
 
 use anyhow::{bail, Context, Result};
+use clap::{App, IntoApp, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::test::*;
@@ -116,17 +117,15 @@ use humility_cortex::itm::*;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::time::Instant;
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "test", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "test", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct TestArgs {
     /// dump full report even on success
-    #[structopt(long, short)]
+    #[clap(long, short)]
     dumpalways: bool,
     /// sets the output file
-    #[structopt(long, short, value_name = "filename")]
+    #[clap(long, short, value_name = "filename")]
     output: Option<String>,
 }
 
@@ -288,7 +287,7 @@ fn test(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = TestArgs::from_iter_safe(subargs)?;
+    let subargs = TestArgs::try_parse_from(subargs)?;
 
     hubris.validate(core, HubrisValidate::Booted)?;
 
@@ -299,7 +298,7 @@ fn test(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "test",
@@ -308,6 +307,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Booted,
             run: test,
         },
-        TestArgs::clap(),
+        TestArgs::into_app(),
     )
 }

--- a/cmd/trace/Cargo.toml
+++ b/cmd/trace/Cargo.toml
@@ -8,5 +8,5 @@ description = "trace Hubris operations"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }

--- a/cmd/trace/src/lib.rs
+++ b/cmd/trace/src/lib.rs
@@ -3,6 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{anyhow, Result};
+use clap::App;
+use clap::IntoApp;
+use clap::Parser;
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -11,14 +14,12 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::time::Instant;
 use std::time::SystemTime;
-use structopt::clap::App;
-use structopt::StructOpt;
 
-#[derive(StructOpt, Debug)]
-#[structopt(name = "trace", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[derive(Parser, Debug)]
+#[clap(name = "trace", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct TraceArgs {
     /// provide statemap-ready output
-    #[structopt(long, short)]
+    #[clap(long, short)]
     statemap: bool,
 }
 
@@ -206,7 +207,7 @@ fn tracecmd(
     _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    let subargs = &TraceArgs::from_iter_safe(subargs)?;
+    let subargs = &TraceArgs::try_parse_from(subargs)?;
     let mut tasks: HashMap<u32, String> = HashMap::new();
 
     /*
@@ -246,7 +247,7 @@ fn tracecmd(
     Ok(())
 }
 
-pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
+pub fn init() -> (Command, App<'static>) {
     (
         Command::Attached {
             name: "trace",
@@ -255,6 +256,6 @@ pub fn init<'a, 'b>() -> (Command, App<'a, 'b>) {
             validate: Validate::Match,
             run: tracecmd,
         },
-        TraceArgs::clap(),
+        TraceArgs::into_app(),
     )
 }

--- a/cmd/vsc7448/Cargo.toml
+++ b/cmd/vsc7448/Cargo.toml
@@ -12,6 +12,6 @@ humility-cmd = { path = "../../humility-cmd" }
 humility-cmd-spi = { path = "../spi" }
 log = {version = "0.4.8", features = ["std"]}
 parse_int = "0.4.0"
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
 vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/humility-cmd/Cargo.toml
+++ b/humility-cmd/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 
 [dependencies]
 humility = { path = "../humility-core", package = "humility-core" }
-clap = "2.33.0"
-structopt = "0.3"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -11,22 +11,22 @@ pub mod reflect;
 pub mod test;
 
 use anyhow::{bail, Result};
+use clap::Parser;
 use humility::core::Core;
 use humility::hubris::*;
-use structopt::StructOpt;
 
 #[macro_use]
 extern crate log;
 
-#[derive(StructOpt)]
-#[structopt(name = "humility", max_term_width = 80)]
+#[derive(Parser)]
+#[clap(name = "humility", max_term_width = 80)]
 pub struct Args {
     /// verbose messages
-    #[structopt(long, short)]
+    #[clap(long, short)]
     pub verbose: bool,
 
     /// specific chip on attached device
-    #[structopt(
+    #[clap(
         long,
         short,
         env = "HUMILITY_CHIP",
@@ -35,24 +35,24 @@ pub struct Args {
     pub chip: String,
 
     /// chip probe to use
-    #[structopt(long, short, env = "HUMILITY_PROBE", conflicts_with = "dump")]
+    #[clap(long, short, env = "HUMILITY_PROBE", conflicts_with = "dump")]
     pub probe: Option<String>,
 
     /// Hubris archive
-    #[structopt(long, short, env = "HUMILITY_ARCHIVE")]
+    #[clap(long, short, env = "HUMILITY_ARCHIVE")]
     pub archive: Option<String>,
 
     /// Hubris dump
-    #[structopt(long, short, env = "HUMILITY_DUMP")]
+    #[clap(long, short, env = "HUMILITY_DUMP")]
     pub dump: Option<String>,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Subcommand,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub enum Subcommand {
-    #[structopt(external_subcommand)]
+    #[clap(external_subcommand)]
     Other(Vec<String>),
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -3,15 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{bail, Context, Result};
+use clap::App;
 use humility::hubris::*;
 use humility_cmd::Args;
 use humility_cmd::{Archive, Command};
 use std::collections::HashMap;
-use structopt::clap::App;
 
-pub fn init<'a, 'b>(
-    app: App<'a, 'b>,
-) -> (HashMap<&'static str, Command>, App<'a, 'b>) {
+pub fn init(
+    app: App<'static>,
+) -> (HashMap<&'static str, Command>, App<'static>) {
     let mut cmds = HashMap::new();
     let mut rval = app;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@
 
 use humility_cmd::{Args, Subcommand};
 
-use structopt::StructOpt;
+use clap::FromArgMatches;
+use clap::IntoApp;
+use clap::Parser;
 
 mod cmd;
 
@@ -83,16 +85,16 @@ fn main() {
      * external_subcommand to directive to allow our subcommand to do any
      * parsing on its own.
      */
-    let (commands, clap) = cmd::init(Args::clap());
+    let (commands, clap) = cmd::init(Args::into_app());
 
     let m = clap.get_matches();
-    let _args = Args::from_clap(&m);
+    let _args = Args::from_arg_matches(&m);
 
     /*
      * If we're here, we know that our arguments pass muster from the
      * Structopt/ Clap perspective.
      */
-    let mut args = Args::from_args();
+    let mut args = Args::parse();
 
     if args.verbose {
         HumilityLog { level: log::LevelFilter::Trace }.enable();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,7 +4,6 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-structopt = "0.3.15"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = "1.0.32"
 cargo_metadata = "0.12.0"
-

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,17 +3,14 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{bail, Result};
+use clap::Parser;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    max_term_width = 80,
-    about = "extra tasks to help you work on Hubris"
-)]
+#[derive(Debug, Parser)]
+#[clap(max_term_width = 80, about = "extra tasks to help you work on Hubris")]
 enum Xtask {
     /// Compiles readme
     Readme,
@@ -126,7 +123,7 @@ fn make_readme() -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let xtask = Xtask::from_args();
+    let xtask = Xtask::parse();
 
     match xtask {
         Xtask::Readme => {


### PR DESCRIPTION
Clap v3 is finally here! This basically makes structopt obsolete, as
clap has now absorbed its main feature.

Most of this is very mechanical. Some names were changed, a lifetime was
removed, repeat a few dozen times.