### PR TITLE
Accept `chip.toml` as peripherals filename

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2231,7 +2231,13 @@ impl HubrisArchive {
             // as a separator.
             //
             let path = match chip.rsplit('/').next() {
-                Some(p) => p,
+                // Newer archive files may include the chip peripherals with
+                // the generic name "chip.toml" instead of something like
+                // "stm32h7.toml".  This is the case when the `chip` parameter
+                // in the app config is a path rather than a filename ending
+                // in ".toml"
+                Some(p) if p.ends_with(".toml") => p,
+                Some(_) => "chip.toml",
                 None => chip,
             };
 


### PR DESCRIPTION
This is Step 0 in my grand plan to move the `gdb` subcommand from Hubris to Humility, so you can easily run GDB against an archive.

As part of this work, I'm reorganizing more files in Hubris to be in per-chip folders; this means the peripherals file is now named `chip.toml` instead of a chip-specific name.  This work is staged in [this PR](https://github.com/oxidecomputer/hubris/pull/539).

This PR loads either the old peripherals file or the new file, so it should be backwards-compatible.