### PR TITLE
Add `net` subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "humility-cmd-manifest",
  "humility-cmd-map",
  "humility-cmd-monorail",
+ "humility-cmd-net",
  "humility-cmd-openocd",
  "humility-cmd-pmbus",
  "humility-cmd-probe",
@@ -1251,6 +1252,20 @@ dependencies = [
  "regex",
  "vsc7448-info",
  "vsc7448-types",
+]
+
+[[package]]
+name = "humility-cmd-net"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "hif",
+ "humility-cmd",
+ "humility-cmd-hiffy",
+ "humility-core",
+ "parse_int",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "cmd/manifest",
     "cmd/map",
     "cmd/monorail",
+    "cmd/net",
     "cmd/openocd",
     "cmd/pmbus",
     "cmd/probe",
@@ -112,6 +113,7 @@ cmd-lpc55gpio = { path = "./cmd/lpc55gpio", package = "humility-cmd-lpc55gpio" }
 cmd-manifest = { path = "./cmd/manifest", package = "humility-cmd-manifest" }
 cmd-map = { path = "./cmd/map", package = "humility-cmd-map" }
 cmd-monorail = { path = "./cmd/monorail", package = "humility-cmd-monorail" }
+cmd-net = { path = "./cmd/net", package = "humility-cmd-net" }
 cmd-openocd = { path = "./cmd/openocd", package = "humility-cmd-openocd" }
 cmd-pmbus = { path = "./cmd/pmbus", package = "humility-cmd-pmbus" }
 cmd-probe = { path = "./cmd/probe", package = "humility-cmd-probe" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -172,26 +172,9 @@ command line.  For example:
 }
 ```
 
-Some targets may require multiple archives. These can be specified by
-name. The archive to be used must be specified with the `--archive-name`
-option to humility.
-
-```json
-{
-    "lucky": {
-        "probe": "0483:374e:002A00174741500520383733",
-        "archive": {
-		imagea: "/gimlet/hubris/archives/lucky/build-a-gimlet.zip",
-		imageb: "/gimlet/hubris/archives/lucky/build-b-gimlet.zip"
-	}
-    },
-}
-```
-
 The above definition -- when provided via `--environment` or
 `HUMILITY_ENVIRONMENT` -- would allow one to (say) run `humility --target
-grimey tasks` or `humility --target lucky --image-name imagea tasks`.
-In addition to `probe` and `archive`, one may also specify
+grimey tasks`.  In addition to `probe` and `archive`, one may also specify
 associated commands in a `cmds` object that contains a mapping of names to
 commands to execute.  For example:
 
