### PR TITLE
Add support for auxiliary flash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "log",
  "parse_int",
  "regex",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc)",
  "vsc7448-info",
  "vsc7448-types",
  "zip",
@@ -1624,7 +1625,7 @@ dependencies = [
  "indicatif",
  "log",
  "parse_int",
- "tlvc",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=string-pieces)",
  "tlvc-text",
  "zerocopy",
 ]
@@ -2914,13 +2915,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tlvc"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/tlvc#4287f4b7cecb42617342f913dbd8ced40eb79646"
+dependencies = [
+ "byteorder",
+ "crc",
+ "zerocopy",
+]
+
+[[package]]
 name = "tlvc-text"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/tlvc?branch=string-pieces#0eb87b67bd7621de0900b624d55b71281ea289cf"
 dependencies = [
  "ron 0.8.0",
  "serde",
- "tlvc",
+ "tlvc 0.1.0 (git+https://github.com/oxidecomputer/tlvc?branch=string-pieces)",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
  "humility-cmd-hiffy",
  "humility-core",
  "idol",
+ "indicatif",
  "log",
  "parse_int",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1116,6 +1116,7 @@ dependencies = [
  "clap",
  "goblin",
  "humility-cmd",
+ "humility-cmd-auxflash",
  "humility-core",
  "humility-cortex",
  "ihex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "regex",
  "vsc7448-info",
  "vsc7448-types",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "hif",
  "humility-cmd",
  "humility-cmd-apptable",
+ "humility-cmd-auxflash",
  "humility-cmd-dashboard",
  "humility-cmd-debugmailbox",
  "humility-cmd-diagnose",
@@ -973,6 +974,25 @@ dependencies = [
  "clap",
  "humility-cmd",
  "humility-core",
+]
+
+[[package]]
+name = "humility-cmd-auxflash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "hif",
+ "humility-cmd",
+ "humility-cmd-hiffy",
+ "humility-core",
+ "idol",
+ "log",
+ "parse_int",
+ "regex",
+ "vsc7448-info",
+ "vsc7448-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.11"
+version = "0.8.12"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "humility-cmd",
     "humility-arch-cortex",
     "cmd/apptable",
+    "cmd/auxflash",
     "cmd/dashboard",
     "cmd/debugmailbox",
     "cmd/diagnose",
@@ -94,6 +95,7 @@ humility = { path = "./humility-core", package = "humility-core" }
 humility-cortex = { path = "./humility-arch-cortex" }
 humility-cmd = { path = "./humility-cmd" }
 cmd-apptable = { path = "./cmd/apptable", package = "humility-cmd-apptable" }
+cmd-auxflash = { path = "./cmd/auxflash", package = "humility-cmd-auxflash" }
 cmd-dashboard = { path = "./cmd/dashboard", package = "humility-cmd-dashboard" }
 cmd-diagnose = { path = "./cmd/diagnose", package = "humility-cmd-diagnose" }
 cmd-debugmailbox = { path = "./cmd/debugmailbox", package = "humility-cmd-debugmailbox" }

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ a specified target.  (In the above example, one could execute `humility
 ## Commands
 
 - [humility apptable](#humility-apptable): print Hubris apptable
+- [humility auxflash](#humility-auxflash): manipulate auxiliary flash
 - [humility dashboard](#humility-dashboard): dashboard for Hubris sensor data
 - [humility debugmailbox](#humility-debugmailbox): interact with the debug mailbox on the LPC55
 - [humility diagnose](#humility-diagnose): analyze a system to detect common problems
@@ -271,6 +272,14 @@ This is a deprecated command that allows for the display of the app table
 found in old Hubris archives; see `humility manifest` to understand
 the contents of an archive.
 
+
+
+### `humility auxflash`
+
+Tools to interact with the auxiliary flash, described in RFD 311.
+
+This subcommand should be rarely used; `humility flash` will automatically
+program auxiliary flash when needed.
 
 
 ### `humility dashboard`
@@ -545,6 +554,10 @@ used.  That said, OpenOCD should generally be discouraged; the disposition
 is to extend probe-rs to support any parts that must be flashed via
 OpenOCD.
 
+If the specified archive includes auxiliary flash data and the new image
+includes a task with the `AuxFlash` API, two slots of auxiliary flash
+will be programmed after the image is written.  See RFD 311 for more
+information about auxiliary flash management.
 
 
 ### `humility gdb`

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -12,6 +12,7 @@ indicatif = "0.15"
 log = {version = "0.4.8", features = ["std"]}
 parse_int = "0.4.0"
 regex = "1.5"
+zip = "0.5"
 
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cmd = { path = "../../humility-cmd" }

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -8,6 +8,7 @@ description = "manipulate auxiliary flash"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 colored = "2.0.0"
+indicatif = "0.15"
 log = {version = "0.4.8", features = ["std"]}
 parse_int = "0.4.0"
 regex = "1.5"

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -20,5 +20,6 @@ humility-cmd-hiffy = { path = "../hiffy" }
 
 hif = { git = "https://github.com/oxidecomputer/hif" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
 vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
 vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "humility-cmd-auxflash"
+version = "0.1.0"
+edition = "2021"
+description = "manipulate auxiliary flash"
+
+[dependencies]
+anyhow = { version = "1.0.44", features = ["backtrace"] }
+clap = { version = "3.0.12", features = ["derive", "env"] }
+colored = "2.0.0"
+log = {version = "0.4.8", features = ["std"]}
+parse_int = "0.4.0"
+regex = "1.5"
+
+humility = { path = "../../humility-core", package = "humility-core" }
+humility-cmd = { path = "../../humility-cmd" }
+humility-cmd-hiffy = { path = "../hiffy" }
+
+hif = { git = "https://github.com/oxidecomputer/hif" }
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -1,0 +1,147 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility auxflash`
+//!
+//! Tools to interact with the auxiliary flash.
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::{Command as ClapCommand, CommandFactory, Parser};
+use colored::Colorize;
+
+use humility::core::Core;
+use humility::hubris::*;
+use humility::reflect::*;
+use humility_cmd::hiffy::HiffyContext;
+use humility_cmd::idol::IdolArgument;
+use humility_cmd::idol::IdolOperation;
+use humility_cmd::{Archive, Attach, Command, Run, Validate};
+
+#[derive(Parser, Debug)]
+#[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct AuxFlashArgs {
+    /// sets timeout
+    #[clap(
+        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        parse(try_from_str = parse_int::parse)
+    )]
+    timeout: u32,
+
+    #[clap(subcommand)]
+    cmd: AuxFlashCommand,
+}
+
+#[derive(Parser, Debug)]
+enum AuxFlashCommand {
+    /// Prints the auxiliary flash status
+    Status,
+}
+
+fn slot_count(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    context: &mut HiffyContext,
+) -> Result<u32> {
+    let op = IdolOperation::new(hubris, "AuxFlash", "slot_count", None)
+        .context(
+            "Could not find `AuxFlash.slot_count`, \
+             is your Hubris archive new enough?",
+        )?;
+    let value =
+        humility_cmd_hiffy::hiffy_call(hubris, core, context, &op, &[], None)?;
+    let v = match value {
+        Ok(v) => v,
+        Err(e) => bail!("Got Hiffy error: {}", e),
+    };
+    let v = v.as_base()?;
+    v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))
+}
+
+fn slot_status(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    context: &mut HiffyContext,
+    slot: u32,
+) -> Result<[u8; 32]> {
+    let op = IdolOperation::new(hubris, "AuxFlash", "read_slot_chck", None)
+        .context(
+            "Could not find `AuxFlash.slot_count`, \
+             is your Hubris archive new enough?",
+        )?;
+    let value = humility_cmd_hiffy::hiffy_call(
+        hubris,
+        core,
+        context,
+        &op,
+        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+        None,
+    )?;
+    let v = match value {
+        Ok(v) => v,
+        Err(e) => bail!("{}", e),
+    };
+    let v = v.as_struct()?;
+    assert_eq!(v.name(), "AuxFlashChecksum");
+    let array = v["__0"].as_array().unwrap();
+    assert_eq!(array.len(), 32);
+    let mut out = [0u8; 32];
+    for (o, v) in out
+        .iter_mut()
+        .zip(array.iter().map(|i| i.as_base().unwrap().as_u8().unwrap()))
+    {
+        *o = v;
+    }
+
+    Ok(out)
+}
+
+fn auxflash_status(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    context: &mut HiffyContext,
+) -> Result<()> {
+    let slot_count = slot_count(hubris, core, context)?;
+    println!("slot | status");
+    println!("-----|--------------------");
+    for i in 0..slot_count {
+        print!(" {:3>} |", i);
+        match slot_status(hubris, core, context, i) {
+            Err(e) => print!("{:?}", e),
+            Ok(v) => {
+                for byte in v {
+                    print!("{:0>2x}", byte);
+                }
+            }
+        }
+        println!();
+    }
+    Ok(())
+}
+
+fn auxflash(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    subargs: &[String],
+) -> Result<()> {
+    let subargs = AuxFlashArgs::try_parse_from(subargs)?;
+    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    match subargs.cmd {
+        AuxFlashCommand::Status => auxflash_status(hubris, core, &mut context)?,
+    }
+    Ok(())
+}
+
+pub fn init() -> (Command, ClapCommand<'static>) {
+    (
+        Command::Attached {
+            name: "auxflash",
+            archive: Archive::Required,
+            attach: Attach::LiveOnly,
+            validate: Validate::Booted,
+            run: Run::Subargs(auxflash),
+        },
+        AuxFlashArgs::command(),
+    )
+}

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -302,7 +302,7 @@ impl<'a> AuxFlashHandler<'a> {
             }
         }
 
