### PR TITLE
Add support for idol Reply::Simple

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,18 +34,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "atomic-polyfill"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686d748538a32325b28d6411dd8a939e7ad5128e5d0023cc4fd3573db456042"
+checksum = "ee6adc1648f03fbc1bc1b5cf0f2fdfb5edbc96215b711edcfe6ce2641ef9b347"
 dependencies = [
  "critical-section",
  "riscv-target",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -240,9 +240,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cfg-if"
@@ -252,9 +252,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.12"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2afefa54b5c7dd40918dc1e09f213a171ab5937aadccab45e804780b238f9f43"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.12"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd2078197a22f338bd4fbf7d6387eb6f0d6a3c69e6cbc09f5c93e97321fd92a"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
 ]
@@ -435,9 +435,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36cfb62ff156596c892272f3015ef952fe1525e85261fa3a7f327bd6b384ab9"
+checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
 dependencies = [
  "nb 0.1.3",
  "void",
@@ -563,9 +563,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e476c64197665c3725621f0ac3f9e5209aa5e889e02a08b1daf5f16dc5fd952"
+checksum = "d076121838e03f862871315477528debffdb7462fb229216ecef91b1a3eb31eb"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c4cc7279df8353788ac551186920e44959d5948aec404be02b28544a598bce"
+checksum = "7fd21b5ac4a597bf657ed92a5b078f46a011837bda14afb7a07a5c1157c33ac2"
 dependencies = [
  "cc",
  "libc",
@@ -602,8 +602,8 @@ dependencies = [
 
 [[package]]
 name = "hif"
-version = "0.2.3"
-source = "git+https://github.com/oxidecomputer/hif#e512e4ce109eb697513cf59def667e2f0d6eae5c"
+version = "0.3.0"
+source = "git+https://github.com/oxidecomputer/hif#b5abd263f179695624b8b4ecf99256f8c9526bf1"
 dependencies = [
  "pkg-version",
  "postcard",
@@ -1154,8 +1154,8 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idol"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#1f782a488a896df2c8f0a7bbf705afa757f245ff"
+version = "0.2.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#478f0b66b9a39e33ca7a726f310cb41304faa5ea"
 dependencies = [
  "indexmap",
  "quote",
@@ -1262,9 +1262,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libflate"
@@ -1280,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "libftdi1-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f115599b5073d108edfcc32daa1a673193323fc10559c33bed6cc20f2f0bf4d"
+checksum = "3ff6928872c7d13bec3c8a60c4c92f41f6252f3369b7552a5b4f9c90c8ba2338"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libusb1-sys"
@@ -1318,9 +1318,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1398,9 +1398,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -1567,7 +1567,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/pmbus#134497275455b89b7684c7f5ffe91b1dca0668e4"
+source = "git+https://github.com/oxidecomputer/pmbus#de86eabcd272f0caf81c7b08d8613730008361c2"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "rle-decode-fast"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "ron"
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -1913,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -1935,9 +1935,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
+checksum = "ec1e6ec4d8950e5b1e894eac0d360742f3b1407a6078a604a731c4b3f49cefbc"
 dependencies = [
  "rustversion",
  "serde",
@@ -2000,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "spd"
@@ -2042,9 +2042,9 @@ checksum = "3bdb25a4593d6656239319426f4025f7a658157e25e89f0e0319d7516d46042d"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2168,9 +2168,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#91a306c5f79e983c11a19c0da5611fa34201bd50"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c48345f64739d01ecee4be1aeaf4227bf2464635"
 dependencies = [
  "lazy_static",
  "postcard",
@@ -2233,7 +2233,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#91a306c5f79e983c11a19c0da5611fa34201bd50"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#c48345f64739d01ecee4be1aeaf4227bf2464635"
 dependencies = [
  "serde",
 ]

--- a/cmd/apptable/src/lib.rs
+++ b/cmd/apptable/src/lib.rs
@@ -10,7 +10,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, AppSettings, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::hubris::{HubrisArchive, HubrisPrintFormat};
 use humility_cmd::{Archive, Args, Command};
 use std::convert::TryInto;
@@ -152,13 +153,13 @@ fn apptablecmd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "apptable",
             archive: Archive::Optional,
             run: apptablecmd,
         },
-        ApptableArgs::into_app().setting(AppSettings::Hidden),
+        ApptableArgs::command().hide(true),
     )
 }

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -13,7 +13,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
@@ -690,7 +691,7 @@ fn dashboard(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "dashboard",
@@ -699,7 +700,7 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: dashboard,
         },
-        DashboardArgs::into_app(),
+        DashboardArgs::command(),
     )
 }
 

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -15,7 +15,8 @@
 //! at the OS level, like faults.
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::doppel::{GenOrRestartCount, Task, TaskDesc, TaskState};
@@ -26,7 +27,7 @@ use std::num::NonZeroU32;
 use std::time::Duration;
 
 /// Command registration.
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "diagnose",
@@ -35,7 +36,7 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: diagnose,
         },
-        DiagnoseArgs::into_app(),
+        DiagnoseArgs::command(),
     )
 }
 

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -49,7 +49,8 @@
 //!
 
 use anyhow::Result;
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -79,7 +80,7 @@ fn dumpcmd(
     rval
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "dump",
@@ -88,6 +89,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: dumpcmd,
         },
