### PR TITLE
Add gdb and openocd subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "darling"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +843,7 @@ dependencies = [
  "humility-cmd-dump",
  "humility-cmd-etm",
  "humility-cmd-flash",
+ "humility-cmd-gdb",
  "humility-cmd-gpio",
  "humility-cmd-hash",
  "humility-cmd-hiffy",
@@ -990,6 +1001,19 @@ dependencies = [
  "serde",
  "srec",
  "tempfile",
+]
+
+[[package]]
+name = "humility-cmd-gdb"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "humility-cmd",
+ "humility-core",
+ "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -1534,9 +1558,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libflate"
@@ -1684,6 +1708,17 @@ name = "nb"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+
+[[package]]
+name = "nix"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "normalize-line-endings"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "humility-cmd-lpc55gpio",
  "humility-cmd-manifest",
  "humility-cmd-map",
+ "humility-cmd-openocd",
  "humility-cmd-pmbus",
  "humility-cmd-probe",
  "humility-cmd-qspi",
@@ -1013,7 +1014,6 @@ dependencies = [
  "humility-cmd",
  "humility-core",
  "tempfile",
- "zip",
 ]
 
 [[package]]
@@ -1128,6 +1128,18 @@ dependencies = [
  "clap",
  "humility-cmd",
  "humility-core",
+]
+
+[[package]]
+name = "humility-cmd-openocd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "humility-cmd",
+ "humility-core",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "cmd/lpc55gpio",
     "cmd/manifest",
     "cmd/map",
+    "cmd/openocd",
     "cmd/pmbus",
     "cmd/probe",
     "cmd/qspi",
@@ -84,6 +85,7 @@ cmd-jefe = { path = "./cmd/jefe", package = "humility-cmd-jefe" }
 cmd-lpc55gpio = { path = "./cmd/lpc55gpio", package = "humility-cmd-lpc55gpio" }
 cmd-manifest = { path = "./cmd/manifest", package = "humility-cmd-manifest" }
 cmd-map = { path = "./cmd/map", package = "humility-cmd-map" }
+cmd-openocd = { path = "./cmd/openocd", package = "humility-cmd-openocd" }
 cmd-pmbus = { path = "./cmd/pmbus", package = "humility-cmd-pmbus" }
 cmd-probe = { path = "./cmd/probe", package = "humility-cmd-probe" }
 cmd-qspi = { path = "./cmd/qspi", package = "humility-cmd-qspi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "cmd/doc",
     "cmd/dump",
     "cmd/etm",
+    "cmd/gdb",
     "cmd/gpio",
     "cmd/flash",
     "cmd/hash",
@@ -73,6 +74,7 @@ cmd-doc = { path = "./cmd/doc", package = "humility-cmd-doc" }
 cmd-dump = { path = "./cmd/dump", package = "humility-cmd-dump" }
 cmd-etm = { path = "./cmd/etm", package = "humility-cmd-etm" }
 cmd-flash = { path = "./cmd/flash", package = "humility-cmd-flash" }
+cmd-gdb = { path = "./cmd/gdb", package = "humility-cmd-gdb" }
 cmd-gpio = { path = "./cmd/gpio", package = "humility-cmd-gpio" }
 cmd-hash = { path = "./cmd/hash", package = "humility-cmd-hash" }
 cmd-hiffy = { path = "./cmd/hiffy", package = "humility-cmd-hiffy" }

--- a/README.md
+++ b/README.md
@@ -300,6 +300,16 @@ flash` will fail unless the `-F` (`--force`) flag is set.
 
 This command launches GDB and attaches to a running device.
 
+By default, the user must be running `openocd` or `pyocd` in a separate
+terminal.
+
+The `--run-openocd` option automatically launches `openocd` based on the
+`openocd.cfg` file included in the build archive.
+
+When using `pyocd`, it must be launched with the `--persist` option,
+because `humility gdb` connects to it multiple times (once to check the
+app id, then again to run the console).
+
 
 
 ### `humility gpio`

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ environment variable.
 - [humility dump](#humility-dump): generate Hubris dump
 - [humility etm](#humility-etm): commands for ARM's Embedded Trace Macrocell (ETM)
 - [humility flash](#humility-flash): flash archive onto attached device
+- [humility gdb](#humility-gdb): Attach to a running system using GDB
 - [humility gpio](#humility-gpio): GPIO pin manipulation
 - [humility hash](#humility-hash): Access to the HASH block
 - [humility hiffy](#humility-hiffy): manipulate HIF execution
@@ -168,6 +169,7 @@ environment variable.
 - [humility lpc55gpio](#humility-lpc55gpio): LPC55 GPIO pin manipulation
 - [humility manifest](#humility-manifest): print archive manifest
 - [humility map](#humility-map): print memory map, with association of regions to tasks
+- [humility openocd](#humility-openocd): Run OpenOCD for the given archive
 - [humility pmbus](#humility-pmbus): scan for and read PMBus devices
 - [humility probe](#humility-probe): probe for any attached devices
 - [humility qspi](#humility-qspi): QSPI status, reading and writing
@@ -190,7 +192,7 @@ environment variable.
 ### `humility apptable`
 
 This is a deprecated command that allows for the display of the app table
-found in old Hubris arhives; see `humility manifest` to understand
+found in old Hubris archives; see `humility manifest` to understand
 the contents of an archive.
 
 
@@ -291,6 +293,12 @@ To see what would be executed without actually executing any commands,
 use the `-n` (`--dry-run`) flag.  As a precautionary measure, if
 the specified archive already appears to be on the target, `humility
 flash` will fail unless the `-F` (`--force`) flag is set.
+
+
+
+### `humility gdb`
+
+This command launches GDB and attaches to a running device.
 
 
 
@@ -731,6 +739,12 @@ DESC       LOW          HIGH          SIZE ATTR  ID TASK
 
 (In this case, task 7, `oh_no`, has overflowed its stack -- which
 we can see from the `map` output has been sized to only 256 bytes.)
+
+
+### `humility openocd`
+
+This command launches OpenOCD based on the config file in a build archive
+
 
 
 ### `humility pmbus`
@@ -1403,7 +1417,42 @@ No documentation yet for `humility trace`; pull requests welcome!
 
 ### `humility validate`
 
-Validates your parking.
+`humility validate` uses the Hubris `validate` task to validate the
+correct presence of devices as described by the application TOML.  To
+view all devices, use the `--list` option; to validate them, run
+without any additional arguments:
+
+```console
+% humility validate
+humility: attached via ST-Link V3
+ID VALIDATION   C P  MUX ADDR DEVICE        DESCRIPTION
+ 0 removed      2 F  -   0x48 tmp117        Southwest temperature sensor
+ 1 removed      2 F  -   0x49 tmp117        South temperature sensor
+ 2 removed      2 F  -   0x4a tmp117        Southeast temperature sensor
+ 3 present      2 F  -   0x70 pca9545       U.2 ABCD mux
+ 4 present      2 F  -   0x71 pca9545       U.2 EFGH mux
+ 5 present      2 F  -   0x72 pca9545       U.2 IJ/FRUID mux
+ 6 timeout      2 B  -   0x73 pca9545       M.2 mux
+ 7 timeout      2 B  1:4 0x4c tmp451        T6 temperature sensor
+ 8 validated    3 H  -   0x24 tps546b24a    A2 3.3V rail
+ 9 validated    3 H  -   0x26 tps546b24a    A0 3.3V rail
+10 validated    3 H  -   0x27 tps546b24a    A2 5V rail
+11 validated    3 H  -   0x29 tps546b24a    A2 1.8V rail
+12 present      3 H  -   0x3a max5970       M.2 hot plug controller
+13 absent       3 H  -   0x4c sbtsi         CPU temperature sensor
+14 present      3 H  -   0x58 idt8a34003    Clock generator
+15 validated    3 H  -   0x5a raa229618     CPU power controller
+16 validated    3 H  -   0x5b raa229618     SoC power controller
+17 validated    3 H  -   0x5c isl68224      DIMM/SP3 1.8V A0 power controller
+18 validated    4 F  -   0x10 adm1272       Fan hot swap controller
+19 validated    4 F  -   0x14 adm1272       Sled hot swap controller
+20 validated    4 F  -   0x20 max31790      Fan controller
+21 validated    4 F  -   0x25 tps546b24a    T6 power controller
+22 removed      4 F  -   0x48 tmp117        Northeast temperature sensor
+23 removed      4 F  -   0x49 tmp117        North temperature sensor
+24 validated    4 F  -   0x4a tmp117        Northwest temperature sensor
+25 validated    4 F  -   0x67 bmr491        Intermediate bus converter
+```
 
 
 

--- a/cmd/apptable/src/lib.rs
+++ b/cmd/apptable/src/lib.rs
@@ -5,7 +5,7 @@
 //! ## `humility apptable`
 //!
 //! This is a deprecated command that allows for the display of the app table
-//! found in old Hubris arhives; see `humility manifest` to understand
+//! found in old Hubris archives; see `humility manifest` to understand
 //! the contents of an archive.
 //!
 

--- a/cmd/gdb/Cargo.toml
+++ b/cmd/gdb/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "humility-cmd-gdb"
+version = "0.1.0"
+edition = "2021"
+description = "Attach to a running system using GDB"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+humility = { path = "../../humility-core", package = "humility-core" }
+humility-cmd = { path = "../../humility-cmd" }
+anyhow = { version = "1.0.44", features = ["backtrace"] }
+clap = { version = "3.0.12", features = ["derive", "env"] }
+ctrlc = "3.1.5"
+tempfile = "3.3"
+zip = "0.5"

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -58,14 +58,18 @@ fn gdb(
     std::fs::create_dir_all(&elf_dir)?;
     hubris.extract_elfs_to(&elf_dir)?;
 
-    hubris.extract_file_to(
-        "debug/openocd.gdb",
-        &work_dir.path().join("openocd.gdb"),
-    )?;
-    hubris.extract_file_to(
-        "debug/script.gdb",
-        &work_dir.path().join("script.gdb"),
-    )?;
+    hubris
+        .extract_file_to(
+            "debug/openocd.gdb",
+            &work_dir.path().join("openocd.gdb"),
+        )
+        .context("GDB config missing. Is your Hubris build too old?")?;
+    hubris
+        .extract_file_to(
+            "debug/script.gdb",
+            &work_dir.path().join("script.gdb"),
+        )
+        .context("GDB script missing. Is your Hubris build too old?")?;
     hubris
         .extract_file_to("img/final.elf", &work_dir.path().join("final.elf"))?;
 
@@ -98,10 +102,12 @@ fn gdb(
 
     // If OpenOCD is requested, then run it in a subprocess here
     let openocd = if subargs.run_openocd {
-        hubris.extract_file_to(
-            "debug/openocd.cfg",
-            &work_dir.path().join("openocd.cfg"),
-        )?;
+        hubris
+            .extract_file_to(
+                "debug/openocd.cfg",
+                &work_dir.path().join("openocd.cfg"),
+            )
+            .context("openocd config missing. Is your Hubris build too old?")?;
         let mut cmd = Command::new(
             subargs.openocd.unwrap_or_else(|| "openocd".to_string()),
         );

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -1,0 +1,105 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility gdb`
+//!
+//! This command launches GDB and attaches to a running device.
+//!
+
+use std::process::Command;
+
+use humility::hubris::*;
+use humility_cmd::{Archive, Args, Attach, Command as HumilityCmd, Validate};
+
+use anyhow::{bail, Result};
+use clap::{Command as ClapCommand, CommandFactory, Parser};
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "gdb", about = env!("CARGO_PKG_DESCRIPTION"),
+)]
+struct GdbArgs {
+    /// when set, calls `load` and `stepi` upon attaching
+    #[clap(long, short)]
+    load: bool,
+}
+
+fn gdb(
+    hubris: &mut HubrisArchive,
+    args: &Args,
+    subargs: &[String],
+) -> Result<()> {
+    let subargs = GdbArgs::try_parse_from(subargs)?;
+
+    // Do a dummy attach to confirm that the image matches
+    humility_cmd::attach(
+        hubris,
+        args,
+        Attach::LiveOnly,
+        Validate::Match,
+        |_, _| Ok(()),
+    )?;
+
+    let work_dir = tempfile::tempdir()?;
+    let name = match &hubris.manifest.name {
+        Some(name) => name,
+        None => bail!("Could not get app name from manifest"),
+    };
+    let elf_dir = work_dir.path().join("target").join(name).join("dist");
+    std::fs::create_dir_all(&elf_dir)?;
+    hubris.extract_elfs_to(&elf_dir)?;
+
+    hubris.extract_file_to(
+        "debug/openocd.gdb",
+        &work_dir.path().join("openocd.gdb"),
+    )?;
+    hubris.extract_file_to(
+        "debug/script.gdb",
+        &work_dir.path().join("script.gdb"),
+    )?;
+    hubris
+        .extract_file_to("img/final.elf", &work_dir.path().join("final.elf"))?;
+
+    let mut cmd = None;
+
+    const GDB_NAMES: [&str; 2] = ["arm-none-eabi-gdb", "gdb-multiarch"];
+    for candidate in &GDB_NAMES {
+        if Command::new(candidate).arg("--version").status().is_ok() {
+            cmd = Some(Command::new(candidate));
+            break;
+        }
+    }
+
+    let mut cmd = cmd.ok_or_else(|| {
+        anyhow::anyhow!("GDB not found.  Tried: {:?}", GDB_NAMES)
+    })?;
+
+    cmd.arg("-q").arg("-x").arg("script.gdb").arg("-x").arg("openocd.gdb");
+
+    if subargs.load {
+        // start the process but immediately halt the processor
+        cmd.arg("-ex").arg("load").arg("-ex").arg("stepi");
+    }
+    cmd.arg("final.elf");
+    cmd.current_dir(work_dir.path());
+    println!("{:?}", cmd);
+
+    ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("command failed, see output for details");
+    }
+    Ok(())
+}
+
+pub fn init() -> (HumilityCmd, ClapCommand<'static>) {
+    (
+        HumilityCmd::Unattached {
+            name: "gdb",
+            archive: Archive::Required,
+            run: gdb,
+        },
+        GdbArgs::command(),
+    )
+}

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -6,6 +6,16 @@
 //!
 //! This command launches GDB and attaches to a running device.
 //!