-        humility::msg!("Erasing slot {}", slot);
+        humility::msg!("erasing slot {}", slot);
         self.slot_erase(slot)?;
 
         if data.len() > SLOT_SIZE_BYTES {
@@ -338,6 +338,7 @@ impl<'a> AuxFlashHandler<'a> {
             }
             bar.set_position(offset as u64);
         }
+        humility::msg!("done");
         Ok(())
     }
 

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -19,7 +19,8 @@ use humility_cmd::{Archive, Attach, Command, Run, Validate};
 use humility_cmd_hiffy::HiffyLease;
 
 const SLOT_SIZE_BYTES: usize = 1024 * 1024;
-const SLOT_CHUNK_SIZE_BYTES: usize = 256;
+const READ_CHUNK_SIZE: usize = 256; // limited by HIFFY_SCRATCH_SIZE
+const WRITE_CHUNK_SIZE: usize = 2048; // limited by HIFFY_DATA_SIZE
 
 #[derive(Parser, Debug)]
 #[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -38,13 +39,24 @@ struct AuxFlashArgs {
 #[derive(Parser, Debug)]
 enum AuxFlashCommand {
     /// Prints the auxiliary flash status
-    Status,
+    Status {
+        #[clap(long, short)]
+        verbose: bool,
+    },
     Read {
+        #[clap(long, short)]
         slot: u32,
+        #[clap(long, short)]
         output: String,
+
+        /// Number of bytes to read (defaults to 1M)
+        #[clap(long, short)]
+        count: Option<usize>,
     },
     Write {
+        #[clap(long, short)]
         slot: u32,
+        #[clap(long, short)]
         input: String,
     },
 }
