### PR TITLE
Upgrade clap to 3.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,16 +272,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "d53da17d37dba964b9b3ecb5c5a1f193a2762c700e6829201e645b9381c99dc7"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
- "lazy_static",
- "os_str_bytes",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -289,15 +289,24 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "c11d40217d16aee8508cc8e5fde8b4ff24639758608e5374e731b53f85749fb9"
 dependencies = [
  "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5538cd660450ebeb4234cfecf8f2284b844ffc4c50531e66d584ad5b91293613"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1820,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_pipe"
@@ -1839,9 +1848,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ fallible-iterator = "0.2.0"
 log = {version = "0.4.8", features = ["std"]}
 env_logger = "0.9.0"
 bitfield = "0.13.2"
-clap = "3.0.12"
+clap = "3.2.5"
 csv = "1.1.3"
 serde = "1.0.126"
 parse_int = "0.4.0"

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -51,7 +51,7 @@ struct DashboardArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -46,7 +46,7 @@ struct DiagnoseArgs {
     /// timeout to wait for interactions with the supervisor task to complete
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -34,7 +34,8 @@ struct EtmArgs {
     /// sets ETM trace identifier
     #[clap(
         long, short, value_name = "identifier",
-        default_value = "0x54", parse(try_from_str = parse_int::parse),
+        default_value = "0x54",
+        value_parser=parse_int::parse::<u8>,
     )]
     traceid: u8,
     /// ingest ETM data as CSV
@@ -46,7 +47,7 @@ struct EtmArgs {
     /// sets the value of SWOSCALER
     #[clap(
         long, short, value_name = "scaler", requires = "enable",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u16>,
     )]
     clockscaler: Option<u16>,
     /// output ETM data as CSV

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -111,7 +111,7 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -92,7 +92,7 @@ struct HashArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -58,7 +58,7 @@ struct HiffyArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -115,7 +115,7 @@ pub struct I2cArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -128,7 +128,7 @@ pub struct I2cArgs {
     /// have side-effects on unsporting devices
     #[clap(long, short = 'S', value_name = "register",
         conflicts_with_all = &["scan", "register", "device"],
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     scanreg: Option<u8>,
 
@@ -156,7 +156,7 @@ pub struct I2cArgs {
 
     /// specifies register
     #[clap(long, short, value_name = "register",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     register: Option<u8>,
 
@@ -184,7 +184,7 @@ pub struct I2cArgs {
     /// number of bytes to read from (or write to) register
     #[clap(long, short, value_name = "nbytes",
         conflicts_with = "write",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     nbytes: Option<u8>,
 

--- a/cmd/itm/src/lib.rs
+++ b/cmd/itm/src/lib.rs
@@ -67,7 +67,7 @@ struct ItmArgs {
     /// sets ITM trace identifier
     #[clap(
         long, short, default_value = "0x3a", value_name = "identifier",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u8>,
     )]
     traceid: u8,
     /// ingest ITM data as CSV
@@ -81,7 +81,7 @@ struct ItmArgs {
     bypass: bool,
     /// sets the value of SWOSCALER
     #[clap(long, short, value_name = "scaler", requires = "enable",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u16>,
     )]
     clockscaler: Option<u16>,
 }

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -96,7 +96,7 @@ struct JefeArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -21,7 +21,7 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -9,7 +9,7 @@ humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
+clap = { version = "3.2.5", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 colored = "2.0.0"
 indexmap = { version = "1.7", features = ["serde-1"] }

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -25,7 +25,7 @@ struct PmbusArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -82,7 +82,7 @@ struct PmbusArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>
     )]
     controller: Option<u8>,
 

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -107,7 +107,7 @@ struct QspiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -144,13 +144,13 @@ struct QspiArgs {
 
     /// specify flash address in bytes
     #[clap(long, short, value_name = "address",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<usize>,
     )]
     addr: Option<usize>,
 
     /// specify size in bytes
     #[clap(long, short, value_name = "nbytes",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<usize>,
     )]
     nbytes: Option<usize>,
 

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -138,7 +138,7 @@ struct ReadmemArgs {
     address: String,
 
     /// length to read
-    #[clap(parse(try_from_str = parse_int::parse))]
+    #[clap(value_parser=parse_int::parse::<usize>)]
     length: Option<usize>,
 }
 

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -34,7 +34,7 @@ struct RencmArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -50,7 +50,7 @@ struct RencmArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -25,7 +25,7 @@ struct RendmpArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -37,7 +37,7 @@ struct RendmpArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -37,7 +37,7 @@ struct SensorsArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -60,12 +60,12 @@ use hif::*;
 #[clap(name = "subcmd")]
 enum SpCtrlCmd {
     Write {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         addr: u32,
         bytes: String,
     },
     Read {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         addr: u32,
         nbytes: usize,
     },
@@ -78,7 +78,7 @@ struct SpCtrlArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -20,7 +20,7 @@ struct SpdArgs {
     /// sets timeout
     #[clap(
         long, short, default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -30,7 +30,7 @@ struct SpdArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -50,7 +50,7 @@ struct SpiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -68,7 +68,7 @@ struct SpiArgs {
 
     /// specify number of bytes to read
     #[clap(long, short, value_name = "nbytes",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<usize>,
     )]
     nbytes: Option<usize>,
 

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -71,9 +71,9 @@ enum StmSecureArgs {
     /// region before this is programmed otherwise you will brick the device
     /// !!!
     SetSecureRegion {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         address: u32,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         size: u32,
         #[clap(long)]
         doit: bool,

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -60,7 +60,7 @@ struct ValidateArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -70,7 +70,7 @@ struct ValidateArgs {
 
     /// specifies an I2C controller to validate
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser=parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -23,7 +23,7 @@ struct Vsc7448Args {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value = "5000", value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser=parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -56,7 +56,7 @@ impl Vsc7448Args {
 enum Command {
     Info {
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         value: Option<u32>,
     },
     Read {
@@ -64,7 +64,7 @@ enum Command {
     },
     Write {
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u32>)]
         value: u32,
     },
     Phy {
@@ -87,7 +87,7 @@ enum PhyCommand {
         #[clap(flatten)]
         addr: PhyAddr,
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser=parse_int::parse::<u16>)]
         value: u16,
     },
 }

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -12,20 +12,19 @@ pub mod stack;
 pub mod test;
 
 use anyhow::{bail, Result};
-use clap::{AppSettings, Parser};
+use clap::Parser;
 use humility::core::Core;
 use humility::hubris::*;
 
 #[derive(Parser)]
 #[clap(name = "humility", max_term_width = 80)]
-#[clap(global_setting(AppSettings::NoAutoVersion))]
 pub struct Args {
     /// verbose messages
     #[clap(long, short)]
     pub verbose: bool,
 
     /// print version information
-    #[clap(long, short = 'V')]
+    #[clap(long, short = 'V', action)]
     pub version: bool,
 
     /// probe to use

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,11 @@ fn main() {
     // line) to win the conflict.
     //
     if args.dump.is_some() && args.archive.is_some() {
-        match (m.occurrences_of("dump") == 1, m.occurrences_of("archive") == 1)
-        {
+        let dump_count =
+            m.get_many::<usize>("dump").map(|m| m.len()).unwrap_or(0);
+        let archive_count =
+            m.get_many::<usize>("archive").map(|m| m.len()).unwrap_or(0);
+        match (dump_count == 1, archive_count == 1) {
             (true, true) => {
                 log::error!("cannot specify both a dump and an archive");
                 std::process::exit(1);

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -7,9 +7,6 @@ $ humility --chip -V
 ? failed
 error: The argument '--chip <CHIP>' requires a value but none was supplied
 
-USAGE:
-    humility [OPTIONS] [SUBCOMMAND]
-
 For more information try --help
 
 ```
@@ -24,9 +21,6 @@ humility 0.7.0
 $ humility -c -V
 ? failed
 error: The argument '--chip <CHIP>' requires a value but none was supplied
-
-USAGE:
-    humility [OPTIONS] [SUBCOMMAND]
 
 For more information try --help
 


### PR DESCRIPTION
Clap 3.2 is the last release before 4.0:
https://epage.github.io/blog/2022/06/clap-32-last-call-before-40/

These changes upgrade our usage of features that are being deprecated,
insuring that we shall have an easy upgrade path to 4.0.

The two biggest changes:

1. removing NoAutoVersion.
2. changing our usage of parse_int::parse to the new value_parser API

Big thanks to @epage for helping out with 2:
https://github.com/clap-rs/clap/discussions/3839

And for working through some error messages:
https://github.com/clap-rs/clap/issues/3822

As for NoAutoVersion, opting into the new behavior via `action` does
what we want, *except* that the output for doing it with another
incorrect flag doesn't give the error about how that's incorrect. I
suspect that this is an acceptable change in behavior, but worth calling
out. You can see the difference in the chip.trycmd tests.