### PR TITLE
Allow specifying multiple archives in environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.4"
+version = "0.8.5"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -172,9 +172,26 @@ command line.  For example:
 }
 ```
 
+Some targets may require multiple archives. These can be specified by
+name. The archive to be used must be specified with the `--archive-name`
+option to humility.
+
+```json
+{
+    "lucky": {
+        "probe": "0483:374e:002A00174741500520383733",
+        "archive": {
+		imagea: "/gimlet/hubris/archives/lucky/build-a-gimlet.zip",
+		imageb: "/gimlet/hubris/archives/lucky/build-b-gimlet.zip"
+	}
+    },
+}
+```
+
 The above definition -- when provided via `--environment` or
 `HUMILITY_ENVIRONMENT` -- would allow one to (say) run `humility --target
-grimey tasks`.  In addition to `probe` and `archive`, one may also specify
+grimey tasks` or `humility --target lucky --image-name imagea tasks`.
+In addition to `probe` and `archive`, one may also specify
 associated commands in a `cmds` object that contains a mapping of names to
 commands to execute.  For example:
 

--- a/humility-cmd/src/env.rs
+++ b/humility-cmd/src/env.rs
@@ -2,21 +2,47 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use indexmap::IndexMap;
 use serde::Deserialize;
+use serde_json::Value;
 use std::{fs, path::PathBuf};
 
 #[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct Environment {
     pub probe: String,
-    pub archive: String,
+    pub archive: serde_json::Value,
     pub description: Option<String>,
     pub cmds: Option<serde_json::Value>,
 }
 
 impl Environment {
+    pub fn archive(&self, archive_name: &Option<String>) -> Result<String> {
+        match &self.archive {
+            Value::String(s) => {
+                if archive_name.is_some() {
+                    bail!("an archive name was specified but there is only one archive");
+                }
+                Ok(s.to_string())
+            }
+            Value::Object(obj) => {
+                if let Some(ref n) = archive_name {
+                    match obj
+                        .get(n)
+                        .ok_or_else(|| anyhow!("Couldn't find archive {}", n))?
+                    {
+                        Value::String(s) => Ok(s.to_string()),
+                        _ => bail!("Badly formed archive entry"),
+                    }
+                } else {
+                    bail!("Need an archive name");
+                }
+            }
+            _ => bail!("Badly formed archive entry"),
+        }
+    }
+
     fn read(filename: &str) -> Result<IndexMap<String, Environment>> {
         let path = PathBuf::from(filename);
         let input = fs::read_to_string(&path)?;
@@ -49,4 +75,42 @@ impl Environment {
             bail!("invalid target \"{}\" (expected one of: {})", target, keys);
         }
     }
+}
+
+#[test]
+fn validate_single_archive() {
+    let data = r#"
+    {
+        "board1": {
+            "description": "a board",
+            "probe" : "1234:5678:ABCDEFG",
+            "archive" : "/some/valid/path"
+        }
+    }
+    "#;
+
+    let v: IndexMap<String, Environment> = serde_json::from_str(&data).unwrap();
+
+    let _b = v.get("board1").unwrap().archive(&None);
+}
+
+#[test]
+fn validate_multi_archive() {
+    let data = r#"
+    {
+        "board1": {
+            "description": "a board",
+            "probe" : "1234:5678:ABCDEFG",
+            "archive" : {
+                "name1" : "/some/valid/path",
+                "name2" : "/some/other/path"
+            }
+        }
+    }
+    "#;
+
+    let v: IndexMap<String, Environment> = serde_json::from_str(&data).unwrap();
+
+    let _b = v.get("board1").unwrap().archive(&Some("name1".to_string()));
+    let _b = v.get("board1").unwrap().archive(&Some("name2".to_string()));
 }

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -55,6 +55,11 @@ pub struct Args {
         conflicts_with_all = &["dump", "probe"])]
     pub target: Option<String>,
 
+    /// If multiple archives are specified in an environment, name of
+    /// the archive to use
+    #[clap(long, requires = "environment")]
+    pub archive_name: Option<String>,
+
     //
     // probe-rs requires the chip to be specified when creating a session,
     // even though it is only used for flashing (which we don't use probe-rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,13 @@ fn main() {
 
                 log::warn!("{} overriding archive in environment file", msg);
             } else {
-                args.archive = Some(env.archive.clone());
+                args.archive = match env.archive(&args.archive_name) {
+                    Ok(a) => Some(a),
+                    Err(e) => {
+                        eprintln!("Failed to get archive: {}", e);
+                        std::process::exit(1);
+                    }
+                }
             }
 
             Some(env)

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.4
+humility 0.8.5
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.4
+humility 0.8.5
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.4
+humility 0.8.5
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.4
+humility 0.8.5
 
 ```


### PR DESCRIPTION
Recent changes to Hubris require multiple archive files to fully
describe what is flashed on some targets. Update the environment
files to account for this.