### PR TITLE
Fix Humility compatibility with rustc 1.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,6 +1472,7 @@ dependencies = [
  "clap",
  "humility-cmd",
  "humility-core",
+ "log",
  "num-traits",
 ]
 

--- a/cmd/tasks/Cargo.toml
+++ b/cmd/tasks/Cargo.toml
@@ -10,3 +10,4 @@ humility-cmd = { path = "../../humility-cmd" }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 num-traits = "0.2"
+log = "0.4"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2761,7 +2761,7 @@ impl HubrisArchive {
                 if self.ptrtypes.contains_key(&goff) {
                     Ok(HubrisType::Ptr(goff))
                 } else {
-                    bail!("not a pointer type");
+                    bail!("no entry found for goff: {:x?}", goff);
                 }
             })?;
         Ok(r)
@@ -4755,6 +4755,19 @@ impl<'a> From<&'a HubrisArray> for HubrisType<'a> {
 impl<'a> From<&'a HubrisUnion> for HubrisType<'a> {
     fn from(x: &'a HubrisUnion) -> Self {
         Self::Union(x)
+    }
+}
+
+impl<'a> std::fmt::Display for HubrisType<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            HubrisType::Struct(ty) => write!(f, "struct {}", ty.name),
+            HubrisType::Enum(ty) => write!(f, "enum {}", ty.name),
+            HubrisType::Base(b) => write!(f, "base type {:?}", b.encoding),
+            HubrisType::Array(_) => f.write_str("array"),
+            HubrisType::Ptr(_) => f.write_str("pointer"),
+            HubrisType::Union(ty) => write!(f, "union {}", ty.name),
+        }
     }
 }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -966,8 +966,10 @@ impl HubrisArchive {
             }
         }
 
-        if let (Some(name), Some(underlying)) = (name, underlying) {
-            self.ptrtypes.insert(goff, (name.to_string(), underlying));
+        let name = name.unwrap_or("<UNNAMED>").to_string();
+
+        if let Some(underlying) = underlying {
+            self.ptrtypes.insert(goff, (name, underlying));
         }
 
         Ok(())

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -36,7 +36,7 @@ const OXIDE_NT_BASE: u32 = 0x1de << 20;
 const OXIDE_NT_HUBRIS_ARCHIVE: u32 = OXIDE_NT_BASE + 1;
 const OXIDE_NT_HUBRIS_REGISTERS: u32 = OXIDE_NT_BASE + 2;
 
-const MAX_HUBRIS_VERSION: u32 = 2;
+const MAX_HUBRIS_VERSION: u32 = 3;
 
 #[derive(Default, Debug)]
 pub struct HubrisManifest {
@@ -5008,24 +5008,4 @@ fn demangle_name(name: &str) -> String {
     // Note: "alternate mode" # causes rustc_demangle to leave off the ugly hash
     // values on functions.
     format!("{:#}", rustc_demangle::demangle(name))
-}
-
-#[cfg(test)]
-mod tests {
-    // Note this useful idiom: importing names from outer (for mod tests) scope.
-    use super::*;
-
-    #[test]
-    fn test_check_version() {
-        let f = HubrisArchive::check_version;
-        assert!(f("hubris app archive").is_err());
-        assert!(f("hubris build archive").is_err());
-        assert!(f("hubris build archive v1").is_err());
-        assert!(f("hubris build archive vaaagh").is_err());
-
-        assert!(f("hubris build archive v1.0.0").is_ok());
-        assert!(f("hubris build archive v2").is_ok());
-
-        assert!(f("hubris build archive v3").is_err());
-    }
 }

--- a/tests/cmd/ringbuf/ringbuf.kiowa.51.stderr
+++ b/tests/cmd/ringbuf/ringbuf.kiowa.51.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.kiowa.52.stderr
+++ b/tests/cmd/ringbuf/ringbuf.kiowa.52.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.kiowa.53.stderr
+++ b/tests/cmd/ringbuf/ringbuf.kiowa.53.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.kiowa.rick.0.stderr
+++ b/tests/cmd/ringbuf/ringbuf.kiowa.rick.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.51.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.51.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.52.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.52.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.53.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.53.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.55.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.55.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.61.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.61.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.64.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.64.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.65.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.65.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x4
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.8.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.8.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x88
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.ouray.9.stderr
+++ b/tests/cmd/ringbuf/ringbuf.ouray.9.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0x88
+humility: ringbuf dump failed: loading value of type array at address 0x8

--- a/tests/cmd/ringbuf/ringbuf.static-tasks.0.stderr
+++ b/tests/cmd/ringbuf/ringbuf.static-tasks.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: ringbuf dump failed: unknown variant: 0xbaddcafe
+humility: ringbuf dump failed: loading value of type struct UnsafeCell<ringbuf::Ringbuf<task_validate::Trace, 64>> at address 0x0


### PR DESCRIPTION
Humility has historically required all symbols to be described the same way in both DWARF and ELF. Nothing actually requires the compiler to behave this way, however, and somewhere between the old version we've been stuck on, and 1.64, this behavior changed.

This caused Humility to refuse to load new images, failing in creative and inscrutable ways.

To address the loading, this PR teaches Humility how to parse and evaluate the DWARF `AT_location` expressions for static variables, and use those if there is no matching information in the ELF. This fixes image loading.

To address the "creative and inscrutable" part, this PR also improves error message reporting for type resolution failures and value loading.

Finally, it turns out that rustc is now generating unnamed pointer types in certain circumstances; this PR hackishly treats them as `"<UNNAMED>"` since Humility in general requires things to have names.