-        DumpArgs::into_app(),
+        DumpArgs::command(),
     )
 }

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -3,9 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{bail, Result};
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::attach_live;
@@ -623,13 +622,13 @@ fn etmcmd(
     rval
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "etm",
             archive: Archive::Required,
             run: etmcmd,
         },
-        EtmArgs::into_app(),
+        EtmArgs::command(),
     )
 }

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -17,9 +17,8 @@
 //!
 
 use anyhow::{bail, Context, Result};
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Command};
 use path_slash::PathExt;
@@ -274,13 +273,13 @@ fn flashcmd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "flash",
             archive: Archive::Required,
             run: flashcmd,
         },
-        FlashArgs::into_app(),
+        FlashArgs::command(),
     )
 }

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -9,7 +9,8 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 
 use std::convert::TryInto;
@@ -244,7 +245,7 @@ fn gpio(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "gpio",
@@ -253,6 +254,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: gpio,
         },
-        GpioArgs::into_app(),
+        GpioArgs::command(),
     )
 }

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -43,9 +43,8 @@
 
 use ::idol::syntax::{Operation, Reply};
 use anyhow::{anyhow, bail, Result};
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
@@ -84,7 +83,7 @@ struct HiffyArgs {
     task: Option<String>,
 
     /// arguments
-    #[clap(long, short, requires = "call", use_delimiter = true)]
+    #[clap(long, short, requires = "call", use_value_delimiter = true)]
     arguments: Vec<String>,
 }
 
@@ -292,7 +291,7 @@ fn hiffy(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "hiffy",
@@ -301,6 +300,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: hiffy,
         },
-        HiffyArgs::into_app(),
+        HiffyArgs::command(),
     )
 }

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -116,10 +116,21 @@ fn hiffy_list(hubris: &HubrisArchive, subargs: &HiffyArgs) -> Result<()> {
         }
 
         match idol::lookup_reply(hubris, module, op.0) {
-            Ok((_, e)) => match &op.1.reply {
+            Ok((_, Some(e))) => match &op.1.reply {
                 Reply::Result { ok, .. } => {
                     println!("{:m$}{:<15} {}", "", "<ok>", ok.ty.0, m = m);
                     println!("{:m$}{:<15} {}", "", "<error>", e.name, m = m);
+                }
+                _ => {
+                    log::warn!("Mismatch between expected reply and operation");
+                }
+            },
+            Ok((_, None)) => match &op.1.reply {
+                Reply::Simple(ok) => {
+                    println!("{:m$}{:<15} {}", "", "<ok>", ok.ty.0, m = m);
+                }
+                _ => {
+                    log::warn!("Mismatch between expected reply and operation");
                 }
             },
             Err(e) => {

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -92,7 +92,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
@@ -711,7 +712,7 @@ fn i2c(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "i2c",
@@ -720,6 +721,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: i2c,
         },
-        I2cArgs::into_app(),
+        I2cArgs::command(),
     )
 }

--- a/cmd/itm/src/lib.rs
+++ b/cmd/itm/src/lib.rs
@@ -33,7 +33,8 @@
 //!
 
 use anyhow::{bail, Context, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::attach_live;
@@ -333,13 +334,13 @@ fn itmcmd(
     rval
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "itm",
             archive: Archive::Optional,
             run: itmcmd,
         },
-        ItmArgs::into_app(),
+        ItmArgs::command(),
     )
 }

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -82,7 +82,8 @@
 //!
 
 use anyhow::{anyhow, bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::jefe::{send_request, JefeRequest};
@@ -162,7 +163,7 @@ fn jefe(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "jefe",
@@ -171,6 +172,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: jefe,
         },
-        JefeArgs::into_app(),
+        JefeArgs::command(),
     )
 }

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -9,7 +9,8 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 
 use std::convert::TryInto;
