### PR TITLE
Fix typo in net command name

### DIFF
--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -62,7 +62,7 @@ enum NetCommand {
 }
 
 #[derive(Parser, Debug)]
-#[clap(name = "monorail", about = env!("CARGO_PKG_DESCRIPTION"))]
+#[clap(name = "net", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct NetArgs {
     /// sets timeout
     #[clap(


### PR DESCRIPTION
Before:

```
% humility help
...
    map             print memory map, with association of regions to tasks
    monorail        Management network control and debugging
    monorail        Management network device-side control and debugging
    openocd         Run OpenOCD for the given archive
...
```

After:

```
% humility help
...
    map             print memory map, with association of regions to tasks
    monorail        Management network control and debugging
    net             Management network device-side control and debugging
    openocd         Run OpenOCD for the given archive
...
```