### PR TITLE
Add hash commands and hash option to qspi command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,6 +391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6966607622438301997d3dac0d2f6e9a90c68bb6bc1785ea98456ab93c0507"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -430,6 +458,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -528,6 +566,16 @@ name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
+
+[[package]]
+name = "generic-array"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "gimli"
@@ -651,6 +699,7 @@ dependencies = [
  "humility-cmd-etm",
  "humility-cmd-flash",
  "humility-cmd-gpio",
+ "humility-cmd-hash",
  "humility-cmd-hiffy",
  "humility-cmd-i2c",
  "humility-cmd-itm",
@@ -799,6 +848,21 @@ dependencies = [
  "humility-cmd",
  "humility-core",
  "parse_int",
+]
+
+[[package]]
+name = "humility-cmd-hash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hif",
+ "humility-cmd",
+ "humility-core",
+ "indicatif",
+ "log",
+ "parse_int",
+ "sha2",
 ]
 
 [[package]]
@@ -1972,6 +2036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "spd"
@@ -2180,6 +2255,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "cmd/etm",
     "cmd/gpio",
     "cmd/flash",
+    "cmd/hash",
     "cmd/hiffy",
     "cmd/i2c",
     "cmd/itm",
@@ -65,6 +66,7 @@ cmd-dump = { path = "./cmd/dump", package = "humility-cmd-dump" }
 cmd-etm = { path = "./cmd/etm", package = "humility-cmd-etm" }
 cmd-flash = { path = "./cmd/flash", package = "humility-cmd-flash" }
 cmd-gpio = { path = "./cmd/gpio", package = "humility-cmd-gpio" }
+cmd-hash = { path = "./cmd/hash", package = "humility-cmd-hash" }
 cmd-hiffy = { path = "./cmd/hiffy", package = "humility-cmd-hiffy" }
 cmd-i2c = { path = "./cmd/i2c", package = "humility-cmd-i2c" }
 cmd-itm = { path = "./cmd/itm", package = "humility-cmd-itm" }