@@ -215,7 +216,7 @@ fn gpio(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "lpc55gpio",
@@ -224,6 +225,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: gpio,
         },
-        GpioArgs::into_app(),
+        GpioArgs::command(),
     )
 }

--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -41,7 +41,8 @@
 //! `humility manifest` can operate on either an archive or on a dump.
 
 use anyhow::Result;
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::hubris::HubrisArchive;
 use humility_cmd::{Archive, Args, Command};
 
@@ -58,13 +59,13 @@ fn manifestcmd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "manifest",
             archive: Archive::Required,
             run: manifestcmd,
         },
-        ManifestArgs::into_app(),
+        ManifestArgs::command(),
     )
 }

--- a/cmd/map/src/lib.rs
+++ b/cmd/map/src/lib.rs
@@ -62,7 +62,8 @@
 //! we can see from the `map` output has been sized to only 256 bytes.)
 
 use anyhow::Result;
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -112,7 +113,7 @@ fn mapcmd(
 }
 
 /// This is some init right here
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "map",
@@ -121,6 +122,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: mapcmd,
         },
-        MapArgs::into_app(),
+        MapArgs::command(),
     )
 }

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -10,8 +10,8 @@ use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 
 use anyhow::{bail, Result};
-use clap::IntoApp;
-use clap::{App, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use indexmap::IndexMap;
 use pmbus::commands::*;
@@ -77,7 +77,7 @@ struct PmbusArgs {
     commands: Option<Vec<String>>,
 
     /// specifies writes to perform
-    #[clap(long, short = 'w', use_delimiter = false)]
+    #[clap(long, short = 'w', use_value_delimiter = false)]
     writes: Option<Vec<String>>,
 
     /// specifies an I2C controller
@@ -105,7 +105,7 @@ struct PmbusArgs {
     device: Option<String>,
 
     /// specifies a rail within the specified device
-    #[clap(long, short = 'r', value_name = "rail", use_delimiter = true)]
+    #[clap(long, short = 'r', value_name = "rail", use_value_delimiter = true)]
     rail: Option<Vec<String>>,
 }
 
@@ -1613,7 +1613,7 @@ fn pmbus(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "pmbus",
@@ -1622,6 +1622,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: pmbus,
         },
-        PmbusArgs::into_app(),
+        PmbusArgs::command(),
     )
 }

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -87,9 +87,8 @@
 //! ```
 
 use anyhow::Result;
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::arch::ARMRegister;
 use humility::core::Core;
 use humility::hubris::*;
@@ -370,7 +369,7 @@ fn probecmd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "probe",
@@ -379,6 +378,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Match,
             run: probecmd,
         },
-        ProbeArgs::into_app(),
+        ProbeArgs::command(),
     )
 }

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -12,7 +12,8 @@ use std::io::Read;
 use std::time::Instant;
 
 use anyhow::{bail, Result};
-use clap::{App, ArgGroup, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{ArgGroup, CommandFactory, Parser};
 use hif::*;
 
 use indicatif::{HumanBytes, HumanDuration};
@@ -327,7 +328,7 @@ fn qspi(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "qspi",
@@ -336,6 +337,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: qspi,
         },
-        QspiArgs::into_app(),
+        QspiArgs::command(),
     )
 }

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -112,7 +112,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Dumper, Validate};
@@ -228,7 +229,7 @@ fn readmem(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "readmem",
@@ -237,6 +238,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::None,
             run: readmem,
         },
-        ReadmemArgs::into_app(),
+        ReadmemArgs::command(),
     )
 }

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -37,7 +37,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -107,7 +108,7 @@ fn readvar(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "readvar",
@@ -116,6 +117,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Match,
             run: readvar,
         },