@@ -241,6 +224,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility manifest](#humility-manifest): print archive manifest
 - [humility map](#humility-map): print memory map, with association of regions to tasks
 - [humility monorail](#humility-monorail): Management network control and debugging
+- [humility net](#humility-net): Management network device-side control and debugging
 - [humility openocd](#humility-openocd): Run OpenOCD for the given archive
 - [humility pmbus](#humility-pmbus): scan for and read PMBus devices
 - [humility probe](#humility-probe): probe for any attached devices
@@ -1174,6 +1158,42 @@ commands to interact with VSC7448 registers.
 
 PHY register names are also found in the
 [`vsc7448-pac` crate](https://github.com/oxidecomputer/vsc7448/tree/master/vsc7448-pac/src/phy).
+
+
+### `humility net`
+`humility net` exposes commands to interact with the management network from
+the client's perspective.
+
+(It is the counterpart to `humility monorail`, which interacts with the
+ management network from the _switch_'s perspective.)
+
+It is fully functional on
+- Gimlet
+- Sidecar
+- PSC
+- `gimletlet-mgmt`
+These PCAs have the KSZ8463 switch + VSC85x2 PHY which is our standard
+management network interface.
+
+#### `humility net ip`
+The `ip` subcommand works on any image with network functionality, and
+prints the MAC and IPv6 address of the board.  Note that on boards with
+multiple ports, this is the lowest MAC / IPv6 address.
+
+#### `humility net mac`
+This subcommand prints the MAC table from the KSZ8463 switch.  It is
+functional on the boards listed above *and* the Gimletlet (when the NIC
+daughterboard is installed)
+
+#### `humility net status`
+This subcommand shows the status of the management network links.  It is
+only functional on the fully supported boards listed above.
+
+#### `humility net counters`
+This subcommand shows the internal counters on the management network links.
+It is only functional on the fully supported boards listed above.  In
+addition, the MAC-side counters are only supported on the VSC8562, not the
+VSC8552; this is indicated with `--` in the relevant table positions.
 
 
 ### `humility openocd`

--- a/README.md
+++ b/README.md
@@ -167,14 +167,31 @@ command line.  For example:
     },
     "grimey": {
         "probe": "0483:374e:003400185553500820393256",
-	"archive": "/gimlet/hubris/archives/grimey/build-gimlet.zip"
+        "archive": "/gimlet/hubris/archives/grimey/build-gimlet.zip"
     }
+}
+```
+
+Some targets may require multiple archives. These can be specified by
+name. The archive to be used must be specified with the `--archive-name`
+option to humility.
+
+```json
+{
+    "lucky": {
+        "probe": "0483:374e:002A00174741500520383733",
+        "archive": {
+            imagea: "/gimlet/hubris/archives/lucky/build-a-gimlet.zip",
+            imageb: "/gimlet/hubris/archives/lucky/build-b-gimlet.zip"
+        }
+    },
 }
 ```
 
 The above definition -- when provided via `--environment` or
 `HUMILITY_ENVIRONMENT` -- would allow one to (say) run `humility --target
-grimey tasks`.  In addition to `probe` and `archive`, one may also specify
+grimey tasks` or `humility --target lucky --image-name imagea tasks`.
+In addition to `probe` and `archive`, one may also specify
 associated commands in a `cmds` object that contains a mapping of names to
 commands to execute.  For example:
 

--- a/README.md.in
+++ b/README.md.in
@@ -157,14 +157,31 @@ command line.  For example:
     },
     "grimey": {
         "probe": "0483:374e:003400185553500820393256",
-	"archive": "/gimlet/hubris/archives/grimey/build-gimlet.zip"
+        "archive": "/gimlet/hubris/archives/grimey/build-gimlet.zip"
     }
+}
+```
+
+Some targets may require multiple archives. These can be specified by
+name. The archive to be used must be specified with the `--archive-name`
+option to humility.
+
+```json
+{
+    "lucky": {
+        "probe": "0483:374e:002A00174741500520383733",
+        "archive": {
+            imagea: "/gimlet/hubris/archives/lucky/build-a-gimlet.zip",
+            imageb: "/gimlet/hubris/archives/lucky/build-b-gimlet.zip"
+        }
+    },
 }
 ```
 
 The above definition -- when provided via `--environment` or
 `HUMILITY_ENVIRONMENT` -- would allow one to (say) run `humility --target
-grimey tasks`.  In addition to `probe` and `archive`, one may also specify
+grimey tasks` or `humility --target lucky --image-name imagea tasks`.
+In addition to `probe` and `archive`, one may also specify
 associated commands in a `cmds` object that contains a mapping of names to
 commands to execute.  For example:
 

--- a/cmd/net/Cargo.toml
+++ b/cmd/net/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "humility-cmd-net"
+version = "0.1.0"
+edition = "2021"
+description = "Management network device-side control and debugging"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = { version = "1.0.44", features = ["backtrace"] }
+clap = { version = "3.0.12", features = ["derive", "env"] }
+parse_int = "0.4.0"
+colored = "2.0.0"
+
+humility = { path = "../../humility-core", package = "humility-core" }
+humility-cmd = { path = "../../humility-cmd" }
+humility-cmd-hiffy = { path = "../hiffy" }
+
+hif = { git = "https://github.com/oxidecomputer/hif" }

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -2,6 +2,40 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//! ## `humility net`
+//! `humility net` exposes commands to interact with the management network from
+//! the client's perspective.
+//!
+//! (It is the counterpart to `humility monorail`, which interacts with the
+//!  management network from the _switch_'s perspective.)
+//!
+//! It is fully functional on
+//! - Gimlet
+//! - Sidecar
+//! - PSC
+//! - `gimletlet-mgmt`
+//! These PCAs have the KSZ8463 switch + VSC85x2 PHY which is our standard
+//! management network interface.
+//!
+//! ### `humility net ip`
+//! The `ip` subcommand works on any image with network functionality, and
+//! prints the MAC and IPv6 address of the board.  Note that on boards with
+//! multiple ports, this is the lowest MAC / IPv6 address.
+//!
+//! ### `humility net mac`
+//! This subcommand prints the MAC table from the KSZ8463 switch.  It is
+//! functional on the boards listed above *and* the Gimletlet (when the NIC
+//! daughterboard is installed)
+//!
+//! ### `humility net status`
+//! This subcommand shows the status of the management network links.  It is
+//! only functional on the fully supported boards listed above.
+//!
+//! ### `humility net counters`
+//! This subcommand shows the internal counters on the management network links.
+//! It is only functional on the fully supported boards listed above.  In
+//! addition, the MAC-side counters are only supported on the VSC8562, not the
+//! VSC8552; this is indicated with `--` in the relevant table positions.
 use std::collections::BTreeMap;
 
 use anyhow::{bail, Context, Result};
@@ -272,7 +306,7 @@ fn net_status(
         "|".dimmed(),
         "SP".bold(),
         "KSZ8463".bold(),
-        "VSC8552".bold()
+        "VSC85x2".bold()
     );
     println!(
         "     RMII {}           {} 2 <----------> 1 {}         {} 1 <------>",
@@ -378,7 +412,7 @@ fn net_counters(
     println!(" -------------------------------------------------------");
     println!(
         " |     {}     |     Transmit    |     Receive     |",
-        "VSC85x2".bold()
+        if v_mac_valid { "VSC8562" } else { "VSC8552" }.bold()
     );
     println!(" |                 |  Good  |   Bad  |  Good  |   Bad  |");
     println!(" |-----------------------------------------------------|");

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -1,0 +1,188 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Context, Result};
+use clap::{Command as ClapCommand, CommandFactory, Parser};
+use colored::Colorize;
+
+use humility::core::Core;
+use humility::hubris::*;
+use humility::reflect::*;
+use humility_cmd::hiffy::HiffyContext;
+use humility_cmd::idol::IdolOperation;
+use humility_cmd::{Archive, Attach, Command, Run, Validate};
+
+#[derive(Parser, Debug)]
+enum NetCommand {
+    /// Dump the KSZ8463's MAC table
+    Mac,
+}
+
+#[derive(Parser, Debug)]
+#[clap(name = "monorail", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct NetArgs {
+    /// sets timeout
+    #[clap(
+        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        parse(try_from_str = parse_int::parse)
+    )]
+    timeout: u32,
+
+    #[clap(subcommand)]
+    cmd: NetCommand,
+}
+
+fn net_mac_table(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    context: &mut HiffyContext,
+) -> Result<()> {
+    let op_mac_count =
+        IdolOperation::new(hubris, "Net", "read_ksz8463_mac_count", None)
+            .context(
+                "Could not find `read_ksz8463_mac_count`, \
+                  is your Hubris archive new enough?",
+            )?;
+
+    // We need to make two HIF calls:
+    // - Read the number of entries in the MAC table
+    // - Loop over the table that many times, reading entries
+    let value = humility_cmd_hiffy::hiffy_call(
+        hubris,
+        core,
+        context,
+        &op_mac_count,
+        &[],
+    )?;
+    let mac_count = match value {
+        Ok(v) => {
+            if let Value::Base(Base::U32(v)) = v {
+                v
+            } else {
+                bail!("Got bad reflected value: expected U32, got {:?}", v);
+            }
+        }
+        Err(e) => {
+            bail!("Got error: {}", e);
+        }
+    };
+
+    // Due to HIF limitations (lack of Expand16 / Collect16), we're going to
+    // limit ourselves to 255 MAC table entries.
+    let (mac_count, clipped) = if mac_count > u8::MAX as u32 {
+        (u8::MAX, true)
+    } else {
+        (mac_count as u8, false)
+    };
+
+    println!("Reading {} MAC addresses...", mac_count);
+
+    let op = IdolOperation::new(hubris, "Net", "read_ksz8463_mac", None)?;
+    let funcs = context.functions()?;
+    let send = funcs.get("Send", 4)?;
+
+    use hif::*;
+    let label = Target(0);
+
+    let ops = vec![
+        Op::Push32(op.task.task()),
+        Op::Push16(op.code),
+        Op::Push(0), // LSB of u16
+        Op::Push(0), // Dumy counter byte
+        Op::Label(label),
+        // BEGIN LOOP
+        Op::Drop,
+        Op::Push(0), // MSB of u16
+        Op::Push(2), // Payload length
+        Op::Push(8), // Return size
+        Op::Call(send.id),
+        Op::DropN(3), // Drop everything until the LSB
+        // Loop iteration is now at the top of the stack
+        Op::Push(1), // Prepare to increment
+        Op::Add,     // i = i + 1
+        Op::Push(mac_count),
+        Op::BranchGreaterThan(label),
+        // END LOOP
+        Op::DropN(3),
+        Op::Done,
+    ];
+
+    let results = context.run(core, ops.as_slice(), None)?;
+    let results = results
+        .into_iter()
+        .map(move |r| humility_cmd_hiffy::hiffy_decode(hubris, &op, r))
+        .collect::<Result<Vec<Result<_, _>>>>()?;
+
+    let mut mac_table: BTreeMap<u16, Vec<[u8; 6]>> = BTreeMap::new();
+    for r in results {
+        if let Ok(r) = r {
+            let s = r.as_struct()?;
+            assert_eq!(s.name(), "KszMacTableEntry");
+            let port = s["port"].as_base().unwrap().as_u16().unwrap();
+            let mut mac = [0; 6];
+            for (i, m) in s["mac"].as_array().unwrap().iter().enumerate() {
+                mac[i] = m.as_base().unwrap().as_u8().unwrap()
+            }
+            if mac == [0; 6] && port == 0xFFFF {
+                println!("Skipping empty MAC address");
+            } else {
+                mac_table.entry(port).or_default().push(mac);
+            }
+        } else {
+            // Log the error but keep going for other entries in the table
+            println!("Got error result: {:?}", r);
+        }
+    }
+    println!(" {} |        {}", "PORT".bold(), "MAC".bold());
+    println!("------|-------------------");
+    for (port, macs) in &mac_table {
+        for (i, mac) in macs.iter().enumerate() {
+            if i == 0 {
+                print!("{:>5} | ", port);
+            } else {
+                print!("      | ");
+            }
+            for (i, m) in mac.iter().enumerate() {
+                if i > 0 {
+                    print!(":");
+                }
+                print!("{:02x}", m);
+            }
+            println!();
+        }
+    }
+    if clipped {
+        println!(" ...  | ...");
+    }
+
+    Ok(())
+}
+
+fn net(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    subargs: &[String],
+) -> Result<()> {
+    let subargs = NetArgs::try_parse_from(subargs)?;
+    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    match subargs.cmd {
+        NetCommand::Mac => net_mac_table(hubris, core, &mut context)?,
+    }
+    Ok(())
+}
+
+pub fn init() -> (Command, ClapCommand<'static>) {
+    (
+        Command::Attached {
+            name: "net",
+            archive: Archive::Required,
+            attach: Attach::LiveOnly,
+            validate: Validate::Booted,
+            run: Run::Subargs(net),
+        },
+        NetArgs::command(),
+    )
+}

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -132,7 +132,7 @@ fn net_mac_table(
         (mac_count as u8, false)
     };
 
-    println!("Reading {} MAC addresses...", mac_count);
+    humility::msg!("Reading {} MAC addresses...", mac_count);
 
     let op = IdolOperation::new(hubris, "Net", "read_ksz8463_mac", None)?;
     let funcs = context.functions()?;
@@ -181,13 +181,13 @@ fn net_mac_table(
                 mac[i] = m.as_base().unwrap().as_u8().unwrap()
             }
             if mac == [0; 6] && port == 0xFFFF {
-                println!("Skipping empty MAC address");
+                humility::msg!("Skipping empty MAC address");
             } else {
                 mac_table.entry(port).or_default().push(mac);
             }
         } else {
             // Log the error but keep going for other entries in the table
-            println!("Got error result: {:?}", r);
+            humility::msg!("Got error result: {:?}", r);
         }
     }
     println!(" {} |        {}", "PORT".bold(), "MAC".bold());

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -310,6 +310,45 @@ fn net_counters(
     let s = v.as_struct()?;
     assert_eq!(s.name(), "ManagementCounters");
 
+    let k_tx = s["ksz8463_tx"].as_array()?;
+    let k_rx = s["ksz8463_rx"].as_array()?;
+    let value = |k: &Struct, s: &str| {
+        let k = k[s].as_base().unwrap().as_u32().unwrap();
+        format!("{:>6}", k)
+    };
+    println!(
+        " -------------------------------------------------------------------"
+    );
+    println!(
+        " |  {}  |         Transmit         |         Receive          |",
+        "KSZ8463".bold(),
+    );
+    println!(
+        " |           |   UC   |   BC   |   MC   |   UC   |   BC   |   MC   |"
+    );
+    println!(
+        " |-----------|--------|--------|--------|--------|--------|--------|"
+    );
+    for i in 0..3 {
+        let k_tx = k_tx[i].as_struct()?;
+        let k_rx = k_rx[i].as_struct()?;
+        println!(
+            " | Port {}    | {} | {} | {} | {} | {} | {} |",
+            i + 1,
+            value(k_tx, "unicast"),
+            value(k_tx, "broadcast"),
+            value(k_tx, "multicast"),
+            value(k_rx, "unicast"),
+            value(k_rx, "broadcast"),
+            value(k_rx, "multicast"),
+        );
+    }
+    println!(
+        " -------------------------------------------------------------------"
+    );
+
+    println!();
+
     let v_tx = s["vsc85x2_tx"].as_array()?;
     let v_rx = s["vsc85x2_rx"].as_array()?;
     let v_mac_valid = s["vsc85x2_mac_valid"].as_base()?.as_bool().unwrap();
@@ -362,45 +401,6 @@ fn net_counters(
         );
     }
     println!(" -------------------------------------------------------");
-
-    println!();
-
-    let k_tx = s["ksz8463_tx"].as_array()?;
-    let k_rx = s["ksz8463_rx"].as_array()?;
-    let value = |k: &Struct, s: &str| {
-        let k = k[s].as_base().unwrap().as_u32().unwrap();
-        format!("{:>6}", k)
-    };
-    println!(
-        " -------------------------------------------------------------------"
-    );
-    println!(
-        " |  {}  |         Transmit         |         Receive          |",
-        "KSZ8463".bold(),
-    );
-    println!(
-        " |           |   UC   |   BC   |   MC   |   UC   |   BC   |   MC   |"
-    );
-    println!(
-        " |-----------|--------|--------|--------|--------|--------|--------|"
-    );
-    for i in 0..3 {
-        let k_tx = k_tx[i].as_struct()?;
-        let k_rx = k_rx[i].as_struct()?;
-        println!(
-            " | Port {}    | {} | {} | {} | {} | {} | {} |",
-            i + 1,
-            value(k_tx, "unicast"),
-            value(k_tx, "broadcast"),
-            value(k_tx, "multicast"),
-            value(k_rx, "unicast"),
-            value(k_rx, "broadcast"),
-            value(k_rx, "multicast"),
-        );
-    }
-    println!(
-        " -------------------------------------------------------------------"
-    );
 
     Ok(())
 }

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -314,7 +314,16 @@ fn net_counters(
     let k_rx = s["ksz8463_rx"].as_array()?;
     let value = |k: &Struct, s: &str| {
         let k = k[s].as_base().unwrap().as_u32().unwrap();
-        format!("{:>6}", k)
+        let out = format!("{:>6}", k);
+        if k > 0 {
+            if s.contains("ERR") {
+                out.red()
+            } else {
+                out.green()
+            }
+        } else {
+            out.normal()
+        }
     };
     println!(
         " -------------------------------------------------------------------"

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.6
+humility 0.8.7
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.6
+humility 0.8.7
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.6
+humility 0.8.7
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.6
+humility 0.8.7
 
 ```


### PR DESCRIPTION
The `net` subcommand allows for management and debugging of the _client side_ of the management network, i.e. the KSZ8463 + VSC85x2 which is common across all boards.

Depends on [hubris#709](https://github.com/oxidecomputer/hubris/pull/709)

# Todo
- [x] Bump version
- [x] Write some docs