@@ -67,6 +79,31 @@ fn slot_count(
     };
     let v = v.as_base()?;
     v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))
+}
+
+fn slot_erase(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    context: &mut HiffyContext,
+    slot: u32,
+) -> Result<()> {
+    let op = IdolOperation::new(hubris, "AuxFlash", "erase_slot", None)
+        .context(
+            "Could not find `AuxFlash.erase_slot`, \
+             is your Hubris archive new enough?",
+        )?;
+    let value = humility_cmd_hiffy::hiffy_call(
+        hubris,
+        core,
+        context,
+        &op,
+        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+        None,
+    )?;
+    match value {
+        Ok(..) => Ok(()),
+        Err(e) => bail!("Got Hiffy error: {}", e),
+    }
 }
 
 fn slot_status(
@@ -92,9 +129,7 @@ fn slot_status(
         Ok(v) => v,
         Err(e) => bail!("{}", e),
     };
-    let v = v.as_struct()?;
-    assert_eq!(v.name(), "AuxFlashChecksum");
-    let array = v["__0"].as_array().unwrap();
+    let array = v.as_1tuple().unwrap().as_array().unwrap();
     assert_eq!(array.len(), 32);
     let mut out = [0u8; 32];
     for (o, v) in out
@@ -111,24 +146,37 @@ fn auxflash_status(
     hubris: &HubrisArchive,
     core: &mut dyn Core,
     context: &mut HiffyContext,
+    verbose: bool,
 ) -> Result<()> {
     let slot_count = slot_count(hubris, core, context)?;
     println!("slot | status");
-    println!("-----|--------------------");
+    println!("-----|----------------------------");
     for i in 0..slot_count {
-        print!(" {:3>} |", i);
+        print!(" {:>3} | ", i);
         match slot_status(hubris, core, context, i) {
             Err(e) => {
                 let err_str = format!("{:?}", e);
-                print!("{}", err_str.red())
-            }
-            Ok(v) => {
-                for byte in v {
-                    print!("{:0>2x}", byte);
+                // Special-casing for a few known error codes
+                match err_str.as_str() {
+                    "MissingChck" => println!("{}", "Missing CHCK".yellow()),
+                    _ => println!("{}", err_str.red()),
                 }
             }
+            Ok(v) => {
+                print!("{} (", "Checkum match".green());
+                if verbose {
+                    for byte in v {
+                        print!("{:0>2x}", byte);
+                    }
+                } else {
+                    for byte in &v[0..4] {
+                        print!("{:0>2x}", byte);
+                    }
+                    print!("...");
+                }
+                println!(")");
+            }
         }
-        println!();
     }
     Ok(())
 }
@@ -138,6 +186,7 @@ fn auxflash_read(
     core: &mut dyn Core,
     context: &mut HiffyContext,
     slot: u32,
+    count: Option<usize>,
 ) -> Result<Vec<u8>> {
     let op =
         IdolOperation::new(hubris, "AuxFlash", "read_slot_with_offset", None)
@@ -146,15 +195,15 @@ fn auxflash_read(
              is your Hubris archive new enough?",
         )?;
 
-    let mut out = vec![0u8; SLOT_SIZE_BYTES];
+    let mut out = vec![0u8; count.unwrap_or(SLOT_SIZE_BYTES)];
     let bar = ProgressBar::new(0);
     bar.set_style(
         ProgressStyle::default_bar()
             .template("humility: reading [{bar:30}] {bytes}/{total_bytes}"),
     );
-    bar.set_length(SLOT_SIZE_BYTES as u64);
-    for (i, chunk) in out.chunks_mut(SLOT_CHUNK_SIZE_BYTES).enumerate() {
-        let offset = i * SLOT_CHUNK_SIZE_BYTES;
+    bar.set_length(out.len() as u64);
+    for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
+        let offset = i * READ_CHUNK_SIZE;
         let value = humility_cmd_hiffy::hiffy_call(
             hubris,
             core,
@@ -182,6 +231,9 @@ fn auxflash_write(
     slot: u32,
     data: &[u8],
 ) -> Result<()> {
+    humility::msg!("Erasing slot {}", slot);
+    slot_erase(hubris, core, context, slot)?;
+
     if data.len() > SLOT_SIZE_BYTES {
         bail!(
             "Data is too large ({} bytes, slot size is {} bytes)",
@@ -199,11 +251,11 @@ fn auxflash_write(
     let bar = ProgressBar::new(0);
     bar.set_style(
         ProgressStyle::default_bar()
-            .template("humility: reading [{bar:30}] {bytes}/{total_bytes}"),
+            .template("humility: writing [{bar:30}] {bytes}/{total_bytes}"),
     );
     bar.set_length(data.len() as u64);
-    for (i, chunk) in data.chunks(SLOT_CHUNK_SIZE_BYTES).enumerate() {
-        let offset = i * SLOT_CHUNK_SIZE_BYTES;
+    for (i, chunk) in data.chunks(WRITE_CHUNK_SIZE).enumerate() {
+        let offset = i * WRITE_CHUNK_SIZE;
         let value = humility_cmd_hiffy::hiffy_call(
             hubris,
             core,
@@ -231,9 +283,11 @@ fn auxflash(
     let subargs = AuxFlashArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     match subargs.cmd {
-        AuxFlashCommand::Status => auxflash_status(hubris, core, &mut context)?,
-        AuxFlashCommand::Read { slot, output } => {
-            let data = auxflash_read(hubris, core, &mut context, slot)?;
+        AuxFlashCommand::Status { verbose } => {
+            auxflash_status(hubris, core, &mut context, verbose)?;
+        }
+        AuxFlashCommand::Read { slot, output, count } => {
+            let data = auxflash_read(hubris, core, &mut context, slot, count)?;
             std::fs::write(&output, &data)?;
         }
         AuxFlashCommand::Write { slot, input } => {

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -4,7 +4,11 @@
 
 //! ## `humility auxflash`
 //!
-//! Tools to interact with the auxiliary flash.
+//! Tools to interact with the auxiliary flash, described in RFD 311.
+//!
+//! This subcommand should be rarely used; `humility flash` will automatically
+//! program auxiliary flash when needed.
+
 use anyhow::{anyhow, bail, Context, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};
 use colored::Colorize;

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -296,11 +296,12 @@ impl<'a> AuxFlashHandler<'a> {
             Err(zip::result::ZipError::FileNotFound) => {
                 bail!(
                     "Could not find img/auxi.tlvc in the archive. \
-                                 Does this app include auxiliary blobs?"
+                     Does this Hubris app include auxiliary blobs?"
                 );
             }
             Err(e) => bail!("Failed to extract auxi.tlvc: {}", e),
         };
+        humility::log!("Flashing auxi.tlvc from the Hubris archive");
         self.auxflash_write(slot, &data)
     }
 }

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -124,7 +124,7 @@ impl<'a> AuxFlashHandler<'a> {
         )?;
         let v = match value {
             Ok(v) => v,
-            Err(e) if format!("{}", e) == "NoActiveSlot" => {
+            Err(e) if e == "NoActiveSlot" => {
                 return Ok(None);
             }
             Err(e) => bail!("Got Hiffy error: {}", e),
@@ -186,8 +186,7 @@ impl<'a> AuxFlashHandler<'a> {
             print!("  {:>3} | ", i);
             match self.slot_status(i) {
                 Err(e) => {
-                    let err_str = format!("{:?}", e);
-                    println!("Error: {}", err_str.red());
+                    println!("Error: {}", e.to_string().red());
                 }
                 Ok(None) => println!("{}", "Missing checksum".yellow()),
                 Ok(Some(v)) => {

--- a/cmd/flash/Cargo.toml
+++ b/cmd/flash/Cargo.toml
@@ -8,6 +8,7 @@ description = "flash archive onto attached device"
 humility = { path = "../../humility-core", package = "humility-core" }
 humility-cortex = { path = "../../humility-arch-cortex" }
 humility-cmd = { path = "../../humility-cmd" }
+humility-cmd-auxflash = { path = "../auxflash" }
 clap = { version = "3.0.12", features = ["derive", "env"] }
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 parse_int = "0.4.0"

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -107,7 +107,7 @@ fn force_openocd(
     // probe-rs, because we use the resulting ProbeCore to program the
     // auxiliary flash (via hiffy)
     if hubris.read_auxflash_data()?.is_some() {
-        bail!("Cannot program an image with auxiliary flash through OpenOCD");
+        bail!("cannot program an image with auxiliary flash through OpenOCD");
     }
 
     //
@@ -399,20 +399,23 @@ fn flashcmd(
     Ok(())
 }
 
-fn try_program_auxflash(hubris: &HubrisArchive, core: &mut dyn Core) -> Result<()> {
+fn try_program_auxflash(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+) -> Result<()> {
     match hubris.read_auxflash_data()? {
         Some(auxflash) => match program_auxflash(hubris, core, &auxflash) {
             Ok(_) => {
                 humility::msg!("done with auxiliary flash");
                 Ok(())
-            },
+            }
             Err(e) => bail!(
                 "failed to program auxflash: {:?}; \
                  your system may not be functional!",
                 e
             ),
-        }
-        None => Ok(())
+        },
+        None => Ok(()),
     }
 }
 
@@ -433,7 +436,7 @@ fn program_auxflash(
             humility::msg!(
                 "auxiliary flash data is already loaded in slot {}; \
                  skipping programming",
-                 i
+                i
             );
             return Ok(());
         }

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -469,8 +469,14 @@ fn program_auxflash(
 
     worker.auxflash_write(target_slot, data, false)?;
 
-    // After a reset, the application should accept the new slot
+    // After a reset, two things will happen:
+    // - The SP `auxflash` task will automatically mirror from the even slot to
+    //   the odd slot, since the even slot will have valid data and the odd slot
+    //   will not.
+    // - The SP will recognize the programmed slot as valid and choose it as the
+    //   active slot.
     worker.reset()?;
+
     match worker.active_slot() {
         Ok(Some(..)) => Ok(()),
         Ok(None) => bail!("No active auxflash slot, even after programming"),

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -24,7 +24,8 @@
 //!
 //! If the specified archive includes auxiliary flash data and the new image
 //! includes a task with the `AuxFlash` API, two slots of auxiliary flash
-//! will be programmed after the image.
+//! will be programmed after the image is written.  See RFD 311 for more
+//! information about auxiliary flash management.
 
 use anyhow::{bail, Context, Result};
 use clap::Command as ClapCommand;
@@ -394,6 +395,13 @@ fn flashcmd(
 
     core.reset()?;
 
+    // At this point, we can attempt to program the auxiliary flash.  This has
+    // to happen *after* the image is flashed and the core is reset, because it
+    // uses hiffy calls to the `auxflash` task to actually do the programming;
+    // because we have no knowledge of the archive previously flashed onto the
+    // chip, we couldn't do hiffy calls before flashing.
+    //
+    // This is called out in RFD 311 as a weakness of our approach!
     try_program_auxflash(hubris, core)?;
     humility::msg!("flashing done");
     Ok(())

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -22,11 +22,14 @@
 //! is to extend probe-rs to support any parts that must be flashed via
 //! OpenOCD.
 //!
+//! If the specified archive includes auxiliary flash data and the new image
+//! includes a task with the `AuxFlash` API, two slots of auxiliary flash
+//! will be programmed after the image.
 
 use anyhow::{bail, Context, Result};
 use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
-use humility::hubris::*;
+use humility::{core::Core, hubris::*};
 use humility_cmd::{Archive, Args, Command, RunUnattached};
 use path_slash::PathExt;
 use std::io::Write;
@@ -100,6 +103,13 @@ fn force_openocd(
     config: &FlashConfig,
     elf: &[u8],
 ) -> Result<()> {
+    // Images that include auxiliary flash data *must* be programmed through
+    // probe-rs, because we use the resulting ProbeCore to program the
+    // auxiliary flash (via hiffy)
+    if hubris.read_auxflash_data()?.is_some() {
+        bail!("Cannot program an image with auxiliary flash through OpenOCD");
+    }
+
     //
     // We need to attach to (1) confirm that we're plugged into something
     // and (2) extract serial information.
@@ -363,28 +373,99 @@ fn flashcmd(
     //
     if let Err(err) = core.load(ihex_path) {
         core.run()?;
-        Err(err)
-    } else {
-        //
-        // On Gimlet Rev B, the BOOT0 pin is unstrapped -- and during a flash,
-        // it seems to float high enough to bounce the part onto the wrong
-        // image (that is, the BOOT1 image -- which by default is the ST
-        // bootloader).  This seems to only be true when resetting immediately
-        // after flashing the part:  if there is a delay on the order of ~35
-        // milliseconds or more, the BOOT0 pin is seen as low when the part
-        // resets.  Because this delay is (more or less) harmless, we do it on
-        // all platforms, and further make it tunable.
-        //
-        let delay = subargs.reset_delay;
+        return Err(err);
+    }
 
-        if delay != 0 {
-            std::thread::sleep(std::time::Duration::from_millis(delay));
+    //
+    // On Gimlet Rev B, the BOOT0 pin is unstrapped -- and during a flash,
+    // it seems to float high enough to bounce the part onto the wrong
+    // image (that is, the BOOT1 image -- which by default is the ST
+    // bootloader).  This seems to only be true when resetting immediately
+    // after flashing the part:  if there is a delay on the order of ~35
+    // milliseconds or more, the BOOT0 pin is seen as low when the part
+    // resets.  Because this delay is (more or less) harmless, we do it on
+    // all platforms, and further make it tunable.
+    //
+    let delay = subargs.reset_delay;
+
+    if delay != 0 {
+        std::thread::sleep(std::time::Duration::from_millis(delay));
+    }
+
+    core.reset()?;
+
+    try_program_auxflash(hubris, core)?;
+    humility::msg!("flashing done");
+    Ok(())
+}
+
+fn try_program_auxflash(hubris: &HubrisArchive, core: &mut dyn Core) -> Result<()> {
+    match hubris.read_auxflash_data()? {
+        Some(auxflash) => match program_auxflash(hubris, core, &auxflash) {
+            Ok(_) => {
+                humility::msg!("done with auxiliary flash");
+                Ok(())
+            },
+            Err(e) => bail!(
+                "failed to program auxflash: {:?}; \
+                 your system may not be functional!",
+                e
+            ),
         }
+        None => Ok(())
+    }
+}
 
-        core.reset()?;
+fn program_auxflash(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    data: &[u8],
+) -> Result<()> {
+    let mut worker =
+        humility_cmd_auxflash::AuxFlashHandler::new(hubris, core, 5000)?;
 
-        humility::msg!("flashing done");
-        Ok(())
+    // At this point, we've already rebooted into the new image.
+    //
+    // If the Hubris auxflash task has picked up an active slot, then we're all
+    // set: our target image was already loaded (or was unchanged).
+    match worker.active_slot() {
+        Ok(Some(i)) => {
+            humility::msg!(
+                "auxiliary flash data is already loaded in slot {}; \
+                 skipping programming",
+                 i
+            );
+            return Ok(());
+        }
+        Ok(None) => (),
+        Err(e) => {
+            humility::msg!("Got error while checking active slot: {:?}", e);
+        }
+    };
+
+    // Otherwise, we need to pick a slot.  This is tricky, because we don't
+    // actually know whether there's an image on the B partition that's using
+    // auxiliary data.  We'll prioritize picking an empty (even) slot, and will
+    // otherwise pick slot 0 arbitrarily.
+    let slot_count = worker.slot_count()?;
+    let mut target_slot = 0;
+    for i in 0..slot_count {
+        if i % 2 == 0 && matches!(worker.slot_status(i), Ok(None)) {
+            target_slot = i;
+            break;
+        }
+    }
+
+    worker.auxflash_write(target_slot, data, false)?;
+
+    // After a reset, the application should accept the new slot
+    worker.reset()?;
+    match worker.active_slot() {
+        Ok(Some(..)) => Ok(()),
+        Ok(None) => bail!("No active auxflash slot, even after programming"),
+        Err(e) => {
+            bail!("Could not check auxflash slot after programming: {:?}", e)
+        }
     }
 }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4411,6 +4411,26 @@ impl HubrisArchive {
             false
         }
     }
+
+    /// Reads the auxiliary flash data from a Hubris archive
+    ///
+    /// Returns `Ok(Some(...))` if the data is loaded, `Ok(None)` if the file
+    /// is missing, or `Err(...)` if a zip file error occurred.
+    pub fn read_auxflash_data(&self) -> Result<Option<Vec<u8>>> {
+        let archive = self.archive();
+        let cursor = Cursor::new(archive);
+        let mut archive = zip::ZipArchive::new(cursor)?;
+        let file = archive.by_name("img/auxi.tlvc");
+        match file {
+            Ok(mut f) => {
+                let mut buffer = Vec::new();
+                f.read_to_end(&mut buffer)?;
+                Ok(Some(buffer))
+            }
+            Err(zip::result::ZipError::FileNotFound) => Ok(None),
+            Err(e) => bail!("Failed to extract auxi.tlvc: {}", e),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.11
+humility 0.8.12
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.11
+humility 0.8.12
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.11
+humility 0.8.12
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.11
+humility 0.8.12
 
 ```


### PR DESCRIPTION
Proposed commit message:

```
Adds support for auxiliary flash!

This PR adds the `humility auxflash` subcommand, which exposes tools for
reading, writing, and checking the status of an auxiliary flash chip (when
present).

In addition, it modifies `humility flash` to program an auxiliary flash if a
blob is found in the Hubris archive.

This depends on [hubris#754](https://github.com/oxidecomputer/hubris/pull/754/),
which adds the `auxflash` task and modifies our archive packing to include these
blobs (based on the app TOML file).
```

(this should be merged with https://github.com/oxidecomputer/hubris/pull/754 , but is not strictly dependent on it)