--- a/cmd/hash/Cargo.toml
+++ b/cmd/hash/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "humility-cmd-hash"
+version = "0.1.0"
+edition = "2021"
+description = "Access to the HASH block"
+
+[dependencies]
+humility = { path = "../../humility-core", package = "humility-core" }
+humility-cmd = { path = "../../humility-cmd" }
+hif = { git = "https://github.com/oxidecomputer/hif" }
+clap = { version = "3.0.12", features = ["derive", "env"] }
+sha2 = "0.10.1"
+# hex-literal = {}
+anyhow = { version = "1.0.44", features = ["backtrace"] }
+parse_int = "0.4.0"
+indicatif = "0.15"
+log = {version = "0.4.8", features = ["std"]}

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -1,0 +1,493 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{anyhow, bail, Result};
+use clap::Command as ClapCommand;
+use clap::{ArgGroup, CommandFactory, Parser};
+
+use humility::core::Core;
+use humility::hubris::*;
+use humility_cmd::hiffy::*;
+use humility_cmd::{Archive, Args, Attach, Command, Validate};
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::Read;
+
+use hif::*;
+
+use indicatif::{ProgressBar, ProgressStyle};
+
+extern crate log;
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "hash", about = env!("CARGO_PKG_DESCRIPTION"),
+    group = ArgGroup::new("command").multiple(false),
+    group = ArgGroup::new("data").multiple(false)
+)]
+struct HashArgs {
+    /// Legal sequences:
+    ///
+    ///   ... hash --digest -s abc # which is equivalent to
+    ///
+    ///   ... hash --digest -x 61,62,63 # which is equivalent to
+    ///
+    ///   echo -n abc > abc.txt
+    ///   ... hash --digest -f abc.txt
+    ///
+    ///   ... hash -i --update -s 'a'
+    ///   ... hash --update -s 'bc'
+    ///   ... hash --finalize
+    ///
+    ///   ... hash --init
+    ///   ... hash --update -f /etc/issue
+    ///   ... hash --update -f /etc/issue.net
+    ///   ... hash --finalize
+    ///
+
+    /// Initialize the hash block and optionally provide a length.
+    #[clap(long, short)] // not in group "command" to allow -i update
+    init: bool,
+
+    /// In one command, initialize, update, and finalize processing the specified
+    /// data. hash.
+    /// In the case of Humility/Hiffy as a client, the size of the bytestream
+    /// is limited to the size of the scratch buffer that hiffy implements.
+    /// For larger bytestreams, use a sequence of init, update, ..., update,
+    /// finalize.
+    #[clap(long, short, group = "command")]
+    digest: bool,
+
+    /// Update the hash with the given data.
+    #[clap(long, short, group = "command")]
+    update: bool,
+
+    /// Complete the hash computation and return the result.
+    #[clap(long, short, group = "command")]
+    finalize: bool,
+
+    /// Process built-in test vectors and compare to known results.
+    #[clap(long, short, group = "command")]
+    test: bool,
+
+    // TODO: if there is reason to use the additional available
+    // algorithms/configurations.
+    // --algo {SHA-1, SHA224, SHA256, MD5, HMAC}
+    // --order {big,little}
+    // test --vector {1,2,3...} // run local sw and SP hardware and compare
+    // HMAC
+    /// Binary is read from a file. TODO: Chunk and loop for digest and update.
+    #[clap(long, short = 'F', value_name = "filename", group = "data")]
+    file: Option<String>,
+
+    /// Data is provided as comma separated hex digits: e.g. -h 1,1f,c3
+    #[clap(long, short = 'x', value_name = "HEX_DATA", group = "data")]
+    hex: Option<String>,
+
+    /// Data is provided as a string
+    #[clap(long, short, group = "data", value_name = "STRING")]
+    string: Option<String>,
+
+    /// sets timeout
+    #[clap(
+        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        parse(try_from_str = parse_int::parse)
+    )]
+    timeout: u32,
+
+    /// enable long test
+    #[clap(long, short)]
+    long: bool,
+}
+
+fn hash(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    _args: &Args,
+    subargs: &[String],
+) -> Result<()> {
+    let subargs = HashArgs::try_parse_from(subargs)?;
+    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let funcs = context.functions()?;
+    let scratch_size = context.scratch_size();
+    let mut ops = vec![];
+
+    // Fetch the supplied data if any.
+    let mut data = Vec::new();
+    let data = if subargs.file.is_some() {
+        let filename = subargs.file.unwrap();
+        let mut file = File::open(&filename)?;
+        if let Err(err) = file.read_to_end(&mut data) {
+            bail!("Cannot read file \"{}\": {}", filename, err);
+        }
+        Some(data.as_slice())
+    } else if subargs.hex.is_some() {
+        let hex = subargs.hex.unwrap();
+        let bytes: Vec<&str> = hex.split(',').collect();
+        for byte in &bytes {
+            if let Ok(val) = u8::from_str_radix(byte, 16) {
+                data.push(val);
+            } else {
+                bail!("invalid byte {}", byte)
+            }
+        }
+        Some(data.as_slice())
+    } else if subargs.string.is_some() {
+        data.extend_from_slice(&subargs.string.unwrap().as_bytes());
+        Some(data.as_slice())
+    } else {
+        None
+    };
+
+    if !subargs.digest && !subargs.update && data.is_some() {
+        return Err(anyhow!("data supplied and not used"));
+    }
+    if (subargs.digest || subargs.update) && data.is_none() {
+        return Err(anyhow!("no data provided"));
+    }
+
+    // Init by itself and with --update is ok.
+    // Other cases are useless or mess up calculations and are disallowed.
+
+    let hash_cmd = if subargs.digest {
+        if subargs.init {
+            return Err(anyhow!("--init is not used with --digest"));
+        }
+        Some(funcs.get("HashDigest", 1)?)
+    } else if subargs.update {
+        if subargs.init {
+            ops.push(Op::Call(funcs.get("HashInit", 0)?.id));
+        }
+        Some(funcs.get("HashUpdate", 1)?)
+    } else if subargs.finalize {
+        if subargs.init {
+            return Err(anyhow!("--init is not used with --finalize"));
+        }
+        Some(funcs.get("HashFinalize", 0)?)
+    } else if subargs.test {
+        if subargs.init {
+            return Err(anyhow!("--init is not used with --test"));
+        }
+        None
+    } else if subargs.init {
+        Some(funcs.get("HashInit", 0)?)
+    } else {
+        None
+    };
+
+    // Process commands other than --test
+    if let Some(cmd) = hash_cmd {
+        if let Some(data) = data {
+            if data.len() > scratch_size {
+                if !subargs.long {
+                    return Err(anyhow!(
+                        "Data size exceeds {}, use --long",
+                        scratch_size
+                    ));
+                }
+                // TODO: suppress progress bar with --quiet/--noverbose option
+                // Execution can take a long time in some cases (30+ minutes)
+                let bar = ProgressBar::new(data.len() as u64);
+                bar.set_style(ProgressStyle::default_bar().template(
+                    "humility: Hashing [{bar:30}] {bytes}/{total_bytes}",
+                ));
+                // On first iteration, --digest won't have the Init already pushed.
+                if subargs.digest {
+                    ops.push(Op::Call(funcs.get("HashInit", 0)?.id));
+                }
+                for index in (0..data.len()).step_by(scratch_size) {
+                    bar.set_position(index as u64);
+                    let nbytes = if index + scratch_size > data.len() {
+                        data.len() - index
+                    } else {
+                        scratch_size
+                    };
+                    let buf = &data[index..index + nbytes];
+                    ops.push(Op::Push32(buf.len() as u32));
+                    ops.push(Op::Call(funcs.get("HashUpdate", 1)?.id));
+                    ops.push(Op::Done);
+                    let results =
+                        context.run(core, ops.as_slice(), Some(buf))?;
+                    if let Err(err) = &results[0] {
+                        println!(
+                            "Fail at index={}: results={:#?}",
+                            index, results
+                        );
+                        return Err(anyhow!("update fails: {:?}", err));
+                    }
+                    ops.clear();
+                }
+                bar.finish_and_clear();
+                if subargs.digest {
+                    ops.push(Op::Call(funcs.get("HashFinalize", 0)?.id));
+                    ops.push(Op::Done);
+                    let results = context.run(core, ops.as_slice(), None)?;
+                    match &results[0] {
+                        Ok(buf) => {
+                            if buf.len() != 32 {
+                                return Err(anyhow!(
+                                    "finalize returns wrong size: {:?}",
+                                    buf.len()
+                                ));
+                            }
+                            print_hash(buf.as_slice());
+                        }
+                        _ => {
+                            return Err(anyhow!("finalize fails"));
+                        }
+                    }
+                }
+            } else {
+                // For update and digest that fit in a single hubris scratch buf,
+                // push the length of data to be sent.
+                ops.push(Op::Push32(data.len() as u32));
+            }
+        }
+
+        ops.push(Op::Call(cmd.id));
+        ops.push(Op::Done);
+        let results = context.run(
+            core,
+            ops.as_slice(),
+            match data {
+                Some(data) => Some(data),
+                _ => None,
+            },
+        )?;
+        println!("returned results={:?}", &results);
+        match &results[0] {
+            Ok(buf) => {
+                print_hash(buf);
+            }
+            Err(err) => {
+                println!("Error returned: {}", err);
+            }
+        }
+        return Ok(());
+    }
+
+    // Any --digest, --init, --update, and --finalize commands are dealt with
+    // above.
+    // The --test command is the last valid command to consider.
+
+    if !subargs.test {
+        bail!("why am I here?")
+    }
+
+    let report = |name, v1: &[u8], correct: &[u8]| {
+        println!(
+            "{}: {}",
+            name,
+            if v1 == correct {
+                "\x1b[32mPass\x1b[m:"
+            } else {
+                "\x1b[41mFail\x1b[m:"
+            }
+        );
+        for index in 0..256 / 8 {
+            print!("{:02x}", v1[index]);
+        }
+        println!(" result");
+        for index in 0..256 / 8 {
+            print!("{:02x}", correct[index]);
+        }
+        println!(" correct");
+    };
+
+    let mut datacmd = |_info, id, data: Option<&[u8]>| {
+        ops.clear();
+        if data.is_some() {
+            ops.push(Op::Push32(data.unwrap().len() as u32));
+        }
+        ops.push(Op::Call(id));
+        ops.push(Op::Done);
+        context.run(
+            core,
+            ops.as_slice(),
+            match data {
+                Some(ref data) => Some(data),
+                _ => None,
+            },
+        )
+    };
+
+    let digest_id = funcs.get("HashDigest", 1)?.id;
+
+    // These short tests all fit in a single Hubris scratch buffer.
+    struct ShortTest<'a> {
+        desc: &'a str,
+        vector: &'a [u8],
+        expected: [u8; 256 / 8],
+    }
+
+    const SHORT_TESTS: &[ShortTest] = &[
+        // [NSRL Test Data | NIST](https://www.nist.gov/itl/ssd/software-quality-group/nsrl-test-data)
+        // A file containing the ASCII string "abc" results in a 256-bit message
+        // digest of
+        // BA7816BF 8F01CFEA 414140DE 5DAE2223 B00361A3 96177A9C B410FF61 F20015AD.
+        //
+        ShortTest {
+            desc: "NSRL Test Data 1",
+            vector: b"abc".as_slice(),
+            expected: [
+                0xBA, 0x78, 0x16, 0xBF, 0x8F, 0x01, 0xCF, 0xEA,
+                0x41, 0x41, 0x40, 0xDE, 0x5D, 0xAE, 0x22, 0x23,
+                0xB0, 0x03, 0x61, 0xA3, 0x96, 0x17, 0x7A, 0x9C,
+                0xB4, 0x10, 0xFF, 0x61, 0xF2, 0x00, 0x15, 0xAD
+            ]
+        },
+
+        // A file containing the ASCII string
+        // "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq" results in a
+        // 256-bit message digest of
+        // 248D6A61 D20638B8 E5C02693 0C3E6039 A33CE459 64FF2167 F6ECEDD4 19DB06C1.
+        // 14 x 32-bit words (less than a block)
+        ShortTest{
+            desc: "NSRL Test Data 2",
+            vector: b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".as_slice(),
+            expected: [
+                0x24, 0x8D, 0x6A, 0x61, 0xD2, 0x06, 0x38, 0xB8,
+                0xE5, 0xC0, 0x26, 0x93, 0x0C, 0x3E, 0x60, 0x39,
+                0xA3, 0x3C, 0xE4, 0x59, 0x64, 0xFF, 0x21, 0x67,
+                0xF6, 0xEC, 0xED, 0xD4, 0x19, 0xDB, 0x06, 0xC1
+            ]
+        },
+
+        // An even block (16 32-bit words)
+        ShortTest{
+            desc: "one full block",
+            vector: b"1234abcd2345bcde3456cdef4567defg5678efgh6789fghi7890ghij8901hijk".as_slice(),
+            expected: [
+                0xc6, 0x41, 0xd5, 0x22, 0x3a, 0x4d, 0x0e, 0xd3,
+                0xc0, 0x6c, 0x6f, 0xd9, 0xe1, 0x96, 0x17, 0x25,
+                0xe9, 0x54, 0xdc, 0x69, 0x99, 0x13, 0xc1, 0xa4,
+                0x96, 0xd7, 0x05, 0x98, 0xc6, 0x39, 0x80, 0x7b
+            ]
+        },
+
+        // One full block plus one byte (16 32-bit words + 1 byte)
+        ShortTest{
+            desc: "one full block+1 byte",
+            vector: b"1234abcd2345bcde3456cdef4567defg5678efgh6789fghi7890ghij8901hijk!".as_slice(),
+            expected: [
+                0xa3, 0x6c, 0x1c, 0x9f, 0xd8, 0x9b, 0x14, 0xc5,
+                0xb5, 0xd7, 0x24, 0x92, 0x8b, 0xed, 0xf0, 0x37,
+                0x30, 0x25, 0x00, 0x22, 0xaa, 0x9e, 0xb3, 0x9b,
+                0x6f, 0x1e, 0x19, 0x3d, 0x0b, 0x42, 0xef, 0xb9,
+            ]
+        }
+    ];
+
+    for test in SHORT_TESTS {
+        println!("\n\nDescription: {}", test.desc);
+        let mut hasher = Sha256::new();
+        hasher.update(test.vector);
+        let lib_sum = hasher.finalize();
+
+        for index in 0..256 / 8 {
+            print!("{:02x}", lib_sum[index]);
+        }
+        println!(" lib_sum");
+        assert_eq!(lib_sum[..], test.expected);
+
+        let result = datacmd(test.desc, digest_id, Some(&test.vector[0..]))?;
+        match &result[0] {
+            Ok(buf) => {
+                report(test.desc, buf.as_slice(), &test.expected[0..]);
+            }
+            _ => bail!("Cannot execute: {}", test.desc),
+        }
+    }
+
+    if !subargs.long {
+        println!("Use --long option to enable 1Mbyte hash test.");
+        return Ok(());
+    }
+
+    println!("\nLong running tests");
+
+    // Let the message be the binary-coded form of the ASCII string which
+    // consists of 1,000,000 repetitions of the character "a" results in a
+    // SHA-256 message digest of
+    let mut block = Vec::new();
+    for _ in 0..scratch_size {
+        block.push(b'a');
+    }
+    let block = block.as_slice();
+    let expected_sum: [u8; 256 / 8] = [
+        0xCD, 0xC7, 0x6E, 0x5C, 0x99, 0x14, 0xFB, 0x92, 0x81, 0xA1, 0xC7, 0xE2,
+        0x84, 0xD7, 0x3E, 0x67, 0xF1, 0x80, 0x9A, 0x48, 0xA4, 0x97, 0x20, 0x0E,
+        0x04, 0x6D, 0x39, 0xCC, 0xC7, 0x11, 0x2C, 0xD0,
+    ];
+    let limit = 1_000_000;
+
+    let bar = ProgressBar::new(limit as u64);
+    bar.set_style(
+        ProgressStyle::default_bar()
+            .template("humility: Hashing [{bar:30}] {bytes}/{total_bytes}"),
+    );
+
+    let mut hasher = Sha256::new();
+
+    datacmd("test 3 init", funcs.get("HashInit", 0)?.id, None)?;
+
+    let mut count = 0;
+    while count < limit {
+        let mut nbytes = limit - count;
+        if nbytes > block.len() {
+            nbytes = block.len();
+        }
+        hasher.update(&block[0..nbytes]);
+        datacmd(
+            "test 3 update",
+            funcs.get("HashUpdate", 1)?.id,
+            Some(&block[0..nbytes]),
+        )?;
+        count += nbytes;
+        bar.set_position(count as u64);
+    }
+    bar.finish_and_clear();
+
+    let lib_sum = hasher.finalize();
+    let result =
+        datacmd("test 3 finalize", funcs.get("HashFinalize", 0)?.id, None)?;
+    match &result[0] {
+        Ok(buf) => {
+            report("Test vector 3", buf.as_slice(), &expected_sum[0..]);
+            assert_eq!(lib_sum.as_slice(), buf.as_slice());
+        }
+        Err(err) => {
+            bail!("Error executing test 3: {:#?}", err)
+        }
+    }
+
+    Ok(())
+}
+
+fn print_hash(buf: &[u8]) {
+    if buf.len() > 0 {
+        if buf.len() != 32 {
+            println!("Warning: return len != 256 bits");
+        }
+        for index in 0..buf.len() {
+            print!("{:02x}", buf[index]);
+        }
+        println!("");
+    } else {
+        println!("returned buffer is empty!");
+    }
+}
+
+pub fn init() -> (Command, ClapCommand<'static>) {
+    (
+        Command::Attached {
+            name: "hash",
+            archive: Archive::Required,
+            attach: Attach::LiveOnly,
+            validate: Validate::Booted,
+            run: hash,
+        },
+        HashArgs::command(),
+    )
+}

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -6,12 +6,14 @@ use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::{Archive, Args, Attach, Command, Dumper, Validate};
+use std::fmt;
 use std::fs;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufWriter, Read, Write};