-        ReadvarArgs::into_app(),
+        ReadvarArgs::command(),
     )
 }

--- a/cmd/renbb/src/lib.rs
+++ b/cmd/renbb/src/lib.rs
@@ -9,7 +9,8 @@ use humility_cmd::i2c::I2cArgs;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::collections::HashMap;
@@ -278,7 +279,7 @@ fn renbb(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "renbb",
@@ -287,6 +288,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: renbb,
         },
-        RenbbArgs::into_app(),
+        RenbbArgs::command(),
     )
 }

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -17,7 +17,8 @@ use humility_cmd::{attach, Archive, Args, Attach, Command, Dumper, Validate};
 use itertools::Itertools;
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use idt8a3xxxx::*;
 use std::collections::BTreeMap;
@@ -802,13 +803,13 @@ fn rencm(
     })
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Unattached {
             name: "rencm",
             archive: Archive::Optional,
             run: rencm,
         },
-        RencmArgs::into_app(),
+        RencmArgs::command(),
     )
 }

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -33,7 +33,8 @@
 //! documentation](https://github.com/oxidecomputer/hubris/blob/master/lib/ringbuf/src/lib.rs) for more details.
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::doppel::{Ringbuf, StaticCell};
@@ -181,7 +182,7 @@ fn ringbuf(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "ringbuf",
@@ -190,6 +191,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Match,
             run: ringbuf,
         },
-        RingbufArgs::into_app(),
+        RingbufArgs::command(),
     )
 }

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -19,9 +19,8 @@
 //! all thermal sensors from either device).
 
 use anyhow::{bail, Context, Result};
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
@@ -51,15 +50,25 @@ struct SensorsArgs {
     sleep: bool,
 
     /// restrict sensors by type of sensor
-    #[clap(long, short, value_name = "sensor type", use_delimiter = true)]
+    #[clap(
+        long,
+        short,
+        value_name = "sensor type",
+        use_value_delimiter = true
+    )]
     types: Option<Vec<String>>,
 
     /// restrict sensors by device
-    #[clap(long, short, value_name = "device", use_delimiter = true)]
+    #[clap(long, short, value_name = "device", use_value_delimiter = true)]
     devices: Option<Vec<String>>,
 
     /// restrict sensors by name
-    #[clap(long, short, value_name = "sensor name", use_delimiter = true)]
+    #[clap(
+        long,
+        short,
+        value_name = "sensor name",
+        use_value_delimiter = true
+    )]
     named: Option<Vec<String>>,
 }
 
@@ -309,7 +318,7 @@ fn sensors(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "sensors",
@@ -318,6 +327,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: sensors,
         },
-        SensorsArgs::into_app(),
+        SensorsArgs::command(),
     )
 }

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -10,7 +10,8 @@ use humility_cmd::{Archive, Args, Attach, Command, Validate};
 use std::str;
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 
 #[derive(Parser, Debug)]
@@ -350,7 +351,7 @@ fn spd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "spd",
@@ -359,6 +360,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: spd,
         },
-        SpdArgs::into_app(),
+        SpdArgs::command(),
     )
 }

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -11,7 +11,8 @@ use std::convert::TryInto;
 use std::str;
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 
 #[derive(Parser, Debug)]
@@ -258,7 +259,7 @@ fn spi(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "spi",
@@ -267,6 +268,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: spi,
         },
-        SpiArgs::into_app(),
+        SpiArgs::command(),
     )
 }

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -28,7 +28,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -116,7 +117,7 @@ fn stackmargin(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "stackmargin",
@@ -125,6 +126,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: stackmargin,
         },
-        StackmarginArgs::into_app(),
+        StackmarginArgs::command(),
     )
 }

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -28,7 +28,8 @@
 //! ```
 
 use anyhow::{anyhow, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::arch::ARMRegister;
 use humility::core::Core;
 use humility::hubris::*;
@@ -316,7 +317,7 @@ fn stmsecure(
     }
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "stmsecure",
@@ -325,6 +326,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::None,
             run: stmsecure,
         },
-        StmSecureArgs::into_app(),
+        StmSecureArgs::command(),
     )
 }

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -112,7 +112,8 @@
 //!
 
 use anyhow::{bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::arch::ARMRegister;
 use humility::core::Core;
 use humility::hubris::*;
@@ -640,7 +641,7 @@ fn explain_recv(
     }
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "tasks",
@@ -649,6 +650,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: tasks,
         },
