### PR TITLE
Stop relying on ihex/srec files in build archives.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,14 +977,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "goblin",
  "humility-cmd",
  "humility-core",
  "humility-cortex",
+ "ihex",
  "log",
  "num-traits",
  "path-slash",
  "ron 0.7.0",
  "serde",
+ "srec",
  "tempfile",
 ]
 
@@ -2388,6 +2391,12 @@ checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "srec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c3a0538ec242e3cd333cdcdc8b720faa2fa0a9d7f444cf1ff63e7d3303adfb"
 
 [[package]]
 name = "stable_deref_trait"

--- a/cmd/flash/Cargo.toml
+++ b/cmd/flash/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1.0.126", features = ["derive"] }
 tempfile = "3.3"
 ron = "0.7"
 path-slash = "0.1.4"
+srec = "0.2"
+ihex = "3.0"
+goblin = "0.2"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -228,8 +228,7 @@ impl HubrisSensorKind {
 //
 pub struct HubrisFlashConfig {
     pub metadata: String,
-    pub srec: Vec<u8>,
-    pub ihex: Vec<u8>,
+    pub elf: Vec<u8>,
 }
 
 #[derive(Debug)]
@@ -2351,11 +2350,7 @@ impl HubrisArchive {
             })?
             .read_to_string(&mut flash)?;
 
-        Ok(HubrisFlashConfig {
-            metadata: flash,
-            srec: slurp!("img/final.srec"),
-            ihex: slurp!("img/final.ihex"),
-        })
+        Ok(HubrisFlashConfig { metadata: flash, elf: slurp!("img/final.elf") })
     }
 
     fn load_registers(&mut self, r: &[u8]) -> Result<()> {


### PR DESCRIPTION
Previously we would use three different representations of the program
in a build archive:

- ELF for most things.
- SREC only for OpenOCD
- IHEX only for PyOCD

The build archive stored all three, adding a _lot_ of size to every
build archive. This commit continues using SREC and IHEX but generates
them on the fly from the ELF file in the archive, so that we can later
land a corresponding Hubris change to stop including SREC/IHEX in every
archive.