### PR TITLE
Validate clap

### DIFF
--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -190,7 +190,7 @@ pub struct I2cArgs {
     /// flash the specified file, assuming two byte addressing
     #[clap(long, short,
         conflicts_with_all = &[
-            "write", "raw", "nbytes", "read", "writeall", "register", "scan",
+            "write", "raw", "nbytes", "register", "scan",
             "writeraw"
         ],
         value_name = "filename",

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -108,7 +108,7 @@ struct JefeArgs {
     start: bool,
 
     /// hold the specified task
-    #[clap(long, short, conflicts_with = "release")]
+    #[clap(long, short = 'H', conflicts_with = "release")]
     hold: bool,
 
     /// release the specified task

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -122,7 +122,7 @@ use std::convert::TryInto;
 #[clap(name = "readmem", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct ReadmemArgs {
     /// print out as halfwords instead of as bytes
-    #[clap(long, short, conflicts_with_all = &["word", "symbol"])]
+    #[clap(long, short = 'H', conflicts_with_all = &["word", "symbol"])]
     halfword: bool,
 
     /// print out as words instead of as bytes

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -49,7 +49,8 @@ struct SpiArgs {
     /// interpret the specified number of trailing bytes on a write as a
     /// bigendian address
     #[clap(
-        long, short = 'A', requires_all = &["read", "write", "discard"]
+        long, short = 'A', requires_all = &["read", "write", "discard"],
+        conflicts_with = "littleendian-address"
     )]
     bigendian_address: Option<usize>,
 
@@ -57,7 +58,7 @@ struct SpiArgs {
     /// bigendian address
     #[clap(
         long, short = 'a', requires_all = &["read", "write", "discard"],
-        conflicts_with = "bigendian_address"
+        conflicts_with = "bigendian-address"
     )]
     littleendian_address: Option<usize>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,3 +84,9 @@ fn main() {
         std::process::exit(1);
     }
 }
+
+#[test]
+fn validate_clap() {
+    let (_, clap) = cmd::init(Args::into_app());
+    clap.clone().debug_assert();
+}


### PR DESCRIPTION
~~This will eventually fix #91, but it's going to be failing until I work through all of the current failures.~~

This introduces a test that will assert that the state built up within
clap is coherent.

Fixes https://github.com/oxidecomputer/humility/issues/91

Most of these removals or changes are simply fixes, but we also change
`jefe -h` to `jefe -H`

Fixes https://github.com/oxidecomputer/humility/issues/90