### PR TITLE
add nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,31 @@
+name: 'nightly'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  nightly-release:
+    name: Build Nightly Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install libusb-1.0-0-dev libftdi1-dev
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Upload Release
+        run: gh release upload --repo oxidecomputer/humility nightly --clobber target/release/humility
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We want to check that hubris doesn't regress certain things in humility, and so the best way to do that is to start producing a nightly build.

Every day, this will run this job. This job will:

* build humility in release
* upload the binary to https://github.com/oxidecomputer/humility/releases/tag/nightly

It will overwrite the one that was previously there, so we don't keep every single nightly around.

This workflow *may* break if the dependencies needed to build changes, in theory I will get a notification if this fails, but it's worth remembering.