### PR TITLE
it's time

### DIFF
--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -150,30 +150,30 @@ fn etmcmd_enable(
         return Ok(());
     }
 
-    /*
-     * First, enable TRCENA in the DEMCR.
-     */
+    //
+    // First, enable TRCENA in the DEMCR.
+    //
     let mut val = DEMCR::read(core)?;
     val.set_trcena(true);
     val.write(core)?;
 
-    /*
-     * Now unlock the ETM.
-     */
+    //
+    // Now unlock the ETM.
+    //
     ETMLAR::unlock(core)?;
 
-    /*
-     * STM32F407-specific: enable TRACE_IOEN in the DBGMCU_CR, and set the
-     * trace mode to be asynchronous.
-     */
+    //
+    // STM32F407-specific: enable TRACE_IOEN in the DBGMCU_CR, and set the
+    // trace mode to be asynchronous.
+    //
     let mut val = STM32F4_DBGMCU_CR::read(core)?;
     val.set_trace_ioen(true);
     val.set_trace_mode(0);
     val.write(core)?;
 
-    /*
-     * Now setup the TPIU.
-     */
+    //
+    // Now setup the TPIU.
+    //
     let mut val = TPIU_SPPR::read(core)?;
     val.set_txmode(TPIUMode::NRZ);
     val.write(core)?;
