### PR TITLE
Bump vsc7448-info and libusb1-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,7 +1605,7 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 [[package]]
 name = "libusb1-sys"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/rusb?branch=probe-rs-0.12-libusb-v1.0.26#fa63411ad6a28bfd5f68f2905a0c258f1352d68e"
+source = "git+https://github.com/oxidecomputer/rusb?branch=probe-rs-0.12-libusb-v1.0.26#b97a32d2b36c3db5c67f58aca015039536416439"
 dependencies = [
  "cc",
  "libc",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-info"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#873309872f2260672bd875a5c4a4ad5121da52df"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#d75eea6d244ca8fc5d782d23e064db404d11ff3a"
 dependencies = [
  "lazy_static",
  "postcard",
@@ -2729,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "vsc7448-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/vsc7448.git#873309872f2260672bd875a5c4a4ad5121da52df"
+source = "git+https://github.com/oxidecomputer/vsc7448.git#d75eea6d244ca8fc5d782d23e064db404d11ff3a"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
This fixes the build on macOS and fixes incorrect PHY register decoding.