### PR TITLE
Bump slot timeout, update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.8.13"
+version = "0.8.14"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -31,7 +31,7 @@ const WRITE_CHUNK_SIZE: usize = 2048; // limited by HIFFY_DATA_SIZE
 struct AuxFlashArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value = "15000", value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -433,7 +433,7 @@ fn program_auxflash(
     data: &[u8],
 ) -> Result<()> {
     let mut worker =
-        humility_cmd_auxflash::AuxFlashHandler::new(hubris, core, 5000)?;
+        humility_cmd_auxflash::AuxFlashHandler::new(hubris, core, 15_000)?;
 
     // At this point, we've already rebooted into the new image.
     //

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.8.13
+humility 0.8.14
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.8.13
+humility 0.8.14
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.8.13
+humility 0.8.14
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.8.13
+humility 0.8.14
 
 ```


### PR DESCRIPTION
https://github.com/oxidecomputer/hubris/pull/782 increases slot size to 2 MiB per the RFD; this requires a longer timeout in Humility.