-        TasksArgs::into_app(),
+        TasksArgs::command(),
     )
 }

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -108,7 +108,8 @@
 //!
 
 use anyhow::{bail, Context, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::test::*;
@@ -298,7 +299,7 @@ fn test(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "test",
@@ -307,6 +308,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Booted,
             run: test,
         },
-        TestArgs::into_app(),
+        TestArgs::command(),
     )
 }

--- a/cmd/trace/src/lib.rs
+++ b/cmd/trace/src/lib.rs
@@ -3,9 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{anyhow, Result};
-use clap::App;
-use clap::IntoApp;
-use clap::Parser;
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command, Validate};
@@ -247,7 +246,7 @@ fn tracecmd(
     Ok(())
 }
 
-pub fn init() -> (Command, App<'static>) {
+pub fn init() -> (Command, ClapCommand<'static>) {
     (
         Command::Attached {
             name: "trace",
@@ -256,6 +255,6 @@ pub fn init() -> (Command, App<'static>) {
             validate: Validate::Match,
             run: tracecmd,
         },
-        TraceArgs::into_app(),
+        TraceArgs::command(),
     )
 }

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -11,7 +11,8 @@ use humility_cmd::{Archive, Args, Attach, Validate};
 use humility_cmd_spi::spi_task;
 
 use anyhow::{anyhow, bail, Result};
-use clap::{App, IntoApp, Parser};
+use clap::Command as ClapCommand;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use vsc7448_info::parse::{PhyRegister, TargetRegister};
 use vsc7448_types::Field;
@@ -471,7 +472,7 @@ fn vsc7448_get_info(
     Ok(())
 }
 
-pub fn init() -> (humility_cmd::Command, App<'static>) {
+pub fn init() -> (humility_cmd::Command, ClapCommand<'static>) {
     // We do a bonus parse of the command-line arguments here to see if we're
     // doing a `vsc7448 info` subcommand, which doesn't require a Hubris image
     // or attached device; skipping those steps improves runtime (especially
@@ -484,7 +485,7 @@ pub fn init() -> (humility_cmd::Command, App<'static>) {
             validate: Validate::Booted,
             run: vsc7448,
         },
-        Vsc7448Args::into_app(),
+        Vsc7448Args::command(),
     );
     let subcmd_unattached = (
         humility_cmd::Command::Unattached {
@@ -492,7 +493,7 @@ pub fn init() -> (humility_cmd::Command, App<'static>) {
             archive: Archive::Ignored,
             run: vsc7448_get_info,
         },
-        Vsc7448Args::into_app(),
+        Vsc7448Args::command(),
     );
 
     // If there's a `vsc7448` subcommand, then attempt to parse the subcmd

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -3,15 +3,15 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::{bail, Context, Result};
-use clap::App;
+use clap::Command as ClapCommand;
 use humility::hubris::*;
 use humility_cmd::Args;
 use humility_cmd::{Archive, Command};
 use std::collections::HashMap;
 
 pub fn init(
-    app: App<'static>,
-) -> (HashMap<&'static str, Command>, App<'static>) {
+    app: ClapCommand<'static>,
+) -> (HashMap<&'static str, Command>, ClapCommand<'static>) {
     let mut cmds = HashMap::new();
     let mut rval = app;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@
 
 use humility_cmd::{Args, Subcommand};
 
+use clap::CommandFactory;
 use clap::FromArgMatches;
-use clap::IntoApp;
 use clap::Parser;
 
 mod cmd;
@@ -20,7 +20,7 @@ fn main() {
     // external_subcommand to directive to allow our subcommand to do any
     // parsing on its own.
     //
-    let (commands, clap) = cmd::init(Args::into_app());
+    let (commands, clap) = cmd::init(Args::command());
 
     let m = clap.get_matches();
     let _args = Args::from_arg_matches(&m);


### PR DESCRIPTION
Commit 7818dbdc73f6e52d2d29297113bb8d29d23479e9 in idolitry added
Reply::Simple to indicate functions that do not return error codes.
Add support into humility for this.

This also includes clippy deprecation warnings because apparently this triggered a version bump(????)