### PR TITLE
"humility qspi" can fail in vexing ways

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.9"
+version = "0.8.10"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.9
+humility 0.8.10
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.9
+humility 0.8.10
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.9
+humility 0.8.10
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.9
+humility 0.8.10
 
 ```


### PR DESCRIPTION
Draft commit message:

```
This fixes a variety of failure modes in "humility qspi", and more
generally misbehaving HIF consumers.

Prior to this work, attempting to serialize more HIF than can fit in
the target text would yield the terse failure "The serialize buffer is
full"; with this work, a much clearer more verbose error message is
generated that indicates clearly that the programmer has attempted to
stuff in more HIF than will fit.

In "humility qspi" itself, there were quite a few other failure modes
that would only crop up when flashing large images (32MB) that would
only induce failure (e.g., due to the SP being mux'ed out), including
return stack overflows and HIF stack overflows.
```