### PR TITLE
Update license-check.yml

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Check License Header
-      uses: apache/skywalking-eyes@501a28d2fb4a9b962661987e50cf0219631b32ff  
+      uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff  

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Check License Header
-      uses: apache/skywalking-eyes@main  
+      uses: apache/skywalking-eyes@501a28d2fb4a9b962661987e50cf0219631b32ff  


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123