### PR TITLE
Fix `humility openocd` when using environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "humility-cmd",
+ "humility-cmd-openocd",
  "humility-core",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,7 @@ dependencies = [
  "ctrlc",
  "humility-cmd",
  "humility-core",
+ "regex",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/gdb/Cargo.toml
+++ b/cmd/gdb/Cargo.toml
@@ -9,6 +9,7 @@ description = "Attach to a running system using GDB"
 [dependencies]
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }
+humility-cmd-openocd = { path = "../openocd" }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 ctrlc = "3.1.5"

--- a/cmd/openocd/Cargo.toml
+++ b/cmd/openocd/Cargo.toml
@@ -10,4 +10,5 @@ humility-cmd = { path = "../../humility-cmd" }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 ctrlc = "3.1.5"
+regex = "1.5"
 tempfile = "3.3"

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -38,11 +38,44 @@ fn openocd(
     args: &Args,
     subargs: &[String],
 ) -> Result<()> {
-    if args.probe.is_some() {
-        bail!("Cannot specify --probe with `openocd` subcommand");
-    }
-
     let subargs = OcdArgs::try_parse_from(subargs)?;
+
+    // We can get the serial name from two different places:
+    // - If the `--probe` argument is of the form `vid:pid:serial`, then we can
+    //   extract the serial name.  This is also the case if we're using an
+    //   environment file, which populates `args.probe` automatically.
+    // - If the `--serial` argument is given, then we use it directly
+    let serial = match &args.probe {
+        Some(probe) => {
+            let re = regex::Regex::new(
+                r"^([[:xdigit:]]+):([[:xdigit:]]+):([[:xdigit:]]+)$",
+            )
+            .unwrap();
+            if let Some(cap) = re.captures(probe) {
+                if subargs.serial.is_some() {
+                    if args.target.is_some() {
+                        bail!(
+                            "Cannot specify probe serial number with both \
+                             environment and `--serial`"
+                        );
+                    } else {
+                        bail!(
+                            "Cannot specify probe serial number with both \
+                             `--probe` and `--serial`"
+                        );
+                    }
+                }
+                Some(cap.get(3).unwrap().as_str().to_string())
+            } else {
+                bail!(
+                    "Cannot specify `--probe {}` with `openocd` subcommand \
+                     (must be of the form vid:pid:serial)",
+                    probe
+                );
+            }
+        }
+        None => subargs.serial,
+    };
 
     let work_dir = tempfile::tempdir()?;
     hubris
@@ -54,7 +87,7 @@ fn openocd(
     let mut cmd =
         Command::new(subargs.exec.unwrap_or_else(|| "openocd".to_string()));
     cmd.arg("-f").arg("openocd.cfg");
-    if let Some(serial) = subargs.serial {
+    if let Some(serial) = serial {
         cmd.arg("-c")
             .arg("interface hla")
             .arg("-c")

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.2
+humility 0.8.3
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.2
+humility 0.8.3
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.2
+humility 0.8.3
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.2
+humility 0.8.3
 
 ```


### PR DESCRIPTION
This kills two birds with one stone:

- It allows us to use `humility openocd` when using an environment + target
- It selects the _correct_ probe (based on serial name), for systems with multiple probes attached

I rolled the same fixes into `humility gdb`, which would otherwise fail in the same way.

Fixes #208