+use std::mem;
 use std::time::Instant;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Command as ClapCommand;
 use clap::{ArgGroup, CommandFactory, Parser};
 use hif::*;
@@ -39,6 +41,11 @@ struct QspiArgs {
     /// pull identifier
     #[clap(long, short, group = "command")]
     id: bool,
+
+    /// Return the hash of a region of the flash
+    /// -a and -n are optional. Default is the entire contents.
+    #[clap(long, short = 'H', group = "command")]
+    hash: bool,
 
     /// perform a sector erase
     #[clap(
@@ -87,6 +94,52 @@ struct QspiArgs {
     /// verify instead of writing
     #[clap(long, short = 'V', requires = "writefile")]
     verify: bool,
+
+    /// file to read
+    #[clap(long, short = 'R', value_name = "filename", group = "command")]
+    readfile: Option<String>,
+}
+
+fn optional_nbytes<'a>(
+    core: &'a mut dyn Core,
+    context: &'a mut HiffyContext,
+    qspi_read_id: &HiffyFunction,
+    nbytes: Option<usize>,
+) -> Result<u32> {
+    // Nbytes (-n) is optional and defaults to
+    // the entire flash contents.
+    // Read the flash size from the flash part itself if nbytes
+    // is not specified.
+    match nbytes {
+        Some(nbytes) => Ok(nbytes as u32),
+        None => {
+            let ops = vec![Op::Call(qspi_read_id.id), Op::Done];
+            // Result<
+            //  Vec<
+            //      Result<Vec<u8>, u32>
+            //  >, anyhow::Error>
+            match context.run(core, ops.as_slice(), None) {
+                Ok(results) => match &results[0] {
+                    Ok(buf) => {
+                        if mem::size_of::<DeviceIdData>() == buf.len() {
+                            let did: DeviceIdData = unsafe {
+                                std::ptr::read(buf.as_ptr() as *const _)
+                            };
+                            Ok(did.size()? as u32)
+                        } else {
+                            Err(anyhow!(
+                                "Unexpected result length: {} != {}",
+                                mem::size_of::<DeviceIdData>(),
+                                buf.len()
+                            ))
+                        }
+                    }
+                    Err(e) => Err(anyhow!("{}", e)),
+                },
+                Err(e) => Err(e),
+            }
+        }
+    }
 }
 
 fn qspi(
@@ -100,9 +153,10 @@ fn qspi(
     let funcs = context.functions()?;
 
     let sector_size = 64 * 1024;
-    let block_size = 256;
+    let block_size = 256; // Conflating flash block size with hubris scratch buffer.
 
     let mut ops = vec![];
+    let mut hash_name = "".to_string();
 
     let data = if subargs.status {
         let qspi_read_status = funcs.get("QspiReadStatus", 0)?;
@@ -111,6 +165,19 @@ fn qspi(
     } else if subargs.id {
         let qspi_read_id = funcs.get("QspiReadId", 0)?;
         ops.push(Op::Call(qspi_read_id.id));
+        None
+    } else if subargs.hash {
+        let qspi_hash = funcs.get("QspiHash", 2)?;
+        let qspi_read_id = funcs.get("QspiReadId", 0)?;
+        // Address is optional and defaults to zero.
+        let addr = subargs.addr.or(Some(0)).unwrap() as u32;
+        // nbytes is optional and defaults to the size of the entire flash.
+        let nbytes =
+            optional_nbytes(core, &mut context, qspi_read_id, subargs.nbytes)?;
+        ops.push(Op::Push32(addr));
+        ops.push(Op::Push32(nbytes));
+        ops.push(Op::Call(qspi_hash.id));
+        hash_name = format!("{:06x}..{:06x}", addr, nbytes);
         None
     } else if subargs.erase {
         let qspi_sector_erase = funcs.get("QspiSectorErase", 1)?;
@@ -229,20 +296,20 @@ fn qspi(
             // in block_size nibbles.
             //
             let ops = vec![
-                Op::Push32(offset),
-                Op::Push32(0),
-                Op::PushNone,
-                Op::Label(Target(0)),
-                Op::Drop,
-                Op::Push32(block_size),
-                Op::Call(qspi_page_program.id),
-                Op::Add,
-                Op::Swap,
-                Op::Push32(block_size),
-                Op::Add,
-                Op::Swap,
-                Op::Push32(chunk),
-                Op::BranchGreaterThan(Target(0)),
+                Op::Push32(offset),               // Push flash address.
+                Op::Push32(0),                    // Buffer offset = 0.
+                Op::PushNone,                     // Placeholder to be dropped.
+                Op::Label(Target(0)),             // Start of loop
+                Op::Drop,                         // Drop placeholder/limit.
+                Op::Push32(block_size),           // Push length of this xfer.
+                Op::Call(qspi_page_program.id),   // Call (&flash, &buf, len)
+                Op::Add,  // Add len of that xfer to both values on stack.
+                Op::Swap, //
+                Op::Push32(block_size), //
+                Op::Add,  //
+                Op::Swap, // Now pointing to next xfer.
+                Op::Push32(chunk), // Push limit.
+                Op::BranchGreaterThan(Target(0)), // Continue if not at limit.
                 Op::Done,
             ];
 
@@ -301,6 +368,117 @@ fn qspi(
         }
 
         return Ok(());
+    } else if let Some(filename) = subargs.readfile {
+        // Address(default=0) and n-bytes(default=size of part-address) are
+        // optional.
+        let qspi_read_id = funcs.get("QspiReadId", 0)?;
+        let qspi_read = funcs.get("QspiRead", 2)?;
+
+        // Address is optional and defaults to zero.
+        // The default can/should be done in `#[clap(...` for "address"
+        // if that works for the other users of the -a flag.
+        let mut address = subargs.addr.or(Some(0)).unwrap() as u32;
+        println!("addr={:?}", address);
+
+        let nbytes =
+            optional_nbytes(core, &mut context, qspi_read_id, subargs.nbytes)?;
+        println!("nbytes={:?}", nbytes);
+
+        //
+        // Low-level reads are in units less than or equal to
+        // context.scratch_size().
+        // Those can be batched, depending on serialization overhead, into
+        // context.rstack_size().
+        //
+        // TODO: check alignment of start and end.
+        // Things are broken if they aren't, so an assert would be ok.
+        //
+        let rstack_size = context.rstack_size() as u32;
+        let scratch_size = context.scratch_size() as u32;
+        // TODO: Don't guess at the overhead. Make sure that data and
+        // serialization meta data are both in rstack.
+        let overhead = 1; // XXX Assume each item in rstack has 1-byte overhead.
+
+        let chunk = scratch_size;
+        let max_chunks = rstack_size / (chunk + overhead);
+
+        let buf = vec![0u8; rstack_size as usize];
+        let output_file =
+            File::create(filename).expect("Cannot create output file");
+        let mut writer = BufWriter::with_capacity(nbytes as usize, output_file);
+
+        let started = Instant::now();
+        let bar = ProgressBar::new(nbytes as u64);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("humility: reading [{bar:30}] {bytes}/{total_bytes}"),
+        );
+        let update_cycle = 64;
+        let mut updates = 0;
+
+        let end_address = address + nbytes;
+        // let mut out_address = address;
+        println!(
+            "address={}, chunk={}, end_address={}",
+            address, chunk, end_address
+        );
+        println!("max_chunks={}", max_chunks);
+        assert!(max_chunks > 0);
+        loop {
+            let mut ops = vec![];
+            for _ in 0..max_chunks {
+                let len = if address + chunk > end_address {
+                    end_address - address
+                } else {
+                    chunk
+                };
+
+                if len == 0 {
+                    break;
+                }
+                ops.push(Op::Push32(address));
+                ops.push(Op::Push32(len));
+                ops.push(Op::Call(qspi_read.id));
+
+                address += len;
+            }
+            ops.push(Op::Done);
+
+            let results = context.run(core, ops.as_slice(), Some(&buf))?;
+
+            if updates % update_cycle == 0 {
+                bar.set_position((address).into());
+            }
+            updates += 1;
+
+            for (i, block_result) in results.iter().enumerate() {
+                match &*block_result {
+                    Err(err) => bail!(
+                        "failed to read block {} at offset {}: {}",
+                        i,
+                        address,
+                        qspi_read.strerror(*err)
+                    ),
+                    Ok(buf) => {
+                        writer.write_all(buf).expect("write error");
+                        // _out_address += buf.len() as u32;
+                    }
+                }
+            }
+            if address >= end_address {
+                // redundant with check at top of loop
+                break;
+            }
+        }
+        writer.flush().unwrap();
+        bar.finish_and_clear();
+        humility::msg!(
+            "read {} in {}",
+            HumanBytes(nbytes as u64),
+            HumanDuration(started.elapsed())
+        );
+
+        return Ok(());
     } else {
         bail!("expected an operation");
     };
@@ -321,11 +499,133 @@ fn qspi(
             Dumper::new().dump(results, 0);
             return Ok(());
         }
+    } else if subargs.id {
+        // If the response is well formatted, print it out in addition to raw hex.
+        if let Ok(results) = &results[0] {
+            if mem::size_of::<DeviceIdData>() == results.len() {
+                let did: DeviceIdData =
+                    unsafe { std::ptr::read(results.as_ptr() as *const _) };
+                println!("{}", did);
+            } else {
+                println!(
+                    "Unexpected result length: {} != {}",
+                    mem::size_of::<DeviceIdData>(),
+                    results.len()
+                );
+            }
+        }
+    } else if subargs.hash {
+        match &results[0] {
+            Ok(buf) => {
+                print!("{}: ", hash_name);
+                for byte in buf {
+                    print!("{:02x}", byte);
+                }
+                println!("");
+            }
+            Err(e) => {
+                bail!("hash failed: {}", e);
+            }
+        }
+        return Ok(());
     }
 
     println!("{:x?}", results);
 
     Ok(())
+}
+
+/// Micron's Device ID Data
+// Responses to the Read ID family of instructions can be more flexible than
+// the struct below, but until we need support beyond Micron MT25Q, this will do.
+#[derive(Debug, Copy, Clone)]
+#[repr(C, packed)]
+struct DeviceIdData {
+    manufacturer_id: u8,
+    memory_type: u8,
+    memory_capacity: u8,
+    uid_n: u8,
+    ext_device_id: u8,
+    device_configuration_info: u8,
+    uid: [u8; 14],
+}
+
+impl DeviceIdData {
+    /// Return flash part size in bytes
+    pub fn size(&self) -> Result<usize> {
+        match self.memory_capacity {
+            // This is currently limited to the codes returned from Micron MT25Q parts.
+            0 => {
+                return Err(anyhow!(
+                    "unknown size code=0x{:02x?}",
+                    self.memory_capacity
+                ))
+            }
+            _ => Ok(1usize << (self.memory_capacity)),
+        }
+    }
+}
+
+impl fmt::Display for DeviceIdData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mfg = match self.manufacturer_id {
+            0x20 => "Micron".to_string(),
+            0xEF => "Winbond".to_string(),
+            _ => format!("unknown({:x?}", self.manufacturer_id),
+        };
+        let memtype: String = match self.memory_type {
+            0xBA => "3V".to_string(),
+            0xBB => "1.8V".to_string(),
+            _ => format!("unknown(0x{:02x?})", self.memory_type),
+        };
+
+        write!(
+            f,
+            "DeviceIdData {{\n\
+            \tmanufacturer_id: {}(0x{:02x})\n\
+            \tmemory_type: {}({})\n\
+            \tmemory_capacity: {}\n\
+            \tuid_n: {}\n\
+            \t# If a Micron device:\n\
+            \text_device_id: 0b{:b}\n\
+            \t\t{} device generation,\n\
+            \t\t{} BP scheme,\n\
+            \t\tHOLD#/RESET#={}\n\
+            \t\tAdditional HW RESET# is {}available,\n\
+            \t\tSector size is {},\n\
+            \tdevice_configuration_info: {}\n\
+            \tuid: {:02x?}\n}}",
+            mfg,
+            self.manufacturer_id,
+            memtype,
+            self.memory_type,
+            match self.size() {
+                Ok(capacity) => capacity.to_string(),
+                Err(e) => e.to_string(),
+            },
+            self.uid_n,
+            self.ext_device_id,
+            if (self.ext_device_id & 0b01000000) != 0 { "2nd" } else { "1st" },
+            if (self.ext_device_id & 0b00100000) != 0 {
+                "Athernate"
+            } else {
+                "Standard"
+            },
+            if (self.ext_device_id & 0b00001000) != 0 {
+                "RESET"
+            } else {
+                "HOLD"
+            },
+            if (self.ext_device_id & 0b00000100) != 0 { "" } else { "not " },
+            if (self.ext_device_id & 0b00000011) == 0b00 {
+                "Uniform 64KB"
+            } else {
+                "unknown"
+            },
+            self.device_configuration_info,
+            self.uid
+        )
+    }
 }
 
 pub fn init() -> (Command, ClapCommand<'static>) {

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -120,7 +120,12 @@ impl HiffyFunctions {
             .get(name)
             .ok_or_else(|| anyhow!("did not find {} function", name))?;
         if f.args.len() != nargs {
-            bail!("mismatched function signature on {}", name);
+            bail!(
+                "mismatched function signature on {} (args.len:{}, nargs:{}",
+                name,
+                f.args.len(),
+                nargs
+            );
         }
         Ok(f)
     }
@@ -208,6 +213,7 @@ impl<'a> HiffyContext<'a> {
             data: Self::variable(hubris, "HIFFY_DATA", false)?,
             rstack: Self::variable(hubris, "HIFFY_RSTACK", false)?,
             requests: Self::variable(hubris, "HIFFY_REQUESTS", true)?,
+            // scratch: Self::variable(hubris, "HIFFY_SCRATCH", false)?,
             errors: Self::variable(hubris, "HIFFY_ERRORS", true)?,
             failure: Self::variable(hubris, "HIFFY_FAILURE", false)?,
             functions: Self::definition(hubris, "HIFFY_FUNCTIONS")?,
@@ -533,5 +539,15 @@ impl<'a> HiffyContext<'a> {
         self.state = State::ResultsConsumed;
 
         Ok(rvec)
+    }
+
+    pub fn rstack_size(&self) -> usize {
+        // self.rstack.size
+        2048 // This value should be discovered.
+    }
+
+    pub fn scratch_size(&self) -> usize {
+        // self.scratch.size
+        256 // This value should be discovered.
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -24,6 +24,7 @@ pub fn init(
         cmd_etm::init,
         cmd_flash::init,
         cmd_gpio::init,
+        cmd_hash::init,
         cmd_hiffy::init,
         cmd_i2c::init,
         cmd_itm::init,


### PR DESCRIPTION
Add qspi command {-H|--hash} [-a addr] [-n length]
Add qspi command --readfile
Make qspi -n default to the discovered size of the flash part.
Qspi --address defaults to zero for readfile and hash.
Hash --test [--long] runs NIST test vectors for SHA256