### PR TITLE
Decode Hiffy return values with `ssmarshal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,6 +908,7 @@ dependencies = [
  "log",
  "parse_int",
  "postcard",
+ "ssmarshal",
 ]
 
 [[package]]
@@ -2487,6 +2488,16 @@ name = "srec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17c3a0538ec242e3cd333cdcdc8b720faa2fa0a9d7f444cf1ff63e7d3303adfb"
+
+[[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode",
+ "serde",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/humility-cmd/Cargo.toml
+++ b/humility-cmd/Cargo.toml
@@ -15,3 +15,4 @@ postcard = "0.7.0"
 parse_int = "0.4.0"
 colored = "2.0.0"
 log = {version = "0.4.8", features = ["std"]}
+ssmarshal = {version = "1"}

--- a/humility-cmd/src/reflect.rs
+++ b/humility-cmd/src/reflect.rs
@@ -1000,13 +1000,13 @@ pub fn deserialize_value<'a>(
 
 /// Deserializes a pointer from `buf` and interprets it as a pointer to the
 /// type designated by `ty`.
-pub fn deserialize_ptr(buf: &[u8], ty: HubrisGoff) -> Result<(Ptr, &[u8])> {
+fn deserialize_ptr(buf: &[u8], ty: HubrisGoff) -> Result<(Ptr, &[u8])> {
     let (dest, cnt) = ssmarshal::deserialize(buf).unwrap();
     Ok((Ptr(ty, dest), &buf[cnt..]))
 }
 
 /// Deserializes an `Array` from `buf`
-pub fn deserialize_array<'a>(
+fn deserialize_array<'a>(
     hubris: &'a HubrisArchive,
     mut buf: &'a [u8],
     ty: &'a HubrisArray,
@@ -1025,7 +1025,7 @@ pub fn deserialize_array<'a>(
 /// Deserializes either a struct or tuple from `buf`
 ///
 /// See details on [load_struct_or_tuple] above
-pub fn deserialize_struct_or_tuple<'a>(
+fn deserialize_struct_or_tuple<'a>(
     hubris: &'a HubrisArchive,
     mut buf: &'a [u8],
     ty: &'a HubrisStruct,
@@ -1066,7 +1066,7 @@ pub fn deserialize_struct_or_tuple<'a>(
 }
 
 /// Deserializes a struct from `buf`
-pub fn deserialize_struct<'a>(
+fn deserialize_struct<'a>(
     hubris: &'a HubrisArchive,
     mut buf: &'a [u8],
     ty: &'a HubrisStruct,
@@ -1084,7 +1084,7 @@ pub fn deserialize_struct<'a>(
 }
 
 /// Deserializes an enum from `buf`
-pub fn deserialize_enum<'a>(
+fn deserialize_enum<'a>(
     hubris: &'a HubrisArchive,
     mut buf: &'a [u8],
     ty: &'a HubrisEnum,
@@ -1107,7 +1107,7 @@ pub fn deserialize_enum<'a>(
 }
 
 /// Deserializes a basetype from `buf`
-pub fn deserialize_base<'a>(
+fn deserialize_base<'a>(
     buf: &'a [u8],
     ty: &'a HubrisBasetype,
 ) -> Result<(Base, &'a [u8])> {

--- a/humility-cmd/src/reflect.rs
+++ b/humility-cmd/src/reflect.rs
@@ -743,21 +743,7 @@ pub fn load_struct_or_tuple(
     ty: &HubrisStruct,
     addr: usize,
 ) -> Result<Value> {
-    // Scan the shape of the type to tell if it's tupley. Tuples are structs
-    // that only have fields of the form __#, where # is a decimal number.
-    let mut probably_a_tuple = true;
-    for m in &ty.members {
-        if !m.name.starts_with("__") {
-            probably_a_tuple = false;
-            break;
-        }
-        if !m.name[2..].chars().all(|c| c.is_numeric()) {
-            probably_a_tuple = false;
-            break;
-        }
-    }
-
-    if probably_a_tuple {
+    if ty.probably_a_tuple() {
         // Start off the tuple filled with nonsense, so that we can set the
         // values out of order if required. Do tuple members ever appear out of
         // order? No idea! But if they do, this method will keep working.
@@ -1030,21 +1016,7 @@ fn deserialize_struct_or_tuple<'a>(
     mut buf: &'a [u8],
     ty: &'a HubrisStruct,
 ) -> Result<(Value, &'a [u8])> {
-    // Scan the shape of the type to tell if it's tupley. Tuples are structs
-    // that only have fields of the form __#, where # is a decimal number.
-    let mut probably_a_tuple = true;
-    for m in &ty.members {
-        if !m.name.starts_with("__") {
-            probably_a_tuple = false;
-            break;
-        }
-        if !m.name[2..].chars().all(|c| c.is_numeric()) {
-            probably_a_tuple = false;
-            break;
-        }
-    }
-
-    if probably_a_tuple {
+    if ty.probably_a_tuple() {
         // Assume that tuple fields were serialized in order
         let mut contents = vec![];
         for i in 0..ty.members.len() {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4530,6 +4530,20 @@ impl HubrisStruct {
             None
         }
     }
+
+    pub fn probably_a_tuple(&self) -> bool {
+        // Scan the shape of the type to tell if it's tupley. Tuples are structs
+        // that only have fields of the form __#, where # is a decimal number.
+        for m in &self.members {
+            if !m.name.starts_with("__") {
+                return false;
+            }
+            if !m.name[2..].chars().all(|c| c.is_numeric()) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
Right now, many of our Hiffy commands use `ssmarshal` to encode parameters or return values.  Consider the following fancy `struct` and a function which generates it:

```rust
#[derive(Copy, Clone, Serialize, Deserialize)]
pub enum Bla {
    Boo,
    Far(u16),
    Baz,
}

#[derive(Copy, Clone, Serialize, Deserialize)]
pub struct FancyTestType {
    pub u: u32,
    pub b: bool,
    pub f: f32,
    pub e: Bla,
    pub g: Bla,
}
```
```ron
        "return_struct_ss": (
            args: {
                "a": "u32",
            },
            reply: Result(
                ok: "FancyTestType",
                err: CLike("NetError"),
            ),
            encoding: Ssmarshal,
        ),
```
```rust
    fn return_struct_ss(
        &mut self,
        _: &userlib::RecvMessage,
        u: u32,
    ) -> Result<FancyTestType, RequestError<NetError>> {
        Ok(FancyTestType {
            u,
            b: true,
            f: 1.23,
            e: Bla::Far(91),
            g: Bla::Boo,
        })
    }
```

If you invoke this function in Humility, it will attempt to decode the buffer based on the DWARF data, and get it _terribly wrong_:
```
Net.return_struct_ss() =  { u: 0xc, b: false, f: -0.0000000000000000000031848523554306865, e: <? (0x13f)>, g: Boo }
```

This PR adds special decoding for Hiffy calls that using the `ssmarshal` encoding, so that Humility prints the output correctly.

```
Net.return_struct_ss() = FancyTestType { u: 0xc, b: true, f: 1.23, e: Far(0x5b), g: Boo }
```

I don't _love_ hard-coding `ssmarshal` details into the deserialization, but `ssmarshal` doesn't expose its `Deserializer` class, and `serde` doesn't have a great way of doing deserialization from an out of band format...