@@ -187,13 +187,13 @@ fn etmcmd_enable(
     acpr.write(core)?;
     log::trace!("{:#x?}", TPIU_ACPR::read(core)?);
 
-    /*
-     * We are now ready to enable ETM.  There are a bunch of steps involved
-     * in this, but we need to first write to the ETMCR to indicate that
-     * we are programming it.  Once done writing to the ETM control
-     * registers, we need to write to ETMCR again to indicate that we are
-     * done programming it.
-     */
+    //
+    // We are now ready to enable ETM.  There are a bunch of steps involved
+    // in this, but we need to first write to the ETMCR to indicate that
+    // we are programming it.  Once done writing to the ETM control
+    // registers, we need to write to ETMCR again to indicate that we are
+    // done programming it.
+    //
     log::trace!("{:#x?}", ETMCR::read(core)?);
     let mut etmcr = ETMCR::read(core)?;
     etmcr.set_branch_output(true);
@@ -205,9 +205,9 @@ fn etmcmd_enable(
     log::trace!("will write {:#x?}", etmcr);
     etmcr.write(core)?;
 
-    /*
-     * Set to the hard-wired always-true event
-     */
+    //
+    // Set to the hard-wired always-true event
+    //
     let mut teevr = ETMTEEVR::read(core)?;
     teevr.set_resource_a(HUMILITY_ETM_ALWAYSTRUE);
     teevr.write(core)?;
@@ -237,9 +237,9 @@ fn etmcmd_enable(
     val.write(core)?;
     log::trace!("{:#x?}", ETMTRACEIDR::read(core)?);
 
-    /*
-     * Finally, indicate that we are done programming!
-     */
+    //
+    // Finally, indicate that we are done programming!
+    //
     etmcr.set_programming(false);
     etmcr.write(core)?;
 
@@ -586,9 +586,9 @@ fn etmcmd(
         }
     }
 
-    /*
-     * For all of the other commands, we need to actually attach to the chip.
-     */
+    //
+    // For all of the other commands, we need to actually attach to the chip.
+    //
     let mut core = attach_live(args)?;
     let _info = core.halt()?;
 

--- a/cmd/itm/src/lib.rs
+++ b/cmd/itm/src/lib.rs
@@ -113,21 +113,21 @@ fn itmcmd_probe(core: &mut dyn Core, coreinfo: &CoreInfo) -> Result<()> {
 }
 
 fn itmcmd_disable(core: &mut dyn Core) -> Result<()> {
-    /*
-     * Unlock the ITM.
-     */
+    //
+    // Unlock the ITM.
+    //
     ITM_LAR::unlock(core)?;
 
-    /*
-     * Disable the ITM.
-     */
+    //
+    // Disable the ITM.
+    //
     let mut tcr = ITM_TCR::read(core)?;
     tcr.set_itm_enable(false);
     tcr.write(core)?;
 
-    /*
-     * Now disable TRCENA in the DEMCR.
-     */
+    //
+    // Now disable TRCENA in the DEMCR.
+    //
     let mut val = DEMCR::read(core)?;
     val.set_trcena(false);
     val.write(core)?;
@@ -266,9 +266,9 @@ fn itmcmd(
         }
     }
 
-    /*
-     * For all of the other commands, we need to actually attach to the chip.
-     */
+    //
+    // For all of the other commands, we need to actually attach to the chip.
+    //
     let mut c = attach_live(args)?;
     let core = c.as_mut();
     hubris.validate(core, HubrisValidate::ArchiveMatch)?;
@@ -291,9 +291,9 @@ fn itmcmd(
             core.init_swv()?;
         }
 
-        /*
-         * By default, we enable all logging (ports 0-7).
-         */
+        //
+        // By default, we enable all logging (ports 0-7).
+        //
         let stim = 0x0000_000f;
         let clockscaler = match subargs.clockscaler {
             Some(value) => value,

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -138,9 +138,9 @@ fn probecmd(
         },
     );
 
-    /*
-     * Start with information about our core and chip...
-     */
+    //
+    // Start with information about our core and chip...
+    //
     print("core", corename(part));
 
     let m = &coreinfo.manufacturer;
@@ -208,9 +208,9 @@ fn probecmd(
         },
     );
 
-    /*
-     * Now display our chip status
-     */
+    //
+    // Now display our chip status
+    //
     statusif(dhcsr.restart_status(), "restarting");
     statusif(dhcsr.reset_status(), "resetting");
     statusif(dhcsr.retire_status(), "executing");
@@ -225,18 +225,18 @@ fn probecmd(
     print(
         "status",
         if status.is_empty() {
-            /*
-             * If the status is unknown, it doesn't mean very much; from the
-             * ARMv7-M ARM on the meaning of S_RETIRE_ST:
-             *
-             *   The architecture does not define precisely when this bit is
-             *   set to 1. It requires only that this happen periodically in
-             *   Non-debug state to indicate that software execution is
-             *   progressing.
-             *
-             * To see if the core is actually executing instructions, we
-             * will attempt to halt it and step it, seeing if the PC moves.
-             */
+            //
+            // If the status is unknown, it doesn't mean very much; from the
+            // ARMv7-M ARM on the meaning of S_RETIRE_ST:
+            //
+            //   The architecture does not define precisely when this bit is
+            //   set to 1. It requires only that this happen periodically in
+            //   Non-debug state to indicate that software execution is
+            //   progressing.
+            //
+            // To see if the core is actually executing instructions, we
+            // will attempt to halt it and step it, seeing if the PC moves.
+            //
             let rval = core
                 .halt()
                 .and_then(|_| core.read_reg(ARMRegister::PC))
@@ -260,9 +260,9 @@ fn probecmd(
         },
     );
 
-    /*
-     * Now display information about each CoreSight component found
-     */
+    //
+    // Now display information about each CoreSight component found
+    //
     let mut sorted = coreinfo
         .components
         .keys()

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -254,10 +254,10 @@ fn tasks(
         let cur =
             core.read_word_32(hubris.lookup_symword("CURRENT_TASK_PTR")?)?;
 
-        /*
-         * We read the entire task table at a go to get as consistent a
-         * snapshot as possible.
-         */
+        //
+        // We read the entire task table at a go to get as consistent a
+        // snapshot as possible.
+        //
         let mut taskblock = vec![0; task_t.size * task_count as usize];
         core.read_8(base, &mut taskblock)?;
 

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -168,10 +168,10 @@ fn test_ingest(
                     bail!("timed out after {} seconds", timeout);
                 }
 
-                /*
-                 * We will keep reading until we have a zero byte read, at
-                 * which time we will kick out and process one byte.
-                 */
+                //
+                // We will keep reading until we have a zero byte read, at
+                // which time we will kick out and process one byte.
+                //
                 let buf = shared.borrow_mut().read_swv()?;
 
                 if !buf.is_empty() {

--- a/cmd/trace/src/lib.rs
+++ b/cmd/trace/src/lib.rs
@@ -210,9 +210,9 @@ fn tracecmd(
     let subargs = &TraceArgs::try_parse_from(subargs)?;
     let mut tasks: HashMap<u32, String> = HashMap::new();
 
-    /*
-     * First, read the task block to get a mapping of IDs to names.
-     */
+    //
+    // First, read the task block to get a mapping of IDs to names.
+    //
     let base = core.read_word_32(hubris.lookup_symword("TASK_TABLE_BASE")?)?;
     let size = core.read_word_32(hubris.lookup_symword("TASK_TABLE_SIZE")?)?;
 
@@ -238,9 +238,9 @@ fn tracecmd(
         tasks.insert(i, module.to_string());
     }
 
-    /*
-     * Now enable ITM and ingest.
-     */
+    //
+    // Now enable ITM and ingest.
+    //
     let traceid = itm_enable_ingest(core, hubris, 0xf000_0000)?;
     tracecmd_ingest(core, subargs, hubris, &tasks, traceid)?;
 

--- a/humility-arch-cortex/src/etm.rs
+++ b/humility-arch-cortex/src/etm.rs
@@ -15,9 +15,9 @@ macro_rules! etm_register {
     )
 }
 
-/*
- * ETM Main Configuration Register
- */
+//
+// ETM Main Configuration Register
+//
 etm_register!(ETMCR, 0x000,
     #[derive(Copy, Clone)]
     pub struct ETMCR(u32);
@@ -47,9 +47,9 @@ etm_register!(ETMCR, 0x000,
     pub power_down, set_power_down: 0;
 );
 
-/*
- * ETM Configuration Code Register
- */
+//
+// ETM Configuration Code Register
+//
 etm_register!(ETMCCR, 0x001,
     #[derive(Copy, Clone)]
     pub struct ETMCCR(u32);
@@ -69,9 +69,9 @@ etm_register!(ETMCCR, 0x001,
     pub num_address_comparators, _: 3, 0;
 );
 
-/*
- * ETM Status Register
- */
+//
+// ETM Status Register
+//
 etm_register!(ETMSR, 0x004,
     #[derive(Copy, Clone)]
     pub struct ETMSR(u32);
@@ -82,9 +82,9 @@ etm_register!(ETMSR, 0x004,
     pub untraced_overflow, _: 0;
 );
 
-/*
- * ETM System Configuration Register
- */
+//
+// ETM System Configuration Register
+//
 etm_register!(ETMSCR, 0x005,
     #[derive(Copy, Clone)]
     pub struct ETMSCR(u32);
@@ -103,9 +103,9 @@ etm_register!(ETMSCR, 0x005,
     pub max_port_size, _: 2, 0;
 );
 
-/*
- * ETM TraceEnable Event Register
- */
+//
+// ETM TraceEnable Event Register
+//
 etm_register!(ETMTEEVR, 0x008,
     #[derive(Copy, Clone)]
     pub struct ETMTEEVR(u32);
@@ -115,9 +115,9 @@ etm_register!(ETMTEEVR, 0x008,
     pub resource_a, set_resource_a: 6, 0;
 );
 
-/*
- * ETM TraceEnable Control 1 Register
- */
+//
+// ETM TraceEnable Control 1 Register
+//
 etm_register!(ETMTECR1, 0x009,
     #[derive(Copy, Clone)]
     pub struct ETMTECR1(u32);
@@ -128,9 +128,9 @@ etm_register!(ETMTECR1, 0x009,
     pub comparator_select, set_comparator_select: 7, 0;
 );
 
-/*
- * ETM FIFOFULL Region Register
- */
+//
+// ETM FIFOFULL Region Register
+//
 etm_register!(ETMFFRR, 0x00a,
     #[derive(Copy, Clone)]
     pub struct ETMFFRR(u32);
@@ -140,9 +140,9 @@ etm_register!(ETMFFRR, 0x00a,
     pub comparator_select, set_comparator_select: 7, 0;
 );
 
-/*
- * ETM FIFOFULL Level Register
- */
+//
+// ETM FIFOFULL Level Register
+//
 etm_register!(ETMFFLR, 0x00b,
     #[derive(Copy, Clone)]
     pub struct ETMFFLR(u32);
@@ -150,9 +150,9 @@ etm_register!(ETMFFLR, 0x00b,
     pub fifo_full_level, set_fifo_full_level: 7, 0;
 );
 
-/*
- * ETM Identification Register
- */
+//
+// ETM Identification Register
+//
 etm_register!(ETMIDR, 0x079,
     #[derive(Copy, Clone)]
     pub struct ETMIDR(u32);
@@ -168,9 +168,9 @@ etm_register!(ETMIDR, 0x079,
     pub etm_revision, _: 3, 0;
 );
 
-/*
- * ETM Configuration Code Extension Register
- */
+//
+// ETM Configuration Code Extension Register
+//
 etm_register!(ETMCCER, 0x07a,
     #[derive(Copy, Clone)]
     pub struct ETMCCER(u32);
@@ -190,9 +190,9 @@ etm_register!(ETMCCER, 0x07a,
     pub num_extended_input_selectors, _: 2, 0;
 );
 
-/*
- * ETM Trace ID Register
- */
+//
+// ETM Trace ID Register
+//
 etm_register!(ETMTRACEIDR, 0x080,
     #[derive(Copy, Clone)]
     pub struct ETMTRACEIDR(u32);
@@ -200,9 +200,9 @@ etm_register!(ETMTRACEIDR, 0x080,
     pub traceid, set_traceid: 6, 0;
 );
 
-/*
- * ETM Identification Register 2
- */
+//
+// ETM Identification Register 2
+//
 etm_register!(ETMIDR2, 0x082,
     #[derive(Copy, Clone)]
     pub struct ETMIDR2(u32);
@@ -211,9 +211,9 @@ etm_register!(ETMIDR2, 0x082,
     pub rfe_cpsr_before_pc, _: 0;
 );
 
-/*
- * ETM Lock Access Register
- */
+//
+// ETM Lock Access Register
+//
 etm_register!(ETMLAR, 0x3ec,
     #[derive(Copy, Clone)]
     pub struct ETMLAR(u32);
@@ -223,9 +223,9 @@ etm_register!(ETMLAR, 0x3ec,
 
 impl ETMLAR {
     pub fn unlock(core: &mut dyn humility::core::Core) -> Result<()> {
-        /*
-         * To unlock, we write "CoreSight Access" in l33t
-         */
+        //
+        // To unlock, we write "CoreSight Access" in l33t
+        //
         let val: u32 = 0xc5ac_ce55;
         core.write_word_32(ETMLAR::ADDRESS, val)?;
         Ok(())
@@ -238,9 +238,9 @@ impl ETMLAR {
     }
 }
 
-/*
- * ETM Lock Status Register
- */
+//
+// ETM Lock Status Register
+//
 etm_register!(ETMLSR, 0x3ed,
     #[derive(Copy, Clone)]
     pub struct ETMLSR(u32);
@@ -488,9 +488,9 @@ fn etm_packet_state(
         ndx + 1
     };
 
-    /*
-     * This assumes the alternative encoding for branch packets.
-     */
+    //
+    // This assumes the alternative encoding for branch packets.
+    //
     assert!(config.alternative_encoding);
 
     match hdr {
@@ -504,15 +504,15 @@ fn etm_packet_state(
             } else {
                 let last = payload[payload.len() - 1];
 
-                /*
-                 * If the high order bit is set, we are always awaiting more
-                 * payload -- regardless of whether that is in one of the
-                 * address bytes (up to five) or one of the exception bytes
-                 * (up to three).
-                 *
-                 * If bit 6 is set, we are awaiting an Exception Information
-                 * Byte.
-                 */
+                //
+                // If the high order bit is set, we are always awaiting more
+                // payload -- regardless of whether that is in one of the
+                // address bytes (up to five) or one of the exception bytes
+                // (up to three).
+                //
+                // If bit 6 is set, we are awaiting an Exception Information
+                // Byte.
+                //
                 if (last & 0b1000_0000) != 0 || (last & 0b0100_0000) != 0 {
                     ETM3PacketState::AwaitingPayload
                 } else {
@@ -647,32 +647,32 @@ fn etm_payload_decode(
             let mut xcp = None;
 
             for (i, pld) in payload.iter().enumerate() {
-                /*
-                 * If our continue bit is set, we always have seven new bits
-                 * of address; or it in, increase the number of bits and
-                 * continue.
-                 */
+                //
+                // If our continue bit is set, we always have seven new bits
+                // of address; or it in, increase the number of bits and
+                // continue.
+                //
                 if (pld & 0b1000_0000) != 0 {
                     target |= ((pld & 0b0111_1111) as u32) << nbits;
                     nbits += 7;
                     continue;
                 }
 
-                /*
-                 * The continue bit is not set, so this packet terminates
-                 * our address.  Bit 6 will indicate whether or not we have
-                 * exception bytes; if we have exception bytes, we'll pull
-                 * those now.
-                 */
+                //
+                // The continue bit is not set, so this packet terminates
+                // our address.  Bit 6 will indicate whether or not we have
+                // exception bytes; if we have exception bytes, we'll pull
+                // those now.
+                //
                 if (pld & 0b0100_0000) != 0 {
                     xcp = Some(exception(i + 1));
                 }
 
-                /*
-                 * For our final address packet, it is generally six bits --
-                 * unless we have a full address change, in which case only
-                 * four bits remain.
-                 */
+                //
+                // For our final address packet, it is generally six bits --
+                // unless we have a full address change, in which case only
+                // four bits remain.
+                //
                 if i < 4 {
                     target |= ((pld & 0b0011_1111) as u32) << nbits;
                     nbits += 6;
@@ -784,10 +784,10 @@ pub fn etm_ingest(
 
         match (state, hdr) {
             (IngestState::ISyncSearching, ETM3Header::ISync) => {
-                /*
-                 * We have our ISync packet -- we can now ingest everything
-                 * (starting with this packet).
-                 */
+                //
+                // We have our ISync packet -- we can now ingest everything
+                // (starting with this packet).
+                //
                 state = IngestState::Ingesting;
             }
             (_, _) => {}

--- a/humility-arch-cortex/src/scs.rs
+++ b/humility-arch-cortex/src/scs.rs
@@ -188,28 +188,27 @@ impl CoreSightComponent {
         let major = devtype.major();
         let sub = devtype.sub();
 
-        /*
-         * Determining the CoreSight component that we're looking at is -- in
-         * classic ARM fashion -- ridiculously complicated.  Table B2-1 in
-         * the CoreSight 3.0 Architecture Specification requires that
-         * we look at up to 13 different fields (!) across 8
-         * different registers (!!) adding to a total of 74 bits
-         * (!!!).  On the one hand, it's reassuring that we can have
-         * a unique CoreSight component for every grain of sand on
-         * Earth and still have enough room to similarly
-         * grant a CoreSight component for the grains of sand on a thousand
-         * other such planets. On the other hand, this is obviously absurd,
-         * and no two bodies of software seem to make this determination the
-         * same way.  (One notable body of software from ARM claims to be
-         * written from the canonical description, which is apparently to be
-         * found on -- wait for it -- an internal Wiki!)
-         *
-         * Absent a single authoritative doc, we muddle through the best we
-         * can, cribbing from various internet sources (searching GitHub for
-         * known constants and their associated components is remarkably
-         * effective).  The ordering here is: part numbers, falling back to
-         * archid second, falling back to device type last.
-         */
+        //
+        // Determining the CoreSight component that we're looking at is -- in
+        // classic ARM fashion -- ridiculously complicated.  Table B2-1 in the
+        // CoreSight 3.0 Architecture Specification requires that we look at
+        // up to 13 different fields (!) across 8 different registers (!!)
+        // adding to a total of 74 bits (!!!).  On the one hand, it's
+        // reassuring that we can have a unique CoreSight component for every
+        // grain of sand on Earth and still have enough room to similarly
+        // grant a CoreSight component for the grains of sand on a thousand
+        // other such planets. On the other hand, this is obviously absurd,
+        // and no two bodies of software seem to make this determination the
+        // same way.  (One notable body of software from ARM claims to be
+        // written from the canonical description, which is apparently to be
+        // found on -- wait for it -- an internal Wiki!)
+        //
+        // Absent a single authoritative doc, we muddle through the best we
+        // can, cribbing from various internet sources (searching GitHub for
+        // known constants and their associated components is remarkably
+        // effective).  The ordering here is: part numbers, falling back to
+        // archid second, falling back to device type last.
+        //
         Ok(match page.part {
             0x001 => CoreSightComponent::ITM,
             0x002 => CoreSightComponent::DWT,
@@ -339,18 +338,18 @@ pub fn read_rom(
     base: u32,
     components: &mut MultiMap<CoreSightComponent, u32>,
 ) -> Result<()> {
-    /*
-     * We need to determine if this, in fact, a ROM table.
-     */
+    //
+    // We need to determine if this, in fact, a ROM table.
+    //
     let page = CoreSightPage::new(core, base)?;
     let max = 0x900;
 
     match page.class {
         CoreSightClass::ROM => {
-            /*
-             * This is a ROM table, so we want to read its entries, and
-             * descend.
-             */
+            //
+            // This is a ROM table, so we want to read its entries, and
+            // descend.
+            //
             for offset in (0..max).step_by(size_of::<u32>() as usize) {
                 let val = core.read_word_32(base + offset as u32)?;
 
@@ -386,11 +385,11 @@ register!(CPUID, 0xe000_ed00,
     pub revision, _: 3, 0;
 );
 
-/*
- * This is the much shorter list of vendors whose parts we support -- and
- * therefore are willing to hard-code special case handling for, to some
- * extent.
- */
+//
+// This is the much shorter list of vendors whose parts we support -- and
+// therefore are willing to hard-code special case handling for, to some
+// extent.
+//
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Vendor {
     ST,
@@ -438,10 +437,10 @@ impl CoreInfo {
         };
 
         if vendor == Vendor::ST && part == ARMCore::CortexM7 {
-            /*
-             * Before we can walk the M7's ROM tables, we need to make sure
-             * that the debug parts are clocked.
-             */
+            //
+            // Before we can walk the M7's ROM tables, we need to make sure
+            // that the debug parts are clocked.
+            //
             let mut cr = STM32H7_DBGMCU_CR::read(core)?;
             cr.set_srdbgcken(true);
             cr.set_cddbgcken(true);
@@ -450,14 +449,14 @@ impl CoreInfo {
         }
 
         if vendor == Vendor::NXP && part == ARMCore::CortexM33 {
-            /*
-             * Before we can talk to the TPIU on the LPC55, we need to make
-             * sure that it is clocked: TRACECLKSEL.SEL must be set to 0 to
-             * select the Trace Divided Clock, and TRACECLKDIV.HALT,
-             * TRACECLKDIV.REQFLAG and TRACECLKDIV.RESET must all be cleared.
-             * (We also must check that IOCON is clocked -- though we expect
-             * this to be true.)
-             */
+            //
+            // Before we can talk to the TPIU on the LPC55, we need to make
+            // sure that it is clocked: TRACECLKSEL.SEL must be set to 0 to
+            // select the Trace Divided Clock, and TRACECLKDIV.HALT,
+            // TRACECLKDIV.REQFLAG and TRACECLKDIV.RESET must all be cleared.
+            // (We also must check that IOCON is clocked -- though we expect
+            // this to be true.)
+            //
             let mut sel = LPC55_SYSCON_TRACECLKSEL::read(core)?;
             sel.set_sel(0);
             sel.write(core)?;

--- a/humility-arch-cortex/src/swo.rs
+++ b/humility-arch-cortex/src/swo.rs
@@ -9,16 +9,16 @@ use humility::core::Core;
 use num_traits::FromPrimitive;
 use num_traits::ToPrimitive;
 
-/*
- * SWO Current Output Divisor Register
- */
+//
+// SWO Current Output Divisor Register
+//
 register_offs!(SWO_CODR, 0x10,
     pub prescaler, set_prescaler: 15, 0;
 );
 
-/*
- * SWO Selected Pin Protocol Register
- */
+//
+// SWO Selected Pin Protocol Register
+//
 register_offs!(SWO_SPPR, 0xf0,
     pub pprot, set_pprot: 1, 0;
 );
@@ -42,9 +42,9 @@ impl From<SWOMode> for u32 {
     }
 }
 
-/*
- * SWO Formatter and Flush Status Register
- */
+//
+// SWO Formatter and Flush Status Register
+//
 register_offs!(SWO_FFSR, 0x300,
     pub formatter_nonstop, _: 3;
     pub tracectl_present, _: 2;
@@ -52,9 +52,9 @@ register_offs!(SWO_FFSR, 0x300,
     pub flush_in_progress, _: 0;
 );
 
-/*
- * SWO Lock Access Register
- */
+//
+// SWO Lock Access Register
+//
 register_offs!(SWO_LAR, 0xfb0,
     pub key, _: 1;
 );
@@ -64,9 +64,9 @@ impl SWO_LAR {
         core: &mut dyn humility::core::Core,
         base: u32,
     ) -> Result<()> {
-        /*
-         * To unlock, we write "CoreSight Access" in l33t
-         */
+        //
+        // To unlock, we write "CoreSight Access" in l33t
+        //
         let val: u32 = 0xc5ac_ce55;
         core.write_word_32(SWO_LAR::address(base), val)?;
         Ok(())

--- a/humility-arch-cortex/src/tpiu.rs
+++ b/humility-arch-cortex/src/tpiu.rs
@@ -16,9 +16,9 @@ register!(TPIU_SSPSR, 0xe004_0000,
     swidth, _: 31, 0;
 );
 
-/*
- * TPIU Asynchronous Clock Prescaler Register
- */
+//
+// TPIU Asynchronous Clock Prescaler Register
+//
 register!(TPIU_ACPR, 0xe004_0010,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -27,9 +27,9 @@ register!(TPIU_ACPR, 0xe004_0010,
     pub swoscaler, set_swoscaler: 15, 0;
 );
 
-/*
- * TPIU Selected Pin Protocol Register
- */
+//
+// TPIU Selected Pin Protocol Register
+//
 register!(TPIU_SPPR, 0xe004_00f0,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -56,9 +56,9 @@ impl TPIU_SPPR {
     }
 }
 
-/*
- * TPIU Supported Test Patterns/Modes Register
- */
+//
+// TPIU Supported Test Patterns/Modes Register
+//
 register!(TPIU_STMR, 0xe004_0200,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -72,9 +72,9 @@ register!(TPIU_STMR, 0xe004_0200,
     pub walking_1s_pattern, _: 0;
 );
 
-/*
- * TPIU Flush and Format Status Register
- */
+//
+// TPIU Flush and Format Status Register
+//
 register!(TPIU_FFSR, 0xe004_0300,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -85,9 +85,9 @@ register!(TPIU_FFSR, 0xe004_0300,
     pub flush_in_progress, _: 0;
 );
 
-/*
- * TPIU Flush and Format Control Register
- */
+//
+// TPIU Flush and Format Control Register
+//
 register!(TPIU_FFCR, 0xe004_0304,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -97,9 +97,9 @@ register!(TPIU_FFCR, 0xe004_0304,
     pub continuous_formatting, set_continuous_formatting: 1;
 );
 
-/*
- * TPIU Formatter Synchronization Counter Register
- */
+//
+// TPIU Formatter Synchronization Counter Register
+//
 register!(TPIU_FSCR, 0xe004_0308,
     #[derive(Copy, Clone)]
     #[allow(non_camel_case_types)]
@@ -151,10 +151,10 @@ const TPIU_ID_NULL: u8 = 0;
 fn tpiu_next_state(state: TPIUState, byte: u8, offset: usize) -> TPIUState {
     let sync = &TPIU_FRAME_SYNC;
 
-    /*
-     * Based on our current state and the byte, we're looking at, determine
-     * our next framing state.
-     */
+    //
+    // Based on our current state and the byte, we're looking at, determine
+    // our next framing state.
+    //
     let nstate = match state {
         TPIUState::SearchingSyncing(next) if byte != sync[next] => {
             TPIUState::Searching
@@ -219,12 +219,12 @@ fn tpiu_check_frame(
     valid: &[bool],
     intermixed: bool,
 ) -> bool {
-    /*
-     * To check a frame, we go through its half words, checking them for
-     * inconsistency.  The false positive rate will very much depend on how
-     * crowded the ID space is:  the sparser the valid space, the less likely
-     * we are to accept a frame that is in fact invalid.
-     */
+    //
+    // To check a frame, we go through its half words, checking them for
+    // inconsistency.  The false positive rate will very much depend on how
+    // crowded the ID space is:  the sparser the valid space, the less likely
+    // we are to accept a frame that is in fact invalid.
+    //
     let max = frame.len() / 2;
 
     for i in 0..max {
@@ -232,20 +232,20 @@ fn tpiu_check_frame(
         let half = TPIUFrameHalfWord::from((frame[base].0, frame[base + 1].0));
 
         if half.f_control() {
-            /*
-             * The NULL source identifier denotes data we need to explicitly
-             * chuck; check for it.
-             */
+            //
+            // The NULL source identifier denotes data we need to explicitly
+            // chuck; check for it.
+            //
             if half.data_or_id() == TPIU_ID_NULL as u16 {
                 continue;
             }
 
-            /*
-             * The two conditions under which we can reject a frame:  we
-             * either have an ID that isn't expected, or we are not expecting
-             * intermixed output and we have an ID on anything but the first
-             * half-word of the frame.
-             */
+            //
+            // The two conditions under which we can reject a frame:  we
+            // either have an ID that isn't expected, or we are not expecting
+            // intermixed output and we have an ID on anything but the first
+            // half-word of the frame.
+            //
             if !valid[half.data_or_id() as usize] || (i > 0 && !intermixed) {
                 return false;
             }
@@ -278,11 +278,11 @@ fn tpiu_process_frame(
         let last = i == max - 1;
 
         if half.f_control() {
-            /*
-             * If our bit is set, the sense of the auxiliary bit tells us
-             * if the ID takes effect with this halfword (bit is clear), or
-             * with the next (bit is set).
-             */
+            //
+            // If our bit is set, the sense of the auxiliary bit tells us
+            // if the ID takes effect with this halfword (bit is clear), or
+            // with the next (bit is set).
+            //
             let delay = auxbit != 0;
             let mut packet = TPIUPacket {
                 id: Some(half.data_or_id() as u8),
@@ -292,12 +292,12 @@ fn tpiu_process_frame(
             };
 
             if last {
-                /*
-                 * If this is the last half-word, the auxiliary bit "must be
-                 * ignored" (Sec. D4.2 in the ARM CoreSight Architecture
-                 * Specification), and applies to the subsequent record.  So
-                 * in this case, we just return the ID.
-                 */
+                //
+                // If this is the last half-word, the auxiliary bit "must be
+                // ignored" (Sec. D4.2 in the ARM CoreSight Architecture
+                // Specification), and applies to the subsequent record.  So
+                // in this case, we just return the ID.
+                //
                 return Ok(packet.id.unwrap());
             }
 
@@ -312,23 +312,23 @@ fn tpiu_process_frame(
                     packet.id = saved;
                 }
                 (true, None) => {
-                    /*
-                     * We have no old ID -- we are going to discard this
-                     * byte, but also warn about it.
-                     */
+                    //
+                    // We have no old ID -- we are going to discard this
+                    // byte, but also warn about it.
+                    //
                     warn!("orphaned byte at offset {}", packet.offset);
                 }
             }
 
             current = packet.id;
         } else {
-            /*
-             * If our bit is NOT set, the auxiliary bit is the actual bit
-             * of data.  If our current is not set, then we are still
-             * searching for a first frame; we don't have an ID
-             * to associate with it, so we need to chuck the
-             * data.
-             */
+            //
+            // If our bit is NOT set, the auxiliary bit is the actual bit
+            // of data.  If our current is not set, then we are still
+            // searching for a first frame; we don't have an ID
+            // to associate with it, so we need to chuck the
+            // data.
+            //
             let id = match current {
                 Some(id) => id,
                 None => {
@@ -357,10 +357,10 @@ fn tpiu_process_frame(
         }
     }
 
-    /*
-     * We shouldn't be able to get here:  the last half-word handling logic
-     * should assure that we return from within the loop.
-     */
+    //
+    // We shouldn't be able to get here:  the last half-word handling logic
+    // should assure that we return from within the loop.
+    //
     unreachable!();
 }
 
@@ -442,10 +442,10 @@ pub fn tpiu_ingest(
                 state = tpiu_next_state(state, datum, offs);
 
                 if state == TPIUState::Searching {
-                    /*
-                     * We just got kicked back into searching; we need to
-                     * replay this datum to see if it starts a frame.
-                     */
+                    //
+                    // We just got kicked back into searching; we need to
+                    // replay this datum to see if it starts a frame.
+                    //
                     replay.push((datum, time, offs));
                     continue;
                 }
@@ -477,10 +477,10 @@ pub fn tpiu_ingest(
                     continue;
                 }
 
-                /*
-                 * We have a complete frame.  We need to now check the entire
-                 * frame.
-                 */
+                //
+                // We have a complete frame.  We need to now check the entire
+                // frame.
+                //
                 if tpiu_check_frame(&frame, valid, true) {
                     humility::msg!(
                         "valid TPIU frame starting at offset {}",
@@ -493,9 +493,9 @@ pub fn tpiu_ingest(
                     continue;
                 }
 
-                /*
-                 * That wasn't a valid frame; we need to replay.
-                 */
+                //
+                // That wasn't a valid frame; we need to replay.
+                //
                 while ndx > 1 {
                     replay.push(frame[ndx - 1]);
                     ndx -= 1;
@@ -526,11 +526,11 @@ pub fn tpiu_ingest(
                     continue;
                 }
 
-                /*
-                 * We have a complete frame, but we more or less expect it to
-                 * be correct.  If this fails, we need to go back in time
-                 * and resume our search for a frame.
-                 */
+                //
+                // We have a complete frame, but we more or less expect it to
+                // be correct.  If this fails, we need to go back in time
+                // and resume our search for a frame.
+                //
                 if !tpiu_check_frame(&frame, valid, true) {
                     warn!(
                         "after {} frame{}, invalid frame at offset {}",

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -260,9 +260,9 @@ impl Dumper {
         let offs = (addr & (width - 1) as u32) as usize;
         addr -= offs as u32;
 
-        /*
-         * Print out header line, OpenBoot PROM style
-         */
+        //
+        // Print out header line, OpenBoot PROM style
+        //
         if self.header {
             print!("  {:width$}  ", "", width = indent + self.addrsize);
 
@@ -278,9 +278,9 @@ impl Dumper {
             indent = self.indent;
         }
 
-        /*
-         * Print our first line.
-         */
+        //
+        // Print our first line.
+        //
         let lim = std::cmp::min(width - offs, bytes.len());
         print(&bytes[0..lim], addr, offs, indent);
         indent = self.indent;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,24 +11,24 @@ use clap::Parser;
 mod cmd;
 
 fn main() {
-    /*
-     * This isn't hugely efficient, but we actually parse our arguments
-     * twice: the first is with our subcommands grafted into our
-     * arguments to get us a unified help and error message in the event
-     * of any parsing value or request for a help message; if that works,
-     * we parse our arguments again but relying on the
-     * external_subcommand to directive to allow our subcommand to do any
-     * parsing on its own.
-     */
+    //
+    // This isn't hugely efficient, but we actually parse our arguments
+    // twice: the first is with our subcommands grafted into our
+    // arguments to get us a unified help and error message in the event
+    // of any parsing value or request for a help message; if that works,
+    // we parse our arguments again but relying on the
+    // external_subcommand to directive to allow our subcommand to do any
+    // parsing on its own.
+    //
     let (commands, clap) = cmd::init(Args::into_app());
 
     let m = clap.get_matches();
     let _args = Args::from_arg_matches(&m);
 
-    /*
-     * If we're here, we know that our arguments pass muster from the
-     * Structopt/ Clap perspective.
-     */
+    //
+    // If we're here, we know that our arguments pass muster from the
+    // Structopt/ Clap perspective.
+    //
     let mut args = Args::parse();
 
     //


### PR DESCRIPTION
When work on Humility was first started, comments were -- for broadly
historical and cultural reasons -- C-style comments.  Like many a
tradition brought from the old world into the new, this practice began
to fade over time, and it came to be that all new comments were
C99-style comments (which is to say: the comment style predominant in
Rust).  While the new comments were conventional, the old comments
remained in the oldest parts of the code base, as if narrow alleys at
the heart of a medieval city.  This modernizes all comments to be
consistent, albeit retaining a slightly idiosyncratic style:  for
reasons of readability, we still prefer block comments to be offset by
(commented) blank lines.