### PR TITLE
Increase default timeout on qspi commands from 5 seconds to 30.

### DIFF
--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -106,7 +106,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 struct QspiArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value = "30000", value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,


### PR DESCRIPTION
The default timeout on the 'qspi -H ...' command was less than the time needed to hash the entire flash part. Increase the default so that people are not forced to do it manually.