+//! By default, the user must be running `openocd` or `pyocd` in a separate
+//! terminal.
+//!
+//! The `--run-openocd` option automatically launches `openocd` based on the
+//! `openocd.cfg` file included in the build archive.
+//!
+//! When using `pyocd`, it must be launched with the `--persist` option,
+//! because `humility gdb` connects to it multiple times (once to check the
+//! app id, then again to run the console).
+//!
 
 use std::process::{Command, Stdio};
 

--- a/cmd/openocd/Cargo.toml
+++ b/cmd/openocd/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
-name = "humility-cmd-gdb"
+name = "humility-cmd-openocd"
 version = "0.1.0"
 edition = "2021"
-description = "Attach to a running system using GDB"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+description = "Run OpenOCD for the given archive"
 
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -24,6 +24,10 @@ struct OcdArgs {
     #[clap(short, long)]
     exec: Option<String>,
 
+    /// specifies the probe serial name to use with OpenOCD
+    #[clap(long)]
+    probe: Option<String>,
+
     /// Extra options to pass to `openocd`
     #[clap(last = true)]
     extra_options: Vec<String>,
@@ -46,6 +50,12 @@ fn openocd(
     let mut cmd =
         Command::new(subargs.exec.unwrap_or_else(|| "openocd".to_string()));
     cmd.arg("-f").arg("openocd.cfg");
+    if let Some(probe) = subargs.probe {
+        cmd.arg("-c")
+            .arg("interface hla")
+            .arg("-c")
+            .arg(format!("hla_serial {}", probe));
+    }
     cmd.current_dir(work_dir.path());
 
     for opt in subargs.extra_options {

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -10,7 +10,7 @@
 use std::process::Command;
 
 use humility::hubris::*;
-use humility_cmd::{Archive, Args, Attach, Command as HumilityCmd, Validate};
+use humility_cmd::{Archive, Args, Command as HumilityCmd};
 
 use anyhow::{Context, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};
@@ -31,19 +31,10 @@ struct OcdArgs {
 
 fn openocd(
     hubris: &mut HubrisArchive,
-    args: &Args,
+    _args: &Args,
     subargs: &[String],
 ) -> Result<()> {
     let subargs = OcdArgs::try_parse_from(subargs)?;
-
-    // Do a dummy attach to confirm that the image matches
-    humility_cmd::attach(
-        hubris,
-        args,
-        Attach::LiveOnly,
-        Validate::Match,
-        |_, _| Ok(()),
-    )?;
 
     let work_dir = tempfile::tempdir()?;
     hubris

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use humility::hubris::*;
 use humility_cmd::{Archive, Args, Attach, Command as HumilityCmd, Validate};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};
 
 #[derive(Parser, Debug)]
@@ -46,10 +46,12 @@ fn openocd(
     )?;
 
     let work_dir = tempfile::tempdir()?;
-    hubris.extract_file_to(
-        "debug/openocd.cfg",
-        &work_dir.path().join("openocd.cfg"),
-    )?;
+    hubris
+        .extract_file_to(
+            "debug/openocd.cfg",
+            &work_dir.path().join("openocd.cfg"),
+        )
+        .context("OpenOCD config missing. Is your Hubris build too old?")?;
     let mut cmd =
         Command::new(subargs.exec.unwrap_or_else(|| "openocd".to_string()));
     cmd.arg("-f").arg("openocd.cfg");

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility openocd`
+//!
+//! This command launches OpenOCD based on the config file in a build archive
+//!
+
+use std::process::Command;
+
+use humility::hubris::*;
+use humility_cmd::{Archive, Args, Attach, Command as HumilityCmd, Validate};
+
+use anyhow::Result;
+use clap::{Command as ClapCommand, CommandFactory, Parser};
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "openocd", about = env!("CARGO_PKG_DESCRIPTION"),
+)]
+struct OcdArgs {
+    /// specifies the `openocd` executable to run
+    #[clap(short, long)]
+    exec: Option<String>,
+
+    /// Extra options to pass to `openocd`
+    #[clap(last = true)]
+    extra_options: Vec<String>,
+}
+
+fn openocd(
+    hubris: &mut HubrisArchive,
+    args: &Args,
+    subargs: &[String],
+) -> Result<()> {
+    let subargs = OcdArgs::try_parse_from(subargs)?;
+
+    // Do a dummy attach to confirm that the image matches
+    humility_cmd::attach(
+        hubris,
+        args,
+        Attach::LiveOnly,
+        Validate::Match,
+        |_, _| Ok(()),
+    )?;
+
+    let work_dir = tempfile::tempdir()?;
+    hubris.extract_file_to(
+        "debug/openocd.cfg",
+        &work_dir.path().join("openocd.cfg"),
+    )?;
+    let mut cmd =
+        Command::new(subargs.exec.unwrap_or_else(|| "openocd".to_string()));
+    cmd.arg("-f").arg("openocd.cfg");
+    cmd.current_dir(work_dir.path());
+
+    for opt in subargs.extra_options {
+        cmd.arg(opt);
+    }
+
+    // Run OpenOCD, ignoring Ctrl-C (so it can handle them)
+    ctrlc::set_handler(|| {}).expect("Error setting Ctrl-C handler");
+    let status = cmd.status()?;
+
+    // Then, check on the OpenOCD status.
+    //
+    // If OpenOCD is killed by Ctrl-C (which is typical), `status.success()`
+    // will be `false`, but `status.code()` will be `None` (based on
+    // `ExitStatus` docs), so this saves us from printing a spurious error
+    // message.
+    if !status.success() && status.code().is_some() {
+        anyhow::bail!(
+            "command failed ({:?}), see output for details",
+            status.code().unwrap()
+        );
+    }
+    Ok(())
+}
+
+pub fn init() -> (HumilityCmd, ClapCommand<'static>) {
+    (
+        HumilityCmd::Unattached {
+            name: "openocd",
+            archive: Archive::Required,
+            run: openocd,
+        },
+        OcdArgs::command(),
+    )
+}

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3983,6 +3983,9 @@ impl HubrisArchive {
     pub fn extract_elfs_to(&self, p: &Path) -> Result<()> {
         self.extract_file_to("elf/kernel", &p.join("kernel"))?;
 
+        // `stage0` is only present in some cases, so we ignore errors here
+        let _ = self.extract_file_to("img/stage0", &p.join("stage0"));
+
         let cursor = Cursor::new(self.archive.as_slice());
         let archive = zip::ZipArchive::new(cursor)?;
         Self::for_each_task(archive, |path, buffer| {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2737,6 +2737,14 @@ impl HubrisArchive {
         );
     }
 
+    pub fn image_id_addr(&self) -> Option<u32> {
+        self.imageid.as_ref().map(|i| i.0)
+    }
+
+    pub fn image_id(&self) -> Option<&[u8]> {
+        self.imageid.as_ref().map(|i| i.1.as_slice())
+    }
+
     pub fn member_offset(
         &self,
         structure: &HubrisStruct,


### PR DESCRIPTION
This PR adds `gdb` and `openocd` subcommands.  The changes are mostly standalone, except for new helper functions in the `HubrisArchive` class to iterate over and manipulate task ELFs.

This is dependent on [@oxidecomputer/hubris#539](https://github.com/oxidecomputer/hubris/pull/539); otherwise, build archives are missing relevant files.