### PR TITLE
Widen `humility tasks` TASK column to 20 chars

### DIFF
--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -263,7 +263,7 @@ fn tasks(context: &mut humility::ExecutionContext) -> Result<()> {
 
         println!("system time = {}", ticks);
 
-        println!("{:2} {:15} {:>8} {:3} {:9}",
+        println!("{:2} {:21} {:>8} {:3} {:9}",
             "ID", "TASK", "GEN", "PRI", "STATE");
 
         let mut any_names_truncated = false;
@@ -293,13 +293,13 @@ fn tasks(context: &mut humility::ExecutionContext) -> Result<()> {
 
             {
                 let mut modname = module.to_string();
-                if modname.len() > 14 {
-                    modname.truncate(14);
+                if modname.len() > 20 {
+                    modname.truncate(20);
                     modname.push('…');
                     any_names_truncated = true;
                 }
                 print!(
-                    "{:2} {:15} {:>8} {:3} ",
+                    "{:2} {:21} {:>8} {:3} ",
                     i,
                     modname,
                     u32::from(task.generation),

--- a/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.stdout
@@ -1,6 +1,6 @@
 system time = 687534
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+66)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+66)
    |
    +--->  0x20017538 0x08065548 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005358 (&TaskDesc)
                 }
 
- 1 net                    0   2 recv, notif: bit0(irq61) bit1(T+21)
+ 1 net                          0   2 recv, notif: bit0(irq61) bit1(T+21)
    |
    +--->  0x200028a8 0x0802e7b4 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005370 (&TaskDesc)
                 }
 
- 2 sys                    0   1 recv
+ 2 sys                          0   1 recv
    |
    +--->  0x2001a350 0x0806a5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005388 (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20017ae8 0x08049c30 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053a0 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x200182e0 0x0804dd58 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -310,7 +310,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053b8 (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 notif: bit2(irq72/irq73)
+ 5 i2c_driver                   0   2 notif: bit2(irq72/irq73)
    |
    +--->  0x20018a30 0x080520d0 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053d0 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x08055f02 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -442,7 +442,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053e8 (&TaskDesc)
                 }
 
- 7 thermal                0   3 wait: send to i2c_driver/gen0
+ 7 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20010498 0x0800a114 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:154
@@ -514,7 +514,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005400 (&TaskDesc)
                 }
 
- 8 power                  0   3 wait: reply from i2c_driver/gen0
+ 8 power                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x20014368 0x0805a220 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:154
@@ -580,7 +580,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005418 (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 notif: bit31(T+6)
+ 9 hiffy                        0   3 notif: bit31(T+6)
    |
    +--->  0x20008140 0x08043672 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -648,7 +648,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005430 (&TaskDesc)
                 }
 
-10 gimlet_seq             0   3 recv
+10 gimlet_seq                   0   3 recv
    |
    +--->  0x200154f0 0x080135a2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -710,7 +710,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005448 (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x200195f8 0x0805d82c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -772,7 +772,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005460 (&TaskDesc)
                 }
 
-12 sensor                 0   3 recv, notif: bit0(T+466)
+12 sensor                       0   3 recv, notif: bit0(T+466)
    |
    +--->  0x20019a88 0x08066bca userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -834,7 +834,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005478 (&TaskDesc)
                 }
 
-13 udpecho                0   3 notif: bit0
+13 udpecho                      0   3 notif: bit0
    |
    +--->  0x20012e08 0x0806157e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -894,7 +894,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005490 (&TaskDesc)
                 }
 
-14 validate               0   3 recv
+14 validate                     0   3 recv
    |
    +--->  0x20016398 0x0806957e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -956,7 +956,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80054a8 (&TaskDesc)
                 }
 
-15 idle                   0   5 RUNNING
+15 idle                         0   5 RUNNING
    |
    +--->  0x2001a500 0x0806a856 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.stdout
@@ -1,6 +1,6 @@
 system time = 2117793075957696
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T-2117793075464596)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T-2117793075464596)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001b5a4   R1 = 0x00000004   R2 = 0x00000003   R3 = 0x2001b5dc
@@ -53,7 +53,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004af0 (&abi::TaskDesc)
                 }
 
- 1 net                    0   5 recv, notif: bit0(irq61) bit1(T-2117793075464456)
+ 1 net                          0   5 recv, notif: bit0(irq61) bit1(T-2117793075464456)
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -109,7 +109,7 @@ Caused by:
                     descriptor: 0x8004b04 (&abi::TaskDesc)
                 }
 
- 2 sys                    0   1 recv
+ 2 sys                          0   1 recv
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001e358   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2001e360
@@ -162,7 +162,7 @@ Caused by:
                     descriptor: 0x8004b18 (&abi::TaskDesc)
                 }
 
- 3 spi4_driver            0   3 recv
+ 3 spi4_driver                  0   3 recv
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -218,7 +218,7 @@ Caused by:
                     descriptor: 0x8004b2c (&abi::TaskDesc)
                 }
 
- 4 spi2_driver            0   3 recv
+ 4 spi2_driver                  0   3 recv
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -274,7 +274,7 @@ Caused by:
                     descriptor: 0x8004b40 (&abi::TaskDesc)
                 }
 
- 5 i2c_driver             0   3 recv
+ 5 i2c_driver                   0   3 recv
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -330,7 +330,7 @@ Caused by:
                     descriptor: 0x8004b54 (&abi::TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20010248 0x0804df76 drv_i2c_api::I2cDevice::write
    |                 @ /hubris/drv/i2c-api/src/lib.rs:453
@@ -386,7 +386,7 @@ Caused by:
                     descriptor: 0x8004b68 (&abi::TaskDesc)
                 }
 
- 7 thermal                0   5 recv, notif: bit0(T-2117793075463689)
+ 7 thermal                      0   5 recv, notif: bit0(T-2117793075463689)
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -442,7 +442,7 @@ Caused by:
                     descriptor: 0x8004b7c (&abi::TaskDesc)
                 }
 
- 8 power                  0   6 notif: bit31(T-2117793075464383)
+ 8 power                        0   6 notif: bit31(T-2117793075464383)
    |
    +--->  0x200163a8 0x0805625a core::result::Result<T,E>::unwrap
    |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/result.rs:1101
@@ -498,7 +498,7 @@ Caused by:
                     descriptor: 0x8004b90 (&abi::TaskDesc)
                 }
 
- 9 hiffy                  0   5 notif: bit31(T-2117793075464596)
+ 9 hiffy                        0   5 notif: bit31(T-2117793075464596)
    stack unwind failed: failed to read cfa 0x80010007, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -554,7 +554,7 @@ Caused by:
                     descriptor: 0x8004ba4 (&abi::TaskDesc)
                 }
 
-10 gimlet_seq             0   4 recv, notif: bit0
+10 gimlet_seq                   0   4 recv, notif: bit0
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: []
 
 Caused by:
@@ -610,7 +610,7 @@ Caused by:
                     descriptor: 0x8004bb8 (&abi::TaskDesc)
                 }
 
-11 hash_driver            0   2 recv
+11 hash_driver                  0   2 recv
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x20018540   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200187d4
@@ -663,7 +663,7 @@ Caused by:
                     descriptor: 0x8004bcc (&abi::TaskDesc)
                 }
 
-12 hf                     0   3 recv
+12 hf                           0   3 recv
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001d5f8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2001d734
@@ -716,7 +716,7 @@ Caused by:
                     descriptor: 0x8004be0 (&abi::TaskDesc)
                 }
 
-13 sensor                 0   4 recv, notif: bit0(T-2117793075463696)
+13 sensor                       0   4 recv, notif: bit0(T-2117793075463696)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001df68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x2001dd00
@@ -769,7 +769,7 @@ Caused by:
                     descriptor: 0x8004bf4 (&abi::TaskDesc)
                 }
 
-14 udpecho                0   6 notif: bit0
+14 udpecho                      0   6 notif: bit0
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x08063c50   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20014fbc
@@ -822,7 +822,7 @@ Caused by:
                     descriptor: 0x8004c08 (&abi::TaskDesc)
                 }
 
-15 udpbroadcast           0   6 notif: bit31(T-2117793075464287)
+15 udpbroadcast                 0   6 notif: bit31(T-2117793075464287)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x080652ac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200197ac
@@ -875,7 +875,7 @@ Caused by:
                     descriptor: 0x8004c1c (&abi::TaskDesc)
                 }
 
-16 validate               0   5 recv
+16 validate                     0   5 recv
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001a3b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2001a3b8
@@ -928,7 +928,7 @@ Caused by:
                     descriptor: 0x8004c30 (&abi::TaskDesc)
                 }
 
-17 idle                   0   7 ready
+17 idle                         0   7 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x2001e500   R1 = 0x2001e500   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.stdout
@@ -1,6 +1,6 @@
 system time = 972988
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+12)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+12)
    |
    +--->  0x2001b530 0x0806561c userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f70 (&abi::TaskDesc)
                 }
 
- 1 net                    0   5 recv, notif: bit0(irq61) bit1(T+18)
+ 1 net                          0   5 recv, notif: bit0(irq61) bit1(T+18)
    |
    +--->  0x20004b58 0x08030666 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f84 (&abi::TaskDesc)
                 }
 
- 2 sys                    0   1 recv
+ 2 sys                          0   1 recv
    |
    +--->  0x2001e330 0x0806c6dc userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
- 3 spi4_driver            0   3 recv
+ 3 spi4_driver                  0   3 recv
    |
    +--->  0x2001bb08 0x08041ff2 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fac (&abi::TaskDesc)
                 }
 
- 4 spi2_driver            0   3 recv
+ 4 spi2_driver                  0   3 recv
    |
    +--->  0x2001c300 0x08046126 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -310,7 +310,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc0 (&abi::TaskDesc)
                 }
 
- 5 i2c_driver             0   3 recv
+ 5 i2c_driver                   0   3 recv
    |
    +--->  0x2001ca48 0x0804a5ca userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -376,7 +376,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fd4 (&abi::TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20010258 0x0804e610 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -444,7 +444,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe8 (&abi::TaskDesc)
                 }
 
- 7 thermal                0   5 recv, notif: bit0(T+879)
+ 7 thermal                      0   5 recv, notif: bit0(T+879)
    |
    +--->  0x200025b8 0x0805279c userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ffc (&abi::TaskDesc)
                 }
 
- 8 power                  0   6 notif: bit31(T+174)
+ 8 power                        0   6 notif: bit31(T+174)
    |
    +--->  0x200163c0 0x08056844 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -570,7 +570,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005010 (&abi::TaskDesc)
                 }
 
- 9 hiffy                  0   5 notif: bit31(T+143)
+ 9 hiffy                        0   5 notif: bit31(T+143)
    |
    +--->  0x20008200 0x0800bfd0 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
-10 gimlet_seq             0   4 recv, notif: bit0
+10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x200174d8 0x08013de0 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -700,7 +700,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005038 (&abi::TaskDesc)
                 }
 
-11 hash_driver            0   2 recv
+11 hash_driver                  0   2 recv
    |
    +--->  0x20018530 0x08059994 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -762,7 +762,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800504c (&abi::TaskDesc)
                 }
 
-12 hf                     0   3 recv
+12 hf                           0   3 recv
    |
    +--->  0x2001d5d8 0x0805df82 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -824,7 +824,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005060 (&abi::TaskDesc)
                 }
 
-13 sensor                 0   4 recv, notif: bit0(T+12)
+13 sensor                       0   4 recv, notif: bit0(T+12)
    |
    +--->  0x2001da88 0x080670ec userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -886,7 +886,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005074 (&abi::TaskDesc)
                 }
 
-14 udpecho                0   6 notif: bit0
+14 udpecho                      0   6 notif: bit0
    |
    +--->  0x20014e00 0x080697a0 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -948,7 +948,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005088 (&abi::TaskDesc)
                 }
 
-15 udpbroadcast           0   6 notif: bit31(T+454)
+15 udpbroadcast                 0   6 notif: bit31(T+454)
    |
    +--->  0x20019770 0x0806b20c userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -1010,7 +1010,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800509c (&abi::TaskDesc)
                 }
 
-16 validate               0   5 recv
+16 validate                     0   5 recv
    |
    +--->  0x2001a3b0 0x08061a78 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:334
@@ -1072,7 +1072,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050b0 (&abi::TaskDesc)
                 }
 
-17 idle                   0   7 RUNNING
+17 idle                         0   7 RUNNING
    |
    +--->  0x2001e500 0x0806c850 cortex_m::asm::inline::__nop
    |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:118

--- a/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.stdout
@@ -1,6 +1,6 @@
 system time = 10001
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+99)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+99)
    |
    +--->  0x20001d38 0x0800754c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80051b8 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20001750 0x0804a5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80051d0 (&TaskDesc)
                 }
 
- 2 i2c_driver             0   2 recv
+ 2 i2c_driver                   0   2 recv
    |
    +--->  0x200102f0 0x080197e8 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80051e8 (&TaskDesc)
                 }
 
- 3 spi_driver             0   2 recv
+ 3 spi_driver                   0   2 recv
    |
    +--->  0x20010af0 0x0801dc30 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005200 (&TaskDesc)
                 }
 
- 4 net                    0   2 recv, notif: bit0(irq61) bit1
+ 4 net                          0   2 recv, notif: bit0(irq61) bit1
    |
    +--->  0x20002908 0x08029cac userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005218 (&TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x20011348 0x0804ab50 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -376,7 +376,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005230 (&TaskDesc)
                 }
 
- 6 ping               10301   4 wait: reply from pong/gen0
+ 6 ping                     10301   4 wait: reply from pong/gen0
    |
    +--->  0x20011740 0x08044a90 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:154
@@ -434,7 +434,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005248 (&TaskDesc)
                 }
 
- 7 pong                   0   3 RUNNING
+ 7 pong                         0   3 RUNNING
    |
    +--->  0x20011b38 0x08005d98 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -496,7 +496,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005260 (&TaskDesc)
                 }
 
- 8 udpecho                0   3 notif: bit0
+ 8 udpecho                      0   3 notif: bit0
    |
    +--->  0x20004e08 0x0800957e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -556,7 +556,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005278 (&TaskDesc)
                 }
 
- 9 hiffy                  0   5 ready
+ 9 hiffy                        0   5 ready
    |
    +--->  0x20008800 0x08010001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -612,7 +612,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005290 (&TaskDesc)
                 }
 
-10 hf                     0   4 notif: bit31(T+22)
+10 hf                           0   4 notif: bit31(T+22)
    |
    +--->  0x20006608 0x08041b80 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -676,7 +676,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052a8 (&TaskDesc)
                 }
 
-11 hash_driver            0   3 recv
+11 hash_driver                  0   3 recv
    |
    +--->  0x20007528 0x080475c2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -738,7 +738,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052c0 (&TaskDesc)
                 }
 
-12 idle                   0   6 ready
+12 idle                         0   6 ready
    |
    +--->  0x20011f00 0x08005a01 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -794,7 +794,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052d8 (&TaskDesc)
                 }
 
-13 rng_driver             0   3 recv
+13 rng_driver                   0   3 recv
    |
    +--->  0x20011cc0 0x08048e7e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
@@ -1,3 +1,3 @@
 system time = 120445
-ID TASK                 GEN PRI STATE    
- 0 runner                 0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 runner                       0   0 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
@@ -1,6 +1,6 @@
 system time = 256368
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bac (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bc4 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bdc (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,4 +192,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bf4 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.stdout
@@ -1,6 +1,6 @@
 system time = 12256713
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+87)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bc8 0x08048d6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 3 spi4_driver            8   2 FAULT: in syscall: bad caller lease index (was: ready)
+ 3 spi4_driver                  8   2 FAULT: in syscall: bad caller lease index (was: ready)
    |
    +--->  0x20001338 0x080358d0 userlib::sys_borrow_info_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:608
@@ -263,7 +263,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20012360 0x080399f8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -325,7 +325,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -391,7 +391,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -453,7 +453,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 7 thermal                0   3 notif: bit31(T+708)
+ 7 thermal                      0   3 notif: bit31(T+708)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -517,7 +517,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 wait: reply from spi4_driver/gen8
+ 8 hiffy                        0   3 wait: reply from spi4_driver/gen8
    |
    +--->  0x20008110 0x0800b6ba userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -581,7 +581,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077dc (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 notif: bit31(T+8)
+ 9 gimlet_seq                   0   3 notif: bit31(T+8)
    |
    +--->  0x20010288 0x08023222 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -645,7 +645,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077f4 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20014690 0x08045680 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -707,7 +707,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800780c (&TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20015100 0x0804c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.stdout
@@ -1,6 +1,6 @@
 system time = 1791860
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+40)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+40)
    |
    +--->  0x20004540 0x0801147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800770c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007724 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800773c (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007754 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800776c (&TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20001360 0x08019960 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007784 (&TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -444,7 +444,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800779c (&TaskDesc)
                 }
 
- 7 pong                   0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
+ 7 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -507,7 +507,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077b4 (&TaskDesc)
                 }
 
- 8 ping               14190   4 wait: send to pong/gen0
+ 8 ping                     14190   4 wait: send to pong/gen0
    |
    +--->  0x200065b0 0x0802ae84 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -565,7 +565,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077cc (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 notif: bit31(T+140)
+ 9 hiffy                        0   3 notif: bit31(T+140)
    |
    +--->  0x20008540 0x0800b2e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -633,7 +633,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077e4 (&TaskDesc)
                 }
 
-10 hf                     0   3 notif: bit31(T+151)
+10 hf                           0   3 notif: bit31(T+151)
    |
    +--->  0x20002648 0x0801d718 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -697,7 +697,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077fc (&TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20006700 0x0802c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.stdout
@@ -1,6 +1,6 @@
 system time = 505162
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+38)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+38)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bd8 0x08048d72 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 RUNNING
+ 4 spi2_driver                  0   2 RUNNING
    |
    +--->  0x200122d8 0x080381c4 ringbuf::Ringbuf<T,_>::entry
    |                 @ /home/bmc/hubris/lib/ringbuf/src/lib.rs:249
@@ -316,7 +316,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -444,7 +444,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 7 thermal                0   3 notif: bit31(T+444)
+ 7 thermal                      0   3 notif: bit31(T+444)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -508,7 +508,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 wait: reply from gimlet_seq/gen0
+ 8 hiffy                        0   3 wait: reply from gimlet_seq/gen0
    |
    +--->  0x20008110 0x0800b696 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -572,7 +572,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077dc (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20010220 0x08023636 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -644,7 +644,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077f4 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20014698 0x080456fc userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -706,7 +706,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800780c (&TaskDesc)
                 }
 
-11 idle                   0   5 ready
+11 idle                         0   5 ready
    |
    +--->  0x20015100 0x0804c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.stdout
@@ -1,6 +1,6 @@
 system time = 2823724
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+76)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bd8 0x08048d72 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 6 spd                    0   2 RUNNING
+ 6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 7 thermal                0   3 ready
+ 7 thermal                      0   3 ready
    |
    +--->  0x200026f0 0x08013522 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -502,7 +502,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 ready
+ 8 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -570,7 +570,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077dc (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 recv
+ 9 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x08023576 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -632,7 +632,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077f4 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20014698 0x080456fc userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -694,7 +694,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800780c (&TaskDesc)
                 }
 
-11 idle                   0   5 ready
+11 idle                         0   5 ready
    |
    +--->  0x20015100 0x0804c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.stdout
@@ -1,6 +1,6 @@
 system time = 56031
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+69)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+69)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800775c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007774 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800778c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077a4 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077bc (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077d4 (&TaskDesc)
                 }
 
- 6 spd                    0   2 RUNNING
+ 6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ec (&TaskDesc)
                 }
 
- 7 thermal                0   3 ready
+ 7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x080136f2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -502,7 +502,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007804 (&TaskDesc)
                 }
 
- 8 power                  0   3 ready
+ 8 power                        0   3 ready
    |
    +--->  0x20014400 0x080511ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -566,7 +566,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800781c (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 ready
+ 9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -634,7 +634,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007834 (&TaskDesc)
                 }
 
-10 gimlet_seq             0   3 recv
+10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x08023576 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -696,7 +696,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800784c (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -758,7 +758,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007864 (&TaskDesc)
                 }
 
-12 sensor                 0   3 ready
+12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c52 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -820,7 +820,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800787c (&TaskDesc)
                 }
 
-13 idle                   0   5 ready
+13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.stdout
@@ -1,6 +1,6 @@
 system time = 2673946
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800775c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007774 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800778c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077a4 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077bc (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077d4 (&TaskDesc)
                 }
 
- 6 spd                    0   2 RUNNING
+ 6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ec (&TaskDesc)
                 }
 
- 7 thermal                0   3 ready
+ 7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x08013796 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -502,7 +502,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007804 (&TaskDesc)
                 }
 
- 8 power                  0   3 ready
+ 8 power                        0   3 ready
    |
    +--->  0x20014400 0x08051302 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -566,7 +566,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800781c (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 ready
+ 9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -634,7 +634,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007834 (&TaskDesc)
                 }
 
-10 gimlet_seq             0   3 recv
+10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x080235ce userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -696,7 +696,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800784c (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -758,7 +758,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007864 (&TaskDesc)
                 }
 
-12 sensor                 0   3 ready
+12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c6a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -820,7 +820,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800787c (&TaskDesc)
                 }
 
-13 idle                   0   5 ready
+13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
@@ -1,6 +1,6 @@
 system time = 1166521
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+79)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+79)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800775c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007774 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800778c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077a4 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077bc (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077d4 (&TaskDesc)
                 }
 
- 6 spd                    0   2 RUNNING
+ 6 spd                          0   2 RUNNING
    stack unwind failed: failed to read cfa 0x9, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200042d0, sym: Some(HubrisSymbol { addr: 8041f8a, name: "sys_recv_stub", demangled_name: "userlib::sys_recv_stub", size: 22, goff: HubrisGoff { object: 7, goff: 13d7c } }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 200042e8, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042d0, LR: 8040675, PC: 8041f9e, PSR: 41000000}, inlined: Some([]) }, HubrisStackFrame { cfa: 200042f0, sym: Some(HubrisSymbol { addr: 8040660, name: "call_once<task_spd::main::{closure#4}, (u32)>", demangled_name: "core::ops::function::FnOnce::call_once", size: 20, goff: HubrisGoff { object: 7, goff: ecf } }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 1, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042f0, LR: 804044b, PC: 8040674, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
@@ -436,7 +436,7 @@ Caused by:
                     descriptor: 0x80077ec (&TaskDesc)
                 }
 
- 7 thermal                0   3 ready
+ 7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x08013796 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -498,7 +498,7 @@ Caused by:
                     descriptor: 0x8007804 (&TaskDesc)
                 }
 
- 8 power                  0   3 ready
+ 8 power                        0   3 ready
    stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200143e0, sym: Some(HubrisSymbol { addr: 80512fa, name: "sys_recv_stub", demangled_name: "userlib::sys_recv_stub", size: 22, goff: HubrisGoff { object: 9, goff: 1c35b } }), registers: {R0: 8051bdc, R1: 0, R2: 80000000, R3: 2001448c, R4: 0, R5: ffff, R6: 80000000, R7: 0, R8: 0, R9: 0, R10: 8051bdc, R11: 1, R12: 0, SP: 200143e0, LR: 8050163, PC: 8051302, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
@@ -554,7 +554,7 @@ Caused by:
                     descriptor: 0x800781c (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 ready
+ 9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -622,7 +622,7 @@ Caused by:
                     descriptor: 0x8007834 (&TaskDesc)
                 }
 
-10 gimlet_seq             0   3 recv
+10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x080235ce userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -684,7 +684,7 @@ Caused by:
                     descriptor: 0x800784c (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -746,7 +746,7 @@ Caused by:
                     descriptor: 0x8007864 (&TaskDesc)
                 }
 
-12 sensor                 0   3 ready
+12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c6a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -808,7 +808,7 @@ Caused by:
                     descriptor: 0x800787c (&TaskDesc)
                 }
 
-13 idle                   0   5 ready
+13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.stdout
@@ -1,6 +1,6 @@
 system time = 643282
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+18)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+18)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c10 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c28 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c40 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018ec6 userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:668
@@ -264,7 +264,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c58 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -328,7 +328,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c70 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+218)
+ 5 pong                         0   3 recv, notif: bit0(T+218)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c88 (&TaskDesc)
                 }
 
- 6 ping                2834   4 wait: reply from usart_driver/gen0
+ 6 ping                      2834   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006ca0 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+43)
+ 7 hiffy                        0   3 notif: bit31(T+43)
    stack unwind failed: 0x20004000 is valid, but offset in dump (0xd7fe0) + size (0x4000) exceeds max (0xda7e0); is the dump truncated or otherwise corrupt? 
    |
    +--->   R0 = 0x08009fb0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200040fc
@@ -505,7 +505,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006cb8 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.stdout
@@ -1,6 +1,6 @@
 system time = 643309
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+91)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+91)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c10 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c28 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c40 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018fda userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:972
@@ -262,7 +262,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c58 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c70 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+191)
+ 5 pong                         0   3 recv, notif: bit0(T+191)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -388,7 +388,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c88 (&TaskDesc)
                 }
 
- 6 ping                2834   4 wait: reply from usart_driver/gen0
+ 6 ping                      2834   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006ca0 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+16)
+ 7 hiffy                        0   3 notif: bit31(T+16)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -518,7 +518,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006cb8 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.stdout
@@ -1,6 +1,6 @@
 system time = 40768
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+32)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+32)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c10 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c28 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c40 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018ef8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -262,7 +262,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c58 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c70 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+232)
+ 5 pong                         0   3 recv, notif: bit0(T+232)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -388,7 +388,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c88 (&TaskDesc)
                 }
 
- 6 ping                 180   4 ready
+ 6 ping                       180   4 ready
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006ca0 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+63)
+ 7 hiffy                        0   3 notif: bit31(T+63)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -518,7 +518,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006cb8 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
@@ -1,6 +1,6 @@
 system time = 2953610
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bc8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004be0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bf8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,4 +192,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c10 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.stdout
@@ -1,6 +1,6 @@
 system time = 166727
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+73)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+73)
    |
    +--->  0x20014538 0x08031554 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b0c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200163d8 0x08050c86 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b24 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x200167c8 0x08052ee6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b3c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080358d8 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b54 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 RUNNING
+ 4 spi2_driver                  0   2 RUNNING
    |
    +--->  0x200122d8 0x080399a2 userlib::sys_borrow_read_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:471
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b6c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20014ad8 0x0803e0ac userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b84 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041ef2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -448,7 +448,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b9c (&TaskDesc)
                 }
 
- 7 thermal                0   3 recv, notif: bit0(T+284)
+ 7 thermal                      0   3 recv, notif: bit0(T+284)
    |
    +--->  0x20002740 0x08011526 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -510,7 +510,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bb4 (&TaskDesc)
                 }
 
- 8 power                 32   3 wait: send to gimlet_seq/gen41
+ 8 power                       32   3 wait: send to gimlet_seq/gen41
    |
    +--->  0x20013518 0x080460c0 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -570,7 +570,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bcc (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 notif: bit31(T+23)
+ 9 hiffy                        0   3 notif: bit31(T+23)
    |
    +--->  0x20008140 0x0800b576 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007be4 (&TaskDesc)
                 }
 
-10 gimlet_seq            41   3 wait: reply from spi2_driver/gen0
+10 gimlet_seq                  41   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20010668 0x080268da userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bfc (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x20015698 0x08049654 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -764,7 +764,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007c14 (&TaskDesc)
                 }
 
-12 sensor                 0   3 recv, notif: bit0(T+273)
+12 sensor                       0   3 recv, notif: bit0(T+273)
    |
    +--->  0x20015c38 0x0804cbca userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -826,7 +826,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007c2c (&TaskDesc)
                 }
 
-13 idle                   0   5 ready
+13 idle                         0   5 ready
    |
    +--->  0x20016900 0x08054056 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.stdout
@@ -1,6 +1,6 @@
 system time = 40900
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c10 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c28 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c40 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 ready
+ 3 usart_driver                 0   2 ready
    |
    +--->  0x20002368 0x08018ec6 userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:668
@@ -264,7 +264,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c58 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -328,7 +328,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c70 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+100)
+ 5 pong                         0   3 recv, notif: bit0(T+100)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006c88 (&TaskDesc)
                 }
 
- 6 ping                 181   4 wait: reply from usart_driver/gen0
+ 6 ping                       181   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006ca0 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+182)
+ 7 hiffy                        0   3 notif: bit31(T+182)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
@@ -520,7 +520,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8006cb8 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.stdout
@@ -1,6 +1,6 @@
 system time = 4863516
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+84)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+84)
    |
    +--->  0x20002540 0x08011480 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076cc (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200033d8 0x0801cd72 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076e4 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x200037c8 0x0801ef8e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076fc (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 ready
+ 3 usart_driver                 0   2 ready
    |
    +--->  0x20003bc0 0x08020e9a userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007714 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b70 0x080158a4 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800772c (&TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20001368 0x080199c4 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007744 (&TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x20003fc8 0x08022e3e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -444,7 +444,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800775c (&TaskDesc)
                 }
 
- 7 ping               40023   4 wait: reply from usart_driver/gen0
+ 7 ping                     40023   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200045b0 0x08024e84 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -504,7 +504,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007774 (&TaskDesc)
                 }
 
- 8 pong                   0   3 recv, notif: bit0(T+484)
+ 8 pong                         0   3 recv, notif: bit0(T+484)
    |
    +--->  0x200043b8 0x08026c0a userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -564,7 +564,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800778c (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 notif: bit31(T+234)
+ 9 hiffy                        0   3 notif: bit31(T+234)
    |
    +--->  0x20008540 0x0800add2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -632,7 +632,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077a4 (&TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING
    |
    +--->  0x20004700 0x08028056 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.stdout
@@ -1,6 +1,6 @@
 system time = 1646441
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+59)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+59)
    |
    +--->  0x20004480 0x0800c980 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002d70 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001340 0x08012254 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002d88 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001710 0x0801091e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002da0 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20001b18 0x080113ae userlib::sys_borrow_read_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:634
@@ -264,7 +264,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002db8 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20001f20 0x08011b26 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -328,7 +328,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002dd0 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+59)
+ 5 pong                         0   3 recv, notif: bit0(T+59)
    |
    +--->  0x20004318 0x0801259c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -392,7 +392,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002de8 (&TaskDesc)
                 }
 
- 6 ping                7399   4 wait: reply from usart_driver/gen0
+ 6 ping                      7399   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004770 0x0800ed54 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002e00 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+170)
+ 7 hiffy                        0   3 notif: bit31(T+170)
    |
    +--->  0x200020a8 0x080098ca userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002e18 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.stdout
@@ -1,6 +1,6 @@
 system time = 1786487
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+13)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+13)
    |
    +--->  0x20004480 0x0800c980 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002d70 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001340 0x08012254 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002d88 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001710 0x0801091e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -196,7 +196,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002da0 (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20001b18 0x08011496 userlib::sys_irq_control_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:920
@@ -262,7 +262,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002db8 (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20001f20 0x08011b26 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002dd0 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+13)
+ 5 pong                         0   3 recv, notif: bit0(T+13)
    |
    +--->  0x20004318 0x0801259c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002de8 (&TaskDesc)
                 }
 
- 6 ping                8028   4 wait: reply from usart_driver/gen0
+ 6 ping                      8028   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004770 0x0800ed54 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002e00 (&TaskDesc)
                 }
 
- 7 hiffy                  0   3 notif: bit31(T+48)
+ 7 hiffy                        0   3 notif: bit31(T+48)
    |
    +--->  0x200020a8 0x080098ca userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -526,7 +526,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002e18 (&TaskDesc)
                 }
 
- 8 idle                   0   5 ready
+ 8 idle                         0   5 ready
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.stdout
@@ -1,6 +1,6 @@
 system time = 256549
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20003538 0x08039540 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e48 (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20012b58 0x0803ace6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e60 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20012f48 0x0803ceee userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e78 (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20003ae8 0x08021b70 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e90 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x200102e8 0x08025ca4 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea8 (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20010a58 0x0802a0b0 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x0802defa userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -442,7 +442,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&TaskDesc)
                 }
 
- 7 thermal                0   3 recv, notif: bit0(T+462)
+ 7 thermal                      0   3 recv, notif: bit0(T+462)
    |
    +--->  0x200116c0 0x0803f52e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -504,7 +504,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&TaskDesc)
                 }
 
- 8 power                  0   3 notif: bit31(T+577)
+ 8 power                        0   3 notif: bit31(T+577)
    |
    +--->  0x20001518 0x08032096 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -568,4 +568,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 FAULT: stack overflow; sp=0x20007ff8 (was: ready)
+ 9 hiffy                        0   3 FAULT: stack overflow; sp=0x20007ff8 (was: ready)

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.stdout
@@ -1,6 +1,6 @@
 system time = 1100533
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+67)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+67)
    |
    +--->  0x20001540 0x08009538 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f28 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20006b50 0x080065d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f40 (&TaskDesc)
                 }
 
- 2 usart_driver           0   2 recv, notif: bit0(irq39)
+ 2 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20006f40 0x0800ae0e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -188,7 +188,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f58 (&TaskDesc)
                 }
 
- 3 i2c_driver             0   2 recv
+ 3 i2c_driver                   0   2 recv
    |
    +--->  0x20001af0 0x0800d81c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f70 (&TaskDesc)
                 }
 
- 4 spi_driver             0   2 recv
+ 4 spi_driver                   0   2 recv
    |
    +--->  0x200062f0 0x08029bcc userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -316,7 +316,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f88 (&TaskDesc)
                 }
 
- 5 net                    0   2 recv, notif: bit0(irq61)
+ 5 net                          0   2 recv, notif: bit0(irq61)
    |
    +--->  0x20002868 0x08019c6c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -378,7 +378,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fa0 (&TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x20007348 0x08006e3c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb8 (&TaskDesc)
                 }
 
- 7 ping                9057   4 wait: reply from usart_driver/gen0
+ 7 ping                      9057   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007730 0x08030da0 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -500,7 +500,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fd0 (&TaskDesc)
                 }
 
- 8 pong                   0   3 recv, notif: bit0(T+467)
+ 8 pong                         0   3 recv, notif: bit0(T+467)
    |
    +--->  0x20007b38 0x08005998 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -562,7 +562,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe8 (&TaskDesc)
                 }
 
- 9 udpecho                0   3 notif: bit0
+ 9 udpecho                      0   3 notif: bit0
    |
    +--->  0x20004dd8 0x0802ebe2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -622,7 +622,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005000 (&TaskDesc)
                 }
 
-10 hiffy                  0   3 notif: bit31(T+237)
+10 hiffy                        0   3 notif: bit31(T+237)
    |
    +--->  0x20008540 0x08022dbe userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -690,7 +690,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005018 (&TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20007d00 0x08005456 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.stdout
@@ -1,6 +1,6 @@
 system time = 25464
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+36)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
    |
    +--->  0x20005538 0x0001953c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xcdf0 (&TaskDesc)
                 }
 
- 1 hiffy                  0   3 notif: bit31(T+39)
+ 1 hiffy                        0   3 notif: bit31(T+39)
    |
    +--->  0x20008540 0x00012132 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -130,7 +130,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce08 (&TaskDesc)
                 }
 
- 2 idle                   0   5 RUNNING
+ 2 idle                         0   5 RUNNING
    |
    +--->  0x2000dd00 0x00029056 main
    |                 @ /hubris//task/idle/src/main.rs:13
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce20 (&TaskDesc)
                 }
 
- 3 syscon_driver          0   2 recv
+ 3 syscon_driver                0   2 recv
    |
    +--->  0x20005bc0 0x00028bb6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -250,7 +250,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce38 (&TaskDesc)
                 }
 
- 4 gpio_driver            0   2 recv
+ 4 gpio_driver                  0   2 recv
    |
    +--->  0x200063a8 0x0001b6ea userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -316,7 +316,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce50 (&TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x0001c44c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -378,7 +378,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce68 (&TaskDesc)
                 }
 
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x200073b0 0x0001ef62 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce80 (&TaskDesc)
                 }
 
- 7 i2c_driver             0   2 recv
+ 7 i2c_driver                   0   2 recv
    |
    +--->  0x20007bb8 0x00021180 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xce98 (&TaskDesc)
                 }
 
- 8 rng_driver             0   2 recv
+ 8 rng_driver                   0   2 recv
    |
    +--->  0x2000c3b8 0x00022d6a userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -566,7 +566,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xceb0 (&TaskDesc)
                 }
 
- 9 spi0_driver            0   2 notif: bit0(irq59)
+ 9 spi0_driver                  0   2 notif: bit0(irq59)
    |
    +--->  0x2000cb70 0x0001511e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -628,7 +628,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xcec8 (&TaskDesc)
                 }
 
-10 ping                  62   4 wait: reply from usart_driver/gen0
+10 ping                        62   4 wait: reply from usart_driver/gen0
    |
    +--->  0x2000d9b0 0x00024da0 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -688,7 +688,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xcee0 (&TaskDesc)
                 }
 
-11 pong                   0   3 recv, notif: bit0(T+36)
+11 pong                         0   3 recv, notif: bit0(T+36)
    |
    +--->  0x2000d3a0 0x00026198 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.stdout
@@ -1,6 +1,6 @@
 system time = 40815
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+85)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+85)
    |
    +--->  0x20003538 0x08035544 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e48 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20012b50 0x0803c5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e60 (&TaskDesc)
                 }
 
- 2 spi4_driver            0   2 recv
+ 2 spi4_driver                  0   2 recv
    |
    +--->  0x20003ae8 0x08021bd0 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e78 (&TaskDesc)
                 }
 
- 3 spi2_driver            0   2 FAULT: stack overflow; sp=0x2000ff98 (was: ready)
+ 3 spi2_driver                  0   2 FAULT: stack overflow; sp=0x2000ff98 (was: ready)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x7fcf0d53   R1 = 0x3e3d79d6   R2 = 0x632c7efd   R3 = 0x993d0532
@@ -244,7 +244,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e90 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20010a58 0x0802a08c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -310,7 +310,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea8 (&TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit31(T+1)
+ 5 spd                          0   2 notif: bit31(T+1)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -374,7 +374,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&TaskDesc)
                 }
 
- 6 thermal                0   3 recv, notif: bit0(T+196)
+ 6 thermal                      0   3 recv, notif: bit0(T+196)
    |
    +--->  0x200116c0 0x0803752e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -436,7 +436,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&TaskDesc)
                 }
 
- 7 power                  0   3 wait: send to gimlet_seq/gen0
+ 7 power                        0   3 wait: send to gimlet_seq/gen0
    |
    +--->  0x20001518 0x080320c8 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -496,7 +496,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+185)
+ 8 hiffy                        0   3 notif: bit31(T+185)
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -564,7 +564,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x200024b0 0x080139ae userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -628,7 +628,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20011e18 0x0803964c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -690,7 +690,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&TaskDesc)
                 }
 
-11 sensor                 0   3 recv, notif: bit0(T+185)
+11 sensor                       0   3 recv, notif: bit0(T+185)
    |
    +--->  0x200123e8 0x0803abbe userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -752,7 +752,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&TaskDesc)
                 }
 
-12 idle                   0   5 RUNNING
+12 idle                         0   5 RUNNING
    |
    +--->  0x20012d00 0x0803c856 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.stdout
@@ -1,6 +1,6 @@
 system time = 12629
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+71)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+71)
    |
    +--->  0x20010538 0x08035544 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e48 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20013350 0x0803c5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e60 (&TaskDesc)
                 }
 
- 2 spi4_driver            0   2 recv
+ 2 spi4_driver                  0   2 recv
    |
    +--->  0x20010ae8 0x08021bd0 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e78 (&TaskDesc)
                 }
 
- 3 spi2_driver            0   2 FAULT: panicked at 'explicit panic', drv/stm32h7-spi-server/src/main.rs:438:21 (was: ready)
+ 3 spi2_driver                  0   2 FAULT: panicked at 'explicit panic', drv/stm32h7-spi-server/src/main.rs:438:21 (was: ready)
    |
    +--->  0x20001248 0x08025dbe userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:989
@@ -261,7 +261,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e90 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20011258 0x0802a08c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -327,7 +327,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea8 (&TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit31(T+7)
+ 5 spd                          0   2 notif: bit31(T+7)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -391,7 +391,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&TaskDesc)
                 }
 
- 6 thermal                0   3 recv, notif: bit0(T+382)
+ 6 thermal                      0   3 recv, notif: bit0(T+382)
    |
    +--->  0x20011ec0 0x0803752e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -453,7 +453,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&TaskDesc)
                 }
 
- 7 power                  0   3 wait: send to gimlet_seq/gen0
+ 7 power                        0   3 wait: send to gimlet_seq/gen0
    |
    +--->  0x20002518 0x080320c8 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -513,7 +513,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+121)
+ 8 hiffy                        0   3 notif: bit31(T+121)
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -581,7 +581,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x200034b0 0x080139ae userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -645,7 +645,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20012618 0x0803964c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -707,7 +707,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&TaskDesc)
                 }
 
-11 sensor                 0   3 recv, notif: bit0(T+371)
+11 sensor                       0   3 recv, notif: bit0(T+371)
    |
    +--->  0x20012be8 0x0803abbe userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -769,7 +769,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&TaskDesc)
                 }
 
-12 idle                   0   5 RUNNING
+12 idle                         0   5 RUNNING
    |
    +--->  0x20013500 0x0803c856 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.stdout
@@ -1,6 +1,6 @@
 system time = 55566
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+34)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+34)
    |
    +--->  0x20010538 0x08035540 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e48 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20013350 0x0803c5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e60 (&TaskDesc)
                 }
 
- 2 spi4_driver            0   2 recv
+ 2 spi4_driver                  0   2 recv
    |
    +--->  0x20010ae8 0x08021bd0 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e78 (&TaskDesc)
                 }
 
- 3 spi2_driver          124   2 RUNNING
+ 3 spi2_driver                124   2 RUNNING
    |
    +--->  0x200012c0 0x08025daa userlib::sys_irq_control_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:922
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e90 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20011258 0x0802a08c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea8 (&TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit31(T+2)
+ 5 spd                          0   2 notif: bit31(T+2)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -384,7 +384,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&TaskDesc)
                 }
 
- 6 thermal                0   3 ready
+ 6 thermal                      0   3 ready
    |
    +--->  0x20011ec0 0x0803752e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -446,7 +446,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&TaskDesc)
                 }
 
- 7 power                  2   3 ready
+ 7 power                        2   3 ready
    |
    +--->  0x20002518 0x08032096 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -510,7 +510,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 ready
+ 8 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&TaskDesc)
                 }
 
- 9 gimlet_seq           124   3 wait: reply from spi2_driver/gen60
+ 9 gimlet_seq                 124   3 wait: reply from spi2_driver/gen60
    |
    +--->  0x200034b0 0x080139ae userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -642,7 +642,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20012618 0x0803964c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -704,7 +704,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&TaskDesc)
                 }
 
-11 sensor                 0   3 ready
+11 sensor                       0   3 ready
    |
    +--->  0x20012be8 0x0803abbe userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&TaskDesc)
                 }
 
-12 idle                   0   5 ready
+12 idle                         0   5 ready
    |
    +--->  0x20013500 0x0803c856 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.stdout
@@ -1,6 +1,6 @@
 system time = 31738
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+62)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+62)
    |
    +--->  0x20000ae0 0x0800697c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002bb0 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x200009c8 0x08003d6a userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -92,7 +92,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002bc8 (&TaskDesc)
                 }
 
- 2 pong                   0   4 recv, notif: bit0(T+262)
+ 2 pong                         0   4 recv, notif: bit0(T+262)
    |
    +--->  0x20000cb0 0x0800319c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -138,7 +138,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002be0 (&TaskDesc)
                 }
 
- 3 user_leds              0   3 recv
+ 3 user_leds                    0   3 recv
    |
    +--->  0x20000db0 0x08007642 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -184,7 +184,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002bf8 (&TaskDesc)
                 }
 
- 4 hiffy                  0   4 notif: bit31(T+13)
+ 4 hiffy                        0   4 notif: bit31(T+13)
    |
    +--->  0x200010d0 0x080050ac userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:331
@@ -240,7 +240,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8002c10 (&TaskDesc)
                 }
 
- 5 idle                   0   5 RUNNING
+ 5 idle                         0   5 RUNNING
    |
    +--->  0x20000840 0x08002f44 cortex_m::asm::inline::__wfi
    |                 @ /crates.io/cortex-m-0.7.3/src/../asm/inline.rs:181

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.stdout
@@ -1,6 +1,6 @@
 system time = 198778
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005044 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800505c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005074 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800508c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050a4 (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -392,7 +392,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050bc (&abi::TaskDesc)
                 }
 
- 6 pong                   0   3 ready
+ 6 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050d4 (&abi::TaskDesc)
                 }
 
- 7 ping                  24   4 ready
+ 7 ping                        24   4 ready
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050ec (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 wait: reply from i2c_driver/gen0
+ 8 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200045e0 0x08021fa0 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -576,7 +576,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005104 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 ready
+ 9 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800511c (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 ready
+10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.stdout
@@ -1,6 +1,6 @@
 system time = 323356
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -336,7 +336,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -398,7 +398,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -464,7 +464,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -522,7 +522,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -588,7 +588,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -648,7 +648,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -712,7 +712,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: reply from i2c_driver/gen0
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -776,7 +776,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x0804373a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -840,7 +840,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 ready
+13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -904,7 +904,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
@@ -1,6 +1,6 @@
 system time = 5457089
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c04 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c1c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c34 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c4c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,7 +242,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c64 (&abi::TaskDesc)
                 }
 
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f68 0x08019822 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -288,7 +288,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c7c (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c94 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+411)
+ 7 pong                         0   3 recv, notif: bit0(T+411)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cac (&abi::TaskDesc)
                 }
 
- 8 i2c_debug              0   3 notif: bit31(T+911)
+ 8 i2c_debug                    0   3 notif: bit31(T+911)
    |
    +--->  0x20005fa0 0x08021726 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -430,7 +430,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cc4 (&abi::TaskDesc)
                 }
 
- 9 adt7420                0   3 notif: bit31(T+361)
+ 9 adt7420                      0   3 notif: bit31(T+361)
    |
    +--->  0x2000ff80 0x0802573e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -478,4 +478,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cdc (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.stdout
@@ -1,6 +1,6 @@
 system time = 3607115
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002ad0 0x0801638a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -400,7 +400,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -466,7 +466,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -524,7 +524,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -590,7 +590,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -650,7 +650,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -714,7 +714,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 ready
+11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -778,7 +778,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -842,7 +842,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -906,7 +906,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.stdout
@@ -1,6 +1,6 @@
 system time = 438460
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b20 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -388,7 +388,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 ready
+11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -830,7 +830,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -894,7 +894,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.stdout
@@ -1,6 +1,6 @@
 system time = 66322
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801638a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 wait: reply from spi_driver/gen0
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+178)
+ 9 pong                         0   3 recv, notif: bit0(T+178)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+178)
+10 i2c_debug                    0   3 notif: bit31(T+178)
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 notif: bit31(T+807)
+11 thermal                      0   3 notif: bit31(T+807)
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 notif: bit31(T+807)
+12 power                        0   3 notif: bit31(T+807)
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -830,7 +830,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 notif: bit31(T+10)
+13 hiffy                        0   3 notif: bit31(T+10)
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -894,7 +894,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.stdout
@@ -1,6 +1,6 @@
 system time = 20495
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -342,7 +342,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -404,7 +404,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -594,7 +594,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -654,7 +654,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -718,7 +718,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: reply from i2c_driver/gen0
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -782,7 +782,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -846,7 +846,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 ready
+13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -910,7 +910,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.stdout
@@ -1,6 +1,6 @@
 system time = 1205360
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005044 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800505c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005074 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800508c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050a4 (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -392,7 +392,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050bc (&abi::TaskDesc)
                 }
 
- 6 pong                   0   3 ready
+ 6 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050d4 (&abi::TaskDesc)
                 }
 
- 7 ping                   4   4 ready
+ 7 ping                         4   4 ready
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050ec (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 wait: reply from i2c_driver/gen0
+ 8 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200045d0 0x08022274 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -576,7 +576,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005104 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 ready
+ 9 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800511c (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 ready
+10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.stdout
@@ -1,6 +1,6 @@
 system time = 272686
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005044 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800505c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005074 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800508c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015a4a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050a4 (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050bc (&abi::TaskDesc)
                 }
 
- 6 pong                   0   3 recv, notif: bit0(T+314)
+ 6 pong                         0   3 recv, notif: bit0(T+314)
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050d4 (&abi::TaskDesc)
                 }
 
- 7 ping                   1   4 wait: reply from usart_driver/gen0
+ 7 ping                         1   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -510,7 +510,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050ec (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+71)
+ 8 hiffy                        0   3 notif: bit31(T+71)
    |
    +--->  0x20004650 0x08022242 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -574,7 +574,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005104 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 notif: bit31(T+210)
+ 9 i2c_debug                    0   3 notif: bit31(T+210)
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800511c (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING
    |
    +--->  0x20008100 0x08038056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.stdout
@@ -1,6 +1,6 @@
 system time = 772538
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005044 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800505c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005074 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 RUNNING
+ 3 usart_driver                 0   2 RUNNING
    |
    +--->  0x200023c0 0x080111a0 userlib::sys_reply_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:326
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800508c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015a4a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050a4 (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050bc (&abi::TaskDesc)
                 }
 
- 6 pong                   0   3 recv, notif: bit0(T+462)
+ 6 pong                         0   3 recv, notif: bit0(T+462)
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050d4 (&abi::TaskDesc)
                 }
 
- 7 ping                  40   4 wait: reply from usart_driver/gen0
+ 7 ping                        40   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -510,7 +510,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050ec (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+211)
+ 8 hiffy                        0   3 notif: bit31(T+211)
    |
    +--->  0x20004650 0x08022242 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -574,7 +574,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005104 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 notif: bit31(T+212)
+ 9 i2c_debug                    0   3 notif: bit31(T+212)
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800511c (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 ready
+10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.stdout
@@ -1,6 +1,6 @@
 system time = 260969
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+31)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+31)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bc8 0x08048d6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001360 0x08035918 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 notif: bit0(irq36)
+ 4 spi2_driver                  0   2 notif: bit0(irq36)
    |
    +--->  0x200122d8 0x080399ec userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -448,7 +448,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 7 thermal                0   3 notif: bit31(T+851)
+ 7 thermal                      0   3 notif: bit31(T+851)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 wait: reply from spi2_driver/gen0
+ 8 hiffy                        0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20008118 0x0800b4de userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -580,7 +580,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077dc (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 notif: bit31(T+2)
+ 9 gimlet_seq                   0   3 notif: bit31(T+2)
    |
    +--->  0x20010288 0x08023222 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -644,7 +644,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077f4 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20014698 0x0804564c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -706,7 +706,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800780c (&TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20015100 0x0804c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.stdout
@@ -1,6 +1,6 @@
 system time = 55965
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+35)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+35)
    |
    +--->  0x20011540 0x0802947c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20012bc8 0x08040d6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20012fc8 0x08042f8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20001360 0x0802d918 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x20010360 0x080319ec userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20011ad8 0x08036154 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d8 0x08039ed2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -442,7 +442,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 7 thermal                0   3 notif: bit31(T+382)
+ 7 thermal                      0   3 notif: bit31(T+382)
    |
    +--->  0x20002718 0x0801397a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
- 8 hiffy                  1   3 FAULT:  (was: ready)
+ 8 hiffy                        1   3 FAULT:  (was: ready)
    |
    +--->  0x20008440 0x0800b53a userlib::sys_panic_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:686
@@ -581,7 +581,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077dc (&TaskDesc)
                 }
 
- 9 gimlet_seq             0   3 notif: bit31(T+3)
+ 9 gimlet_seq                   0   3 notif: bit31(T+3)
    |
    +--->  0x20013298 0x0802138e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -645,7 +645,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077f4 (&TaskDesc)
                 }
 
-10 hf                     0   3 recv
+10 hf                           0   3 recv
    |
    +--->  0x20012698 0x0803d64c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -707,7 +707,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800780c (&TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20013500 0x08044056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.stdout
@@ -1,6 +1,6 @@
 system time = 1342206
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x200015c0 0x080081fa <core::result::Result<T,E> as core::ops::try::Try>::into_result
    |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1635
@@ -78,7 +78,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005318 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
@@ -142,7 +142,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005330 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
@@ -208,7 +208,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005348 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
@@ -272,7 +272,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005360 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801622a userlib::sys_recv_stub
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005378 (&abi::TaskDesc)
                 }
 
- 5 spd                   14   2 FAULT: panicked at 'called `Result::unwrap()` on an `Err` value: BadArg', drv/stm32h7-rcc-api/src/lib.rs:56:50 (was: ready)
+ 5 spd                         14   2 FAULT: panicked at 'called `Result::unwrap()` on an `Err` value: BadArg', drv/stm32h7-rcc-api/src/lib.rs:56:50 (was: ready)
    |
    +--->  0x20003268 0x080198e6 userlib::sys_panic_stub
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:655
@@ -419,7 +419,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005390 (&abi::TaskDesc)
                 }
 
- 6 spi2_driver            0   2 ready
+ 6 spi2_driver                  0   2 ready
    |
    +--->  0x200043e8 0x0801c001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -475,7 +475,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053a8 (&abi::TaskDesc)
                 }
 
- 7 spi4_driver            0   2 ready
+ 7 spi4_driver                  0   2 ready
    |
    +--->  0x200053e8 0x08020001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -531,7 +531,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053c0 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 ready
+ 8 user_leds                    0   2 ready
    |
    +--->  0x20006400 0x08024001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -587,7 +587,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053d8 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20006800 0x08026001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -643,7 +643,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053f0 (&abi::TaskDesc)
                 }
 
-10 thermal                0   3 ready
+10 thermal                      0   3 ready
    |
    +--->  0x20008800 0x08030001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -699,7 +699,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005408 (&abi::TaskDesc)
                 }
 
-11 power                  0   3 ready
+11 power                        0   3 ready
    |
    +--->  0x2000a800 0x08040001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -755,7 +755,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005420 (&abi::TaskDesc)
                 }
 
-12 hiffy                  0   3 ready
+12 hiffy                        0   3 ready
    |
    +--->  0x2000c800 0x08050001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
@@ -811,7 +811,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005438 (&abi::TaskDesc)
                 }
 
-13 idle                   0   5 ready
+13 idle                         0   5 ready
    |
    +--->  0x20010100 0x08058001 _start
    |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.stdout
@@ -1,6 +1,6 @@
 system time = 10293
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+7)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+7)
    |
    +--->  0x20004540 0x08011480 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076ec (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007704 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800771c (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007734 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800774c (&TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20001360 0x08019954 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007764 (&TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -444,7 +444,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800777c (&TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+207)
+ 7 pong                         0   3 recv, notif: bit0(T+207)
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -504,7 +504,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007794 (&TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+207)
+ 8 hiffy                        0   3 notif: bit31(T+207)
    |
    +--->  0x20008540 0x0800b12e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -572,7 +572,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077ac (&TaskDesc)
                 }
 
- 9 hf                     0   3 notif: bit31(T+718)
+ 9 hf                           0   3 notif: bit31(T+718)
    |
    +--->  0x20002658 0x0801d660 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -636,7 +636,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077c4 (&TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING
    |
    +--->  0x20006500 0x0802a056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
@@ -1,6 +1,6 @@
 system time = 575890
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bb8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bd0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004be8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c00 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x080154f6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,7 +242,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c18 (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x200027c8 0x08018e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -292,7 +292,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c30 (&abi::TaskDesc)
                 }
 
- 6 pong                   0   3 recv, notif: bit0(T+110)
+ 6 pong                         0   3 recv, notif: bit0(T+110)
    |
    +--->  0x20002bb8 0x0801ad36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -336,7 +336,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c48 (&abi::TaskDesc)
                 }
 
- 7 ping                   4   4 wait: reply from usart_driver/gen0
+ 7 ping                         4   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002da8 0x0801cf50 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c60 (&abi::TaskDesc)
                 }
 
- 8 i2c_debug              0   3 notif: bit31(T+110)
+ 8 i2c_debug                    0   3 notif: bit31(T+110)
    |
    +--->  0x20005fa0 0x080216c6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -428,4 +428,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c78 (&abi::TaskDesc)
                 }
 
- 9 idle                   0   5 RUNNING
+ 9 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
@@ -1,6 +1,6 @@
 system time = 263349
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c04 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c1c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c34 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c4c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,4 +242,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c64 (&abi::TaskDesc)
                 }
 
- 5 i2c_target             0   2 RUNNING
+ 5 i2c_target                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
@@ -1,6 +1,6 @@
 system time = 541258
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048b0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -94,4 +94,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048c8 (&abi::TaskDesc)
                 }
 
- 2 usart_driver           0   2 RUNNING
+ 2 usart_driver                 0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
@@ -1,6 +1,6 @@
 system time = 2896993
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004db0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004de0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,4 +192,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df8 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
@@ -1,6 +1,6 @@
 system time = 50976
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f74 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f8c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fa4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fbc (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015926 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,4 +322,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fd4 (&abi::TaskDesc)
                 }
 
- 5 spd                   61   2 RUNNING
+ 5 spd                         61   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
@@ -1,6 +1,6 @@
 system time = 1041634
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,4 +256,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
@@ -1,6 +1,6 @@
 system time = 53379
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022b0 0x080166b2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,7 +384,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005054 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 not started
+ 7 spi                          0   3 not started
    |
    +--->  0x20003c00 0x08020001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800506c (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -572,7 +572,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005084 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+121)
+ 9 pong                         0   3 recv, notif: bit0(T+121)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -632,7 +632,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800509c (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+621)
+10 i2c_debug                    0   3 notif: bit31(T+621)
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -696,7 +696,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050b4 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: send to i2c_driver/gen0
+11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x08035636 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -762,4 +762,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050cc (&abi::TaskDesc)
                 }
 
-12 idle                   0   5 RUNNING
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
@@ -1,6 +1,6 @@
 system time = 170019523
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
@@ -1,6 +1,6 @@
 system time = 12289080
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,7 +384,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 notif: bit0(irq84)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005054 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 wait: reply from spi_driver/gen0
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800506c (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005084 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+420)
+ 9 pong                         0   3 recv, notif: bit0(T+420)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800509c (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+920)
+10 i2c_debug                    0   3 notif: bit31(T+920)
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050b4 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: send to i2c_driver/gen0
+11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x0803559e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -768,4 +768,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80050cc (&abi::TaskDesc)
                 }
 
-12 idle                   0   5 RUNNING
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
@@ -1,6 +1,6 @@
 system time = 12356272
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
@@ -1,6 +1,6 @@
 system time = 87365
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016652 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801999e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -386,4 +386,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
@@ -1,6 +1,6 @@
 system time = 1217
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,4 +256,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
@@ -1,6 +1,6 @@
 system time = 65738550
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cf2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004800 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e3a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004818 (&abi::TaskDesc)
                 }
 
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001bb0 0x0801d1e2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
@@ -142,7 +142,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004830 (&abi::TaskDesc)
                 }
 
- 3 user_leds              0   2 recv
+ 3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004848 (&abi::TaskDesc)
                 }
 
- 4 ping                  25   4 wait: reply from pong/gen0
+ 4 ping                        25   4 wait: reply from pong/gen0
    |
    +--->  0x20002fa0 0x080250fc userlib::sys_send_stub
    |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:127
@@ -234,4 +234,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004860 (&abi::TaskDesc)
                 }
 
- 5 log                    0   3 RUNNING
+ 5 log                          0   3 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
@@ -1,6 +1,6 @@
 system time = 4038
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fdc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800500c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 ready
+ 4 i2c_driver                   0   2 ready
    |
    +--->  0x200022e0 0x080166ba userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -328,7 +328,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005024 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801999e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -390,4 +390,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800503c (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
@@ -1,6 +1,6 @@
 system time = 61893323
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
@@ -1,6 +1,6 @@
 system time = 61921802
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
@@ -1,6 +1,6 @@
 system time = 184021
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
@@ -1,6 +1,6 @@
 system time = 2957351
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
@@ -1,6 +1,6 @@
 system time = 16250
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
@@ -1,6 +1,6 @@
 system time = 174278
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
@@ -1,6 +1,6 @@
 system time = 257977
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,7 +384,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 notif: bit0(irq84)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x20003398 0x0801d3b2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e38 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 wait: reply from spi_driver/gen0
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e50 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e68 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+23)
+ 9 pong                         0   3 recv, notif: bit0(T+23)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e80 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+23)
+10 i2c_debug                    0   3 notif: bit31(T+23)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e98 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 notif: bit31(T+182)
+11 thermal                      0   3 notif: bit31(T+182)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004eb0 (&abi::TaskDesc)
                 }
 
-12 net                    0   2 notif: bit31(T+1)
+12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -832,4 +832,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec8 (&abi::TaskDesc)
                 }
 
-13 idle                   0   5 RUNNING
+13 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
@@ -1,6 +1,6 @@
 system time = 1137995
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
@@ -1,6 +1,6 @@
 system time = 23
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80047dc (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80047f4 (&abi::TaskDesc)
                 }
 
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001bb0 0x0801d1c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -142,7 +142,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800480c (&abi::TaskDesc)
                 }
 
- 3 user_leds              0   2 recv
+ 3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -190,4 +190,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004824 (&abi::TaskDesc)
                 }
 
- 4 ping                   1   4 RUNNING
+ 4 ping                         1   4 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
@@ -1,6 +1,6 @@
 system time = 1346098
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004da8 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dd8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004df0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e08 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -384,4 +384,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e20 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 notif: bit0(irq84)
+ 6 spi_driver                   0   2 notif: bit0(irq84)

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
@@ -1,3 +1,3 @@
 system time = 289452420
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.stdout
@@ -1,6 +1,6 @@
 system time = 290381949
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -60,7 +60,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -116,7 +116,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -180,7 +180,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             35   2 ready
+ 4 user_leds                   35   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -302,7 +302,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -358,7 +358,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -414,7 +414,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -526,7 +526,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -582,7 +582,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.stdout
@@ -1,6 +1,6 @@
 system time = 302579193
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001360 0x00011b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -118,7 +118,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -182,7 +182,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             17   2 ready
+ 4 user_leds                   17   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -304,7 +304,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -360,7 +360,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -416,7 +416,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -472,7 +472,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -584,7 +584,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.stdout
@@ -1,6 +1,6 @@
 system time = 335837028
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001360 0x00011b56 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -118,7 +118,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -182,7 +182,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 ready
+ 3 gpio_driver                  0   2 ready
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds              7   2 wait: reply from gpio_driver/gen0
+ 4 user_leds                    7   2 wait: reply from gpio_driver/gen0
    |
    +--->  0x20002f88 0x0002520a userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -310,7 +310,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -366,7 +366,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -422,7 +422,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -478,7 +478,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -534,7 +534,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -590,7 +590,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -646,7 +646,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.stdout
@@ -1,6 +1,6 @@
 system time = 335883880
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -60,7 +60,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -116,7 +116,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -180,7 +180,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             59   2 ready
+ 4 user_leds                   59   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -302,7 +302,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -358,7 +358,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -414,7 +414,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -526,7 +526,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -582,7 +582,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.stdout
@@ -1,6 +1,6 @@
 system time = 19544
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001290 0x000115ae cortex_m::itm::write_words
    |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:16
@@ -72,7 +72,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds              2   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
+ 4 user_leds                    2   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x20002bdc   R1 = 0x20002bd8   R2 = 0x00000804   R3 = 0x20002bf8
@@ -316,7 +316,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -372,7 +372,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -428,7 +428,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -484,7 +484,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -540,7 +540,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -596,7 +596,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -652,7 +652,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
@@ -1,6 +1,6 @@
 system time = 48664
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80047dc (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
@@ -94,4 +94,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80047f4 (&abi::TaskDesc)
                 }
 
- 2 usart_driver           0   2 RUNNING
+ 2 usart_driver                 0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.stdout
@@ -1,6 +1,6 @@
 system time = 21440
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -60,7 +60,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -116,7 +116,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -180,7 +180,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds              3   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
+ 4 user_leds                    3   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x20002bdc   R1 = 0x20002bd8   R2 = 0x00000c04   R3 = 0x20002bf8
@@ -304,7 +304,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -360,7 +360,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -416,7 +416,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -472,7 +472,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -584,7 +584,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.stdout
@@ -1,6 +1,6 @@
 system time = 24581
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011d80 __aeabi_memset4
    |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/arm.rs:211
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -118,7 +118,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -182,7 +182,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             13   2 ready
+ 4 user_leds                   13   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -304,7 +304,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -360,7 +360,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -416,7 +416,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -472,7 +472,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -584,7 +584,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.stdout
@@ -1,6 +1,6 @@
 system time = 26336
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -60,7 +60,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -116,7 +116,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -180,7 +180,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             22   2 ready
+ 4 user_leds                   22   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -302,7 +302,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -358,7 +358,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -414,7 +414,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -526,7 +526,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -582,7 +582,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.stdout
@@ -1,6 +1,6 @@
 system time = 27649
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -60,7 +60,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4d8c (&abi::TaskDesc)
                 }
 
- 1 idle                   0   5 ready
+ 1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -116,7 +116,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4da4 (&abi::TaskDesc)
                 }
 
- 2 syscon_driver          0   2 recv
+ 2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -180,7 +180,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dbc (&abi::TaskDesc)
                 }
 
- 3 gpio_driver            0   2 recv
+ 3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dd4 (&abi::TaskDesc)
                 }
 
- 4 user_leds             24   2 ready
+ 4 user_leds                   24   2 ready
    |
    +--->  0x20003000 0x00024001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -302,7 +302,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4dec (&abi::TaskDesc)
                 }
 
- 5 usart_driver           0   2 ready
+ 5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -358,7 +358,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e04 (&abi::TaskDesc)
                 }
 
- 6 i2c_driver             0   2 ready
+ 6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -414,7 +414,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e1c (&abi::TaskDesc)
                 }
 
- 7 rng_driver             0   2 ready
+ 7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e34 (&abi::TaskDesc)
                 }
 
- 8 spi_driver             0   2 ready
+ 8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -526,7 +526,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e4c (&abi::TaskDesc)
                 }
 
- 9 ping                   0   4 ready
+ 9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -582,7 +582,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e64 (&abi::TaskDesc)
                 }
 
-10 pong                   0   3 ready
+10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x4e7c (&abi::TaskDesc)
                 }
 
-11 spam                   0   3 not started
+11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
@@ -1,6 +1,6 @@
 system time = 348745
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+55)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+55)
    |
    +--->  0x20001320 0x08009e7a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004d7c (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004d94 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dac (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,4 +256,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004dc4 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver            52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)
+ 4 i2c_driver                  52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.stdout
@@ -1,6 +1,6 @@
 system time = 83329
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 FAULT: stack overflow; sp=0x20000fa0 (was: ready)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 FAULT: stack overflow; sp=0x20000fa0 (was: ready)
    stack unwind failed: Do not have unwind info for the given address. 
    |
    +--->   R0 = 0x20000ac0   R1 = 0x00000540   R2 = 0x08004c38   R3 = 0x08004c38
@@ -58,7 +58,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e98 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -122,7 +122,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004eb0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -188,7 +188,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ee0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b30 0x080162a2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -318,7 +318,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef8 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003350 0x08019972 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -380,7 +380,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f10 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
@@ -448,7 +448,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f28 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 wait: reply from spi_driver/gen0
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f40 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -572,7 +572,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f58 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
+ 9 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -635,7 +635,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f70 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+671)
+10 i2c_debug                    0   3 notif: bit31(T+671)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -699,7 +699,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f88 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 notif: bit31(T+552)
+11 thermal                      0   3 notif: bit31(T+552)
    |
    +--->  0x200085d0 0x08035396 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -763,7 +763,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fa0 (&abi::TaskDesc)
                 }
 
-12 idle                   0   5 ready
+12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.stdout
@@ -1,6 +1,6 @@
 system time = 17
-ID TASK                 GEN PRI STATE    
- 0 runner                 0   0 ready
+ID TASK                       GEN PRI STATE    
+ 0 runner                       0   0 ready
    |
    +--->  0x20001598 0x0800a48e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cd4 (&abi::TaskDesc)
                 }
 
- 1 suite                 18   2 ready
+ 1 suite                       18   2 ready
    |
    +--->  0x20002510 0x080155a6 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -132,7 +132,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cec (&abi::TaskDesc)
                 }
 
- 2 assist                18   1 RUNNING
+ 2 assist                      18   1 RUNNING
    |
    +--->  0x20003558 0x08019d46 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -200,7 +200,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004d04 (&abi::TaskDesc)
                 }
 
- 3 idle                   0   3 ready
+ 3 idle                         0   3 ready
    |
    +--->  0x20004100 0x0801c001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:807

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.stdout
@@ -1,6 +1,6 @@
 system time = 226724
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+76)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
    |
    +--->  0x20001538 0x08009ef2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e40 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e58 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e70 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e88 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b60 0x08015a16 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea0 (&abi::TaskDesc)
                 }
 
- 5 spi_driver             0   2 RUNNING
+ 5 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003398 0x080193ca userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004eb8 (&abi::TaskDesc)
                 }
 
- 6 spi                    0   3 wait: reply from spi_driver/gen0
+ 6 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0801c20e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -448,7 +448,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed0 (&abi::TaskDesc)
                 }
 
- 7 user_leds              0   2 recv
+ 7 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x0801eea6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -514,7 +514,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ee8 (&abi::TaskDesc)
                 }
 
- 8 pong                   0   3 recv, notif: bit0(T+276)
+ 8 pong                         0   3 recv, notif: bit0(T+276)
    |
    +--->  0x200047b8 0x08020d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -574,7 +574,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f00 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 notif: bit31(T+276)
+ 9 i2c_debug                    0   3 notif: bit31(T+276)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f18 (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 ready
+10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08030056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.stdout
@@ -1,6 +1,6 @@
 system time = 18946
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20001538 0x08009ef2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e40 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e58 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e70 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004e88 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b60 0x08015a16 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ea0 (&abi::TaskDesc)
                 }
 
- 5 spi_driver             0   2 notif: bit0(irq84)
+ 5 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x20003398 0x080193ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -392,7 +392,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004eb8 (&abi::TaskDesc)
                 }
 
- 6 spi                    0   3 wait: reply from spi_driver/gen0
+ 6 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0801c20e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed0 (&abi::TaskDesc)
                 }
 
- 7 user_leds              0   2 recv
+ 7 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x0801eea6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -516,7 +516,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ee8 (&abi::TaskDesc)
                 }
 
- 8 pong                   0   3 recv, notif: bit0(T+54)
+ 8 pong                         0   3 recv, notif: bit0(T+54)
    |
    +--->  0x200047b8 0x08020d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -576,7 +576,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f00 (&abi::TaskDesc)
                 }
 
- 9 i2c_debug              0   3 notif: bit31(T+54)
+ 9 i2c_debug                    0   3 notif: bit31(T+54)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f18 (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING
    |
    +--->  0x20008100 0x08030056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.stdout
@@ -1,6 +1,6 @@
 system time = 323356
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -336,7 +336,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -398,7 +398,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -464,7 +464,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -522,7 +522,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -588,7 +588,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -648,7 +648,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -712,7 +712,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: reply from i2c_driver/gen0
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -776,7 +776,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x0804373a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -840,7 +840,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 ready
+13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -904,7 +904,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
@@ -1,6 +1,6 @@
 system time = 5457089
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c04 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c1c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c34 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c4c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,7 +242,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c64 (&abi::TaskDesc)
                 }
 
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f68 0x08019822 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -288,7 +288,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c7c (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c94 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+411)
+ 7 pong                         0   3 recv, notif: bit0(T+411)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cac (&abi::TaskDesc)
                 }
 
- 8 i2c_debug              0   3 notif: bit31(T+911)
+ 8 i2c_debug                    0   3 notif: bit31(T+911)
    |
    +--->  0x20005fa0 0x08021726 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -430,7 +430,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cc4 (&abi::TaskDesc)
                 }
 
- 9 adt7420                0   3 notif: bit31(T+361)
+ 9 adt7420                      0   3 notif: bit31(T+361)
    |
    +--->  0x2000ff80 0x0802573e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -478,4 +478,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cdc (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.stdout
@@ -1,6 +1,6 @@
 system time = 3607115
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002ad0 0x0801638a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -400,7 +400,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -466,7 +466,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -524,7 +524,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -590,7 +590,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -650,7 +650,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -714,7 +714,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 ready
+11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -778,7 +778,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -842,7 +842,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -906,7 +906,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.stdout
@@ -1,6 +1,6 @@
 system time = 438460
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b20 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -326,7 +326,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -388,7 +388,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 ready
+11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -830,7 +830,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -894,7 +894,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.stdout
@@ -1,6 +1,6 @@
 system time = 66322
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801638a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
@@ -454,7 +454,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 wait: reply from spi_driver/gen0
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -578,7 +578,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+178)
+ 9 pong                         0   3 recv, notif: bit0(T+178)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 notif: bit31(T+178)
+10 i2c_debug                    0   3 notif: bit31(T+178)
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 notif: bit31(T+807)
+11 thermal                      0   3 notif: bit31(T+807)
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -766,7 +766,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 notif: bit31(T+807)
+12 power                        0   3 notif: bit31(T+807)
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -830,7 +830,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 notif: bit31(T+10)
+13 hiffy                        0   3 notif: bit31(T+10)
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -894,7 +894,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.stdout
@@ -1,6 +1,6 @@
 system time = 20495
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ec0 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ed8 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ef0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f08 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
@@ -342,7 +342,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f20 (&abi::TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit1(irq33/irq34)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -404,7 +404,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f38 (&abi::TaskDesc)
                 }
 
- 6 spi_driver             0   2 recv
+ 6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -470,7 +470,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f50 (&abi::TaskDesc)
                 }
 
- 7 spi                    0   3 ready
+ 7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -528,7 +528,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f68 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -594,7 +594,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f80 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 ready
+ 9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -654,7 +654,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004f98 (&abi::TaskDesc)
                 }
 
-10 i2c_debug              0   3 ready
+10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -718,7 +718,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fb0 (&abi::TaskDesc)
                 }
 
-11 thermal                0   3 wait: reply from i2c_driver/gen0
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
@@ -782,7 +782,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fc8 (&abi::TaskDesc)
                 }
 
-12 power                  0   3 ready
+12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -846,7 +846,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004fe0 (&abi::TaskDesc)
                 }
 
-13 hiffy                  0   3 ready
+13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -910,7 +910,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ff8 (&abi::TaskDesc)
                 }
 
-14 idle                   0   5 ready
+14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.stdout
@@ -1,6 +1,6 @@
 system time = 166704
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c8 0x08011db6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a18 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x08018e06 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a30 (&abi::TaskDesc)
                 }
 
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001fc0 0x0801d202 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a48 (&abi::TaskDesc)
                 }
 
- 3 user_leds              0   2 recv
+ 3 user_leds                    0   2 recv
    |
    +--->  0x200023d0 0x08021052 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a60 (&abi::TaskDesc)
                 }
 
- 4 ping                  59   4 FAULT: divide by zero (was: ready)
+ 4 ping                        59   4 FAULT: divide by zero (was: ready)
    |
    +--->  0x200025b0 0x0802405e task_ping::divzero
    |                 @ /home/bmc/hubris/task-ping/src/main.rs:28
@@ -315,7 +315,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a78 (&abi::TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+296)
+ 5 pong                         0   3 recv, notif: bit0(T+296)
    |
    +--->  0x20002bb8 0x08026d1a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -375,7 +375,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004a90 (&abi::TaskDesc)
                 }
 
- 6 hiffy                  0   3 notif: bit31(T+203)
+ 6 hiffy                        0   3 notif: bit31(T+203)
    |
    +--->  0x20004588 0x08029ae6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
@@ -439,7 +439,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004aa8 (&abi::TaskDesc)
                 }
 
- 7 idle                   0   5 RUNNING
+ 7 idle                         0   5 RUNNING
    |
    +--->  0x20006100 0x08030056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
@@ -1,6 +1,6 @@
 system time = 9405072
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c04 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c1c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c34 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,4 +192,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c4c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.stdout
@@ -1,6 +1,6 @@
 system time = 78902779
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009d9e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005288 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052a0 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052b8 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052d0 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015962 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80052e8 (&abi::TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20003388 0x080193c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -390,7 +390,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005300 (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x0801ce6a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -456,7 +456,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005318 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+221)
+ 7 pong                         0   3 recv, notif: bit0(T+221)
    |
    +--->  0x200047b0 0x0801ecde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -516,7 +516,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005330 (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+175)
+ 8 hiffy                        0   3 notif: bit31(T+175)
    |
    +--->  0x20008580 0x08022386 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -580,7 +580,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005348 (&abi::TaskDesc)
                 }
 
- 9 ping                  20   4 wait: reply from usart_driver/gen0
+ 9 ping                        20   4 wait: reply from usart_driver/gen0
    |
    +--->  0x2000c1b0 0x08028f58 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:128
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005360 (&abi::TaskDesc)
                 }
 
-10 idle                   0   5 RUNNING
+10 idle                         0   5 RUNNING
    |
    +--->  0x2000c300 0x0802a056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.stdout
@@ -1,6 +1,6 @@
 system time = 154939
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009daa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005308 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005320 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005338 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005350 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801624a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005368 (&abi::TaskDesc)
                 }
 
- 5 spd                    1   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:300:17 (was: ready)
+ 5 spd                          1   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:300:17 (was: ready)
    |
    +--->  0x20004230 0x08019d00 userlib::sys_panic_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:654
@@ -395,7 +395,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005380 (&abi::TaskDesc)
                 }
 
- 6 spi2_driver            0   2 recv
+ 6 spi2_driver                  0   2 recv
    |
    +--->  0x20008390 0x0801d3ae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -461,7 +461,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005398 (&abi::TaskDesc)
                 }
 
- 7 spi4_driver            0   2 recv
+ 7 spi4_driver                  0   2 recv
    |
    +--->  0x20009390 0x080213ae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -527,7 +527,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053b0 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x2000a3c8 0x08024e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -593,7 +593,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053c8 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+61)
+ 9 pong                         0   3 recv, notif: bit0(T+61)
    |
    +--->  0x2000a7b0 0x08026cde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -653,7 +653,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053e0 (&abi::TaskDesc)
                 }
 
-10 thermal                0   3 notif: bit31(T+609)
+10 thermal                      0   3 notif: bit31(T+609)
    |
    +--->  0x2000c670 0x08033fde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -717,7 +717,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053f8 (&abi::TaskDesc)
                 }
 
-11 power                  0   3 notif: bit31(T+608)
+11 power                        0   3 notif: bit31(T+608)
    |
    +--->  0x2000e760 0x08043686 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -781,7 +781,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005410 (&abi::TaskDesc)
                 }
 
-12 hiffy                  0   3 notif: bit31(T+171)
+12 hiffy                        0   3 notif: bit31(T+171)
    |
    +--->  0x20010580 0x08052d06 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -845,7 +845,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005428 (&abi::TaskDesc)
                 }
 
-13 idle                   0   5 RUNNING
+13 idle                         0   5 RUNNING
    |
    +--->  0x20014100 0x08058056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.stdout
@@ -1,6 +1,6 @@
 system time = 134568
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009daa userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -64,7 +64,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005308 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -128,7 +128,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005320 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -194,7 +194,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005338 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -258,7 +258,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005350 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801624a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -324,7 +324,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005368 (&abi::TaskDesc)
                 }
 
- 5 spd                    2   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:312:17 (was: ready)
+ 5 spd                          2   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:312:17 (was: ready)
    |
    +--->  0x20004230 0x08019d00 userlib::sys_panic_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:654
@@ -395,7 +395,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005380 (&abi::TaskDesc)
                 }
 
- 6 spi2_driver            0   2 recv
+ 6 spi2_driver                  0   2 recv
    |
    +--->  0x20008390 0x0801d3ae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -461,7 +461,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005398 (&abi::TaskDesc)
                 }
 
- 7 spi4_driver            0   2 recv
+ 7 spi4_driver                  0   2 recv
    |
    +--->  0x20009390 0x080213ae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -527,7 +527,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053b0 (&abi::TaskDesc)
                 }
 
- 8 user_leds              0   2 recv
+ 8 user_leds                    0   2 recv
    |
    +--->  0x2000a3c8 0x08024e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -593,7 +593,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053c8 (&abi::TaskDesc)
                 }
 
- 9 pong                   0   3 recv, notif: bit0(T+432)
+ 9 pong                         0   3 recv, notif: bit0(T+432)
    |
    +--->  0x2000a7b0 0x08026cde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -653,7 +653,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053e0 (&abi::TaskDesc)
                 }
 
-10 thermal                0   3 notif: bit31(T+661)
+10 thermal                      0   3 notif: bit31(T+661)
    |
    +--->  0x2000c670 0x08033fde userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -717,7 +717,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053f8 (&abi::TaskDesc)
                 }
 
-11 power                  0   3 notif: bit31(T+660)
+11 power                        0   3 notif: bit31(T+660)
    |
    +--->  0x2000e760 0x08043686 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -781,7 +781,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005410 (&abi::TaskDesc)
                 }
 
-12 hiffy                  0   3 notif: bit31(T+42)
+12 hiffy                        0   3 notif: bit31(T+42)
    |
    +--->  0x20010580 0x08052d06 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
@@ -845,7 +845,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005428 (&abi::TaskDesc)
                 }
 
-13 idle                   0   5 RUNNING
+13 idle                         0   5 RUNNING
    |
    +--->  0x20014100 0x08058056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.stdout
@@ -1,6 +1,6 @@
 system time = 17903
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+97)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+97)
    |
    +--->  0x20005538 0x00011efe userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf63c (&abi::TaskDesc)
                 }
 
- 1 hiffy                  0   3 notif: bit31(T+101)
+ 1 hiffy                        0   3 notif: bit31(T+101)
    |
    +--->  0x20008580 0x0001a13a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf654 (&abi::TaskDesc)
                 }
 
- 2 idle                   0   5 RUNNING
+ 2 idle                         0   5 RUNNING
    |
    +--->  0x2000c900 0x00042056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
@@ -182,7 +182,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf66c (&abi::TaskDesc)
                 }
 
- 3 syscon_driver          0   2 recv
+ 3 syscon_driver                0   2 recv
    |
    +--->  0x200063c0 0x00020d2a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf684 (&abi::TaskDesc)
                 }
 
- 4 gpio_driver            0   2 recv
+ 4 gpio_driver                  0   2 recv
    |
    +--->  0x200067a8 0x000258da userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -312,7 +312,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf69c (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x00028f7e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -378,7 +378,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6b4 (&abi::TaskDesc)
                 }
 
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x20006fb0 0x0002d15e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6cc (&abi::TaskDesc)
                 }
 
- 7 i2c_driver             0   2 recv
+ 7 i2c_driver                   0   2 recv
    |
    +--->  0x200073b8 0x0003133c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6e4 (&abi::TaskDesc)
                 }
 
- 8 rng_driver             0   2 recv
+ 8 rng_driver                   0   2 recv
    |
    +--->  0x200077b8 0x00034f1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -566,7 +566,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6fc (&abi::TaskDesc)
                 }
 
- 9 spi_driver             0   2 recv, notif: bit0(irq59)
+ 9 spi_driver                   0   2 recv, notif: bit0(irq59)
    |
    +--->  0x20007b68 0x00039594 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -630,7 +630,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf714 (&abi::TaskDesc)
                 }
 
-10 ping                  44   4 wait: reply from usart_driver/gen0
+10 ping                        44   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007f98 0x0003cfa0 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:129
@@ -690,7 +690,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf72c (&abi::TaskDesc)
                 }
 
-11 pong                   0   3 recv, notif: bit0(T+97)
+11 pong                         0   3 recv, notif: bit0(T+97)
    |
    +--->  0x2000c398 0x0003ed02 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -750,7 +750,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf744 (&abi::TaskDesc)
                 }
 
-12 spam                   0   3 not started
+12 spam                         0   3 not started
    |
    +--->  0x2000c7e8 0x00040001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:766

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.stdout
@@ -1,6 +1,6 @@
 system time = 46973
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+27)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+27)
    |
    +--->  0x20005538 0x00011efe userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf63c (&abi::TaskDesc)
                 }
 
- 1 hiffy                  0   3 notif: bit31(T+31)
+ 1 hiffy                        0   3 notif: bit31(T+31)
    |
    +--->  0x20008580 0x0001a13a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf654 (&abi::TaskDesc)
                 }
 
- 2 idle                   0   5 RUNNING
+ 2 idle                         0   5 RUNNING
    |
    +--->  0x2000c900 0x00042056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
@@ -182,7 +182,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf66c (&abi::TaskDesc)
                 }
 
- 3 syscon_driver          0   2 recv
+ 3 syscon_driver                0   2 recv
    |
    +--->  0x200063c0 0x00020d2a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -246,7 +246,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf684 (&abi::TaskDesc)
                 }
 
- 4 gpio_driver            0   2 recv
+ 4 gpio_driver                  0   2 recv
    |
    +--->  0x200067a8 0x000258da userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -312,7 +312,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf69c (&abi::TaskDesc)
                 }
 
- 5 user_leds              0   2 recv
+ 5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x00028f7e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -378,7 +378,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6b4 (&abi::TaskDesc)
                 }
 
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x20006fb0 0x0002d15e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -440,7 +440,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6cc (&abi::TaskDesc)
                 }
 
- 7 i2c_driver             0   2 recv
+ 7 i2c_driver                   0   2 recv
    |
    +--->  0x200073b8 0x0003133c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6e4 (&abi::TaskDesc)
                 }
 
- 8 rng_driver             0   2 recv
+ 8 rng_driver                   0   2 recv
    |
    +--->  0x200077b8 0x00034f1e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -566,7 +566,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf6fc (&abi::TaskDesc)
                 }
 
- 9 spi_driver             0   2 recv, notif: bit0(irq59)
+ 9 spi_driver                   0   2 recv, notif: bit0(irq59)
    |
    +--->  0x20007b68 0x00039594 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -630,7 +630,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf714 (&abi::TaskDesc)
                 }
 
-10 ping                  50   4 wait: reply from usart_driver/gen0
+10 ping                        50   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007f98 0x0003cfa0 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:129
@@ -690,7 +690,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf72c (&abi::TaskDesc)
                 }
 
-11 pong                   0   3 recv, notif: bit0(T+27)
+11 pong                         0   3 recv, notif: bit0(T+27)
    |
    +--->  0x2000c398 0x0003ed02 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
@@ -750,7 +750,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0xf744 (&abi::TaskDesc)
                 }
 
-12 spam                   0   3 not started
+12 spam                         0   3 not started
    |
    +--->  0x2000c7e8 0x00040001 _start
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:766

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.stdout
@@ -1,6 +1,6 @@
 system time = 223859
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+41)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+41)
    |
    +--->  0x20002540 0x08011fc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007680 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08020e66 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007698 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc0 0x08023036 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076b0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200043c0 0x08024fee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076c8 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b78 0x08015ba0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076e0 (&abi::TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20001370 0x08019968 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076f8 (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200047c8 0x08026ece userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007710 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+141)
+ 7 pong                         0   3 recv, notif: bit0(T+141)
    |
    +--->  0x20004bb0 0x08028d02 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007728 (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+169)
+ 8 hiffy                        0   3 notif: bit31(T+169)
    |
    +--->  0x20008578 0x0800c02e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -576,7 +576,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007740 (&abi::TaskDesc)
                 }
 
- 9 hf                     0   3 recv
+ 9 hf                           0   3 recv
    |
    +--->  0x200036b0 0x0801d7f8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -642,7 +642,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007758 (&abi::TaskDesc)
                 }
 
-10 ping                  44   4 wait: reply from usart_driver/gen0
+10 ping                        44   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004db0 0x0802afa0 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:130
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007770 (&abi::TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20004f00 0x0802c056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.stdout
@@ -1,6 +1,6 @@
 system time = 1008605
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+95)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+95)
    |
    +--->  0x20002540 0x08011fc6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007680 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08020e66 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -126,7 +126,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007698 (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc0 0x08023036 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076b0 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200043c0 0x08024fee userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -256,7 +256,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076c8 (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b78 0x08015ba0 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -322,7 +322,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076e0 (&abi::TaskDesc)
                 }
 
- 5 spi_driver             0   2 recv
+ 5 spi_driver                   0   2 recv
    |
    +--->  0x20001370 0x08019968 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -386,7 +386,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80076f8 (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200047c8 0x08026ece userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007710 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+395)
+ 7 pong                         0   3 recv, notif: bit0(T+395)
    |
    +--->  0x20004bb0 0x08028d02 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -512,7 +512,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007728 (&abi::TaskDesc)
                 }
 
- 8 hiffy                  0   3 notif: bit31(T+26)
+ 8 hiffy                        0   3 notif: bit31(T+26)
    |
    +--->  0x20008578 0x0800c02e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -576,7 +576,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007740 (&abi::TaskDesc)
                 }
 
- 9 hf                     0   3 recv
+ 9 hf                           0   3 recv
    |
    +--->  0x200036b0 0x0801d7f8 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
@@ -642,7 +642,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007758 (&abi::TaskDesc)
                 }
 
-10 ping                  31   4 wait: reply from usart_driver/gen0
+10 ping                        31   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004db0 0x0802afa0 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:130
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007770 (&abi::TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING
    |
    +--->  0x20004f00 0x0802c056 main
    |                 @ /home/bmc/hubris/task-idle/src/main.rs:9

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
@@ -1,6 +1,6 @@
 system time = 4318592
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bb4 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bcc (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004be4 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,4 +192,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004bfc (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 RUNNING
+ 4 i2c_driver                   0   2 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.stdout
@@ -1,6 +1,6 @@
 system time = 606213
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+87)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
    |
    +--->  0x20004540 0x0801147c userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800770c (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007724 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800773c (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007754 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800776c (&TaskDesc)
                 }
 
- 5 spi_driver             0   2 RUNNING
+ 5 spi_driver                   0   2 RUNNING
    |
    +--->  0x200012d8 0x080199f2 userlib::sys_irq_control_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
@@ -388,7 +388,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007784 (&TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -450,7 +450,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800779c (&TaskDesc)
                 }
 
- 7 pong                   0   3 ready
+ 7 pong                         0   3 ready
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -510,7 +510,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077b4 (&TaskDesc)
                 }
 
- 8 ping                4777   4 ready
+ 8 ping                      4777   4 ready
    |
    +--->  0x200065b0 0x0802ae84 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -570,7 +570,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077cc (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 wait: reply from spi_driver/gen0
+ 9 hiffy                        0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20008518 0x0800b696 userlib::sys_send_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
@@ -638,7 +638,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077e4 (&TaskDesc)
                 }
 
-10 hf                     0   3 ready
+10 hf                           0   3 ready
    |
    +--->  0x20002648 0x0801d718 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
@@ -702,7 +702,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80077fc (&TaskDesc)
                 }
 
-11 idle                   0   5 ready
+11 idle                         0   5 ready
    |
    +--->  0x20006700 0x0802c056 main
    |                 @ /home/bmc/hubris/task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.stdout
@@ -1,6 +1,6 @@
 system time = 58463
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+37)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+37)
    |
    +--->  0x20002540 0x0801154c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007afc (&TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08024c86 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b14 (&TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc8 0x08026ee6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b2c (&TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200103c0 0x08028dee userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -254,7 +254,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b44 (&TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b58 0x08015814 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -320,7 +320,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b5c (&TaskDesc)
                 }
 
- 5 spd                    0   2 notif: bit31(T+7)
+ 5 spd                          0   2 notif: bit31(T+7)
    |
    +--->  0x20004328 0x08019ef2 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -384,7 +384,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b74 (&TaskDesc)
                 }
 
- 6 spi_driver             0   2 RUNNING
+ 6 spi_driver                   0   2 RUNNING
    |
    +--->  0x200012e0 0x0801d97e userlib::sys_irq_control_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:651
@@ -452,7 +452,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007b8c (&TaskDesc)
                 }
 
- 7 user_leds              0   2 recv
+ 7 user_leds                    0   2 recv
    |
    +--->  0x200107c8 0x0802ad5e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -514,7 +514,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007ba4 (&TaskDesc)
                 }
 
- 8 pong                   0   3 ready
+ 8 pong                         0   3 ready
    |
    +--->  0x20010bb8 0x0802cb1e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -574,7 +574,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bbc (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 wait: reply from spi_driver/gen0
+ 9 hiffy                        0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20008530 0x0800b7f2 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:153
@@ -640,7 +640,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bd4 (&TaskDesc)
                 }
 
-10 hf                     0   3 ready
+10 hf                           0   3 ready
    |
    +--->  0x20003658 0x08021658 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:288
@@ -704,7 +704,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8007bec (&TaskDesc)
                 }
 
-11 idle                   0   5 ready
+11 idle                         0   5 ready
    |
    +--->  0x20010d00 0x0802e056 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
@@ -1,6 +1,6 @@
 system time = 27971
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c24 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c3c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c54 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c6c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015902 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,7 +242,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c84 (&abi::TaskDesc)
                 }
 
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f60 0x080197ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -288,7 +288,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c9c (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cb4 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+29)
+ 7 pong                         0   3 recv, notif: bit0(T+29)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ccc (&abi::TaskDesc)
                 }
 
- 8 i2c_debug              0   3 notif: bit31(T+29)
+ 8 i2c_debug                    0   3 notif: bit31(T+29)
    |
    +--->  0x20005f78 0x08022be6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -430,7 +430,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ce4 (&abi::TaskDesc)
                 }
 
- 9 adt7420                0   3 notif: bit31(T+29)
+ 9 adt7420                      0   3 notif: bit31(T+29)
    |
    +--->  0x2000ff78 0x0802984e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -478,7 +478,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cfc (&abi::TaskDesc)
                 }
 
-10 max31790               0   3 notif: bit31(T+30)
+10 max31790                     0   3 notif: bit31(T+30)
    |
    +--->  0x200103b0 0x0802d1da userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -526,4 +526,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004d14 (&abi::TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
@@ -1,6 +1,6 @@
 system time = 1049327
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -46,7 +46,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c24 (&abi::TaskDesc)
                 }
 
- 1 rcc_driver             0   1 recv
+ 1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -94,7 +94,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c3c (&abi::TaskDesc)
                 }
 
- 2 gpio_driver            0   2 recv
+ 2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -144,7 +144,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c54 (&abi::TaskDesc)
                 }
 
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -192,7 +192,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c6c (&abi::TaskDesc)
                 }
 
- 4 i2c_driver             0   2 recv
+ 4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015902 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -242,7 +242,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c84 (&abi::TaskDesc)
                 }
 
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f60 0x080197ea userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -288,7 +288,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004c9c (&abi::TaskDesc)
                 }
 
- 6 user_leds              0   2 recv
+ 6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -338,7 +338,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cb4 (&abi::TaskDesc)
                 }
 
- 7 pong                   0   3 recv, notif: bit0(T+173)
+ 7 pong                         0   3 recv, notif: bit0(T+173)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -382,7 +382,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ccc (&abi::TaskDesc)
                 }
 
- 8 i2c_debug              0   3 notif: bit31(T+673)
+ 8 i2c_debug                    0   3 notif: bit31(T+673)
    |
    +--->  0x20005f78 0x08022be6 userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -430,7 +430,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004ce4 (&abi::TaskDesc)
                 }
 
- 9 adt7420                0   3 notif: bit31(T+673)
+ 9 adt7420                      0   3 notif: bit31(T+673)
    |
    +--->  0x2000ff78 0x0802984e userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -478,7 +478,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004cfc (&abi::TaskDesc)
                 }
 
-10 max31790               0   3 notif: bit31(T+674)
+10 max31790                     0   3 notif: bit31(T+674)
    |
    +--->  0x200103b0 0x0802d1da userlib::sys_recv_stub
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
@@ -526,4 +526,4 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004d14 (&abi::TaskDesc)
                 }
 
-11 idle                   0   5 RUNNING
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.stdout
@@ -1,6 +1,6 @@
 system time = 444064
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+36)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
    |
    +--->  0x20014538 0x0805d54c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005358 (&TaskDesc)
                 }
 
- 1 net                    0   2 recv, notif: bit0(irq61) bit1(T+179)
+ 1 net                          0   2 recv, notif: bit0(irq61) bit1(T+179)
    |
    +--->  0x200028a8 0x0802e7f8 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005370 (&TaskDesc)
                 }
 
- 2 sys                    0   1 recv
+ 2 sys                          0   1 recv
    |
    +--->  0x20017b50 0x080625d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -186,7 +186,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005388 (&TaskDesc)
                 }
 
- 3 spi4_driver            0   2 recv
+ 3 spi4_driver                  0   2 recv
    |
    +--->  0x20014ae8 0x08041c30 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -248,7 +248,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053a0 (&TaskDesc)
                 }
 
- 4 spi2_driver            0   2 recv
+ 4 spi2_driver                  0   2 recv
    |
    +--->  0x200152e0 0x08045d58 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -310,7 +310,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053b8 (&TaskDesc)
                 }
 
- 5 i2c_driver             0   2 recv
+ 5 i2c_driver                   0   2 recv
    |
    +--->  0x20015a58 0x0804a06c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -376,7 +376,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053d0 (&TaskDesc)
                 }
 
- 6 spd                    0   2 notif: bit0(irq31/irq32)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x0804deee userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -438,7 +438,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80053e8 (&TaskDesc)
                 }
 
- 7 thermal                0   3 recv, notif: bit0(T+943)
+ 7 thermal                      0   3 recv, notif: bit0(T+943)
    |
    +--->  0x200166c0 0x0805f512 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -500,7 +500,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005400 (&TaskDesc)
                 }
 
- 8 power                  0   3 notif: bit31(T+618)
+ 8 power                        0   3 notif: bit31(T+618)
    |
    +--->  0x200123c8 0x0805229e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -564,7 +564,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005418 (&TaskDesc)
                 }
 
- 9 hiffy                  0   3 notif: bit31(T+172)
+ 9 hiffy                        0   3 notif: bit31(T+172)
    |
    +--->  0x20008140 0x0800b672 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -632,7 +632,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005430 (&TaskDesc)
                 }
 
-10 gimlet_seq             0   3 recv
+10 gimlet_seq                   0   3 recv
    |
    +--->  0x200134f0 0x080135da userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -694,7 +694,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005448 (&TaskDesc)
                 }
 
-11 hf                     0   3 recv
+11 hf                           0   3 recv
    |
    +--->  0x20016df8 0x0805582c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -756,7 +756,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005460 (&TaskDesc)
                 }
 
-12 sensor                 0   3 recv, notif: bit0(T+936)
+12 sensor                       0   3 recv, notif: bit0(T+936)
    |
    +--->  0x20017388 0x08060bbe userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -818,7 +818,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005478 (&TaskDesc)
                 }
 
-13 udpecho                0   3 notif: bit0
+13 udpecho                      0   3 notif: bit0
    |
    +--->  0x20010e08 0x0805957e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -878,7 +878,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8005490 (&TaskDesc)
                 }
 
-14 idle                   0   5 RUNNING
+14 idle                         0   5 RUNNING
    |
    +--->  0x20017d00 0x08062856 main
    |                 @ /hubris//task/idle/src/main.rs:13

--- a/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.stdout
@@ -1,6 +1,6 @@
 system time = 0
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 wait: send to jefe/gen0
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 wait: send to jefe/gen0
    |
    +--->  0x20013538 0x0803554c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004870 (&TaskDesc)
                 }
 
- 1 sys                    0   1 FAULT: illegal instruction (was: ready)
+ 1 sys                          0   1 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20015330 0x0803e60a userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:990
@@ -137,7 +137,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004884 (&TaskDesc)
                 }
 
- 2 i2c_driver             0   2 FAULT: illegal instruction (was: ready)
+ 2 i2c_driver                   0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20013a48 0x0802995a userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:990
@@ -206,7 +206,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004898 (&TaskDesc)
                 }
 
- 3 spi_driver             0   2 FAULT: illegal instruction (was: ready)
+ 3 spi_driver                   0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20014278 0x0802dcaa userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:990
@@ -275,7 +275,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048ac (&TaskDesc)
                 }
 
- 4 user_leds              0   2 FAULT: illegal instruction (was: ready)
+ 4 user_leds                    0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x200156f0 0x0803ebf2 userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:990
@@ -348,7 +348,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048c0 (&TaskDesc)
                 }
 
- 5 pong                   0   3 FAULT: illegal instruction (was: ready)
+ 5 pong                         0   3 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20015b20 0x0803f1fa userlib::sys_panic_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:990
@@ -417,7 +417,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048d4 (&TaskDesc)
                 }
 
- 6 uartecho               0   3 RUNNING
+ 6 uartecho                     0   3 RUNNING
    |
    +--->  0x20010728 0x080372ae userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:154
@@ -483,7 +483,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048e8 (&TaskDesc)
                 }
 
- 7 hiffy                  0   4 ready
+ 7 hiffy                        0   4 ready
    |
    +--->  0x20008800 0x08008001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -539,7 +539,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048fc (&TaskDesc)
                 }
 
- 8 hf                     0   3 ready
+ 8 hf                           0   3 ready
    |
    +--->  0x20014f80 0x08030001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -595,7 +595,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004910 (&TaskDesc)
                 }
 
- 9 net                    0   3 ready
+ 9 net                          0   3 ready
    |
    +--->  0x200050e0 0x08010001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -651,7 +651,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004924 (&TaskDesc)
                 }
 
-10 udpecho                0   4 ready
+10 udpecho                      0   4 ready
    |
    +--->  0x20003000 0x08038001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -707,7 +707,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004938 (&TaskDesc)
                 }
 
-11 validate               0   3 ready
+11 validate                     0   3 ready
    |
    +--->  0x20011400 0x08020001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -763,7 +763,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800494c (&TaskDesc)
                 }
 
-12 idle                   0   5 ready
+12 idle                         0   5 ready
    |
    +--->  0x20015f00 0x0803f401 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -819,7 +819,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004960 (&TaskDesc)
                 }
 
-13 rng_driver             0   3 ready
+13 rng_driver                   0   3 ready
    |
    +--->  0x20015d00 0x0803a001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167
@@ -875,7 +875,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004974 (&TaskDesc)
                 }
 
-14 update_server          0   3 ready
+14 update_server                0   3 ready
    |
    +--->  0x20012800 0x0803c001 _start
    |                 @ /hubris//sys/userlib/src/lib.rs:1167

--- a/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.stdout
@@ -1,6 +1,6 @@
 system time = 695346
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20013538 0x0803554c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -62,7 +62,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004880 (&TaskDesc)
                 }
 
- 1 sys                    0   1 recv
+ 1 sys                          0   1 recv
    |
    +--->  0x20015350 0x0803e5d6 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -124,7 +124,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004894 (&TaskDesc)
                 }
 
- 2 i2c_driver             0   2 recv
+ 2 i2c_driver                   0   2 recv
    |
    +--->  0x20013ac0 0x08029898 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -190,7 +190,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048a8 (&TaskDesc)
                 }
 
- 3 spi_driver             0   2 recv
+ 3 spi_driver                   0   2 recv
    |
    +--->  0x200142f0 0x0802dc34 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -252,7 +252,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048bc (&TaskDesc)
                 }
 
- 4 user_leds              0   2 recv
+ 4 user_leds                    0   2 recv
    |
    +--->  0x20015740 0x0803eb60 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -314,7 +314,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048d0 (&TaskDesc)
                 }
 
- 5 pong                   0   3 recv, notif: bit0(T+154)
+ 5 pong                         0   3 recv, notif: bit0(T+154)
    |
    +--->  0x20015b38 0x0803f198 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -376,7 +376,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048e4 (&TaskDesc)
                 }
 
- 6 uartecho               0   3 notif: bit0(irq38)
+ 6 uartecho                     0   3 notif: bit0(irq38)
    |
    +--->  0x20010728 0x08037292 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -438,7 +438,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x80048f8 (&TaskDesc)
                 }
 
- 7 hiffy                  0   4 notif: bit31(T+175)
+ 7 hiffy                        0   4 notif: bit31(T+175)
    |
    +--->  0x20008540 0x0800bd62 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -506,7 +506,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800490c (&TaskDesc)
                 }
 
- 8 hf                     0   3 recv
+ 8 hf                           0   3 recv
    |
    +--->  0x20014e08 0x080317b4 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -568,7 +568,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004920 (&TaskDesc)
                 }
 
- 9 net                    0   3 notif: bit31(T+2)
+ 9 net                          0   3 notif: bit31(T+2)
    |
    +--->  0x200047e0 0x0801b68c userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -636,7 +636,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004934 (&TaskDesc)
                 }
 
-10 udpecho                0   4 wait: send to net/gen0
+10 udpecho                      0   4 wait: send to net/gen0
    |
    +--->  0x20002dd0 0x08039726 userlib::sys_send_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:154
@@ -698,7 +698,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004948 (&TaskDesc)
                 }
 
-11 validate               0   3 recv
+11 validate                     0   3 recv
    |
    +--->  0x200113d8 0x08020bda userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -760,7 +760,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x800495c (&TaskDesc)
                 }
 
-12 idle                   0   5 ready
+12 idle                         0   5 ready
    |
    +--->  0x20015f00 0x0803f456 main
    |                 @ /hubris//task/idle/src/main.rs:13
@@ -816,7 +816,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004970 (&TaskDesc)
                 }
 
-13 rng_driver             0   3 recv
+13 rng_driver                   0   3 recv
    |
    +--->  0x20015cc0 0x0803ae7e userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332
@@ -878,7 +878,7 @@ ID TASK                 GEN PRI STATE
                     descriptor: 0x8004984 (&TaskDesc)
                 }
 
-14 update_server          0   3 recv
+14 update_server                0   3 recv
    |
    +--->  0x200123c0 0x0803d046 userlib::sys_recv_stub
    |                 @ /hubris//sys/userlib/src/lib.rs:332

--- a/tests/cmd/tasks/tasks.chilly.0.stdout
+++ b/tests/cmd/tasks/tasks.chilly.0.stdout
@@ -1,18 +1,18 @@
 system time = 687534
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+66)
- 1 net                    0   2 recv, notif: bit0(irq61) bit1(T+21)
- 2 sys                    0   1 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 notif: bit2(irq72/irq73)
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 wait: send to i2c_driver/gen0
- 8 power                  0   3 wait: reply from i2c_driver/gen0
- 9 hiffy                  0   3 notif: bit31(T+6)
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 recv, notif: bit0(T+466)
-13 udpecho                0   3 notif: bit0
-14 validate               0   3 recv
-15 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+66)
+ 1 net                          0   2 recv, notif: bit0(irq61) bit1(T+21)
+ 2 sys                          0   1 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 notif: bit2(irq72/irq73)
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 wait: send to i2c_driver/gen0
+ 8 power                        0   3 wait: reply from i2c_driver/gen0
+ 9 hiffy                        0   3 notif: bit31(T+6)
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 recv, notif: bit0(T+466)
+13 udpecho                      0   3 notif: bit0
+14 validate                     0   3 recv
+15 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.flash-ram-mismatch.0.stdout
+++ b/tests/cmd/tasks/tasks.flash-ram-mismatch.0.stdout
@@ -1,20 +1,20 @@
 system time = 2117793075957696
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T-2117793075464596)
- 1 net                    0   5 recv, notif: bit0(irq61) bit1(T-2117793075464456)
- 2 sys                    0   1 recv
- 3 spi4_driver            0   3 recv
- 4 spi2_driver            0   3 recv
- 5 i2c_driver             0   3 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   5 recv, notif: bit0(T-2117793075463689)
- 8 power                  0   6 notif: bit31(T-2117793075464383)
- 9 hiffy                  0   5 notif: bit31(T-2117793075464596)
-10 gimlet_seq             0   4 recv, notif: bit0
-11 hash_driver            0   2 recv
-12 hf                     0   3 recv
-13 sensor                 0   4 recv, notif: bit0(T-2117793075463696)
-14 udpecho                0   6 notif: bit0
-15 udpbroadcast           0   6 notif: bit31(T-2117793075464287)
-16 validate               0   5 recv
-17 idle                   0   7 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T-2117793075464596)
+ 1 net                          0   5 recv, notif: bit0(irq61) bit1(T-2117793075464456)
+ 2 sys                          0   1 recv
+ 3 spi4_driver                  0   3 recv
+ 4 spi2_driver                  0   3 recv
+ 5 i2c_driver                   0   3 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   5 recv, notif: bit0(T-2117793075463689)
+ 8 power                        0   6 notif: bit31(T-2117793075464383)
+ 9 hiffy                        0   5 notif: bit31(T-2117793075464596)
+10 gimlet_seq                   0   4 recv, notif: bit0
+11 hash_driver                  0   2 recv
+12 hf                           0   3 recv
+13 sensor                       0   4 recv, notif: bit0(T-2117793075463696)
+14 udpecho                      0   6 notif: bit0
+15 udpbroadcast                 0   6 notif: bit31(T-2117793075464287)
+16 validate                     0   5 recv
+17 idle                         0   7 ready

--- a/tests/cmd/tasks/tasks.in_bootloader.0.stdout
+++ b/tests/cmd/tasks/tasks.in_bootloader.0.stdout
@@ -1,20 +1,20 @@
 system time = 972988
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+12)
- 1 net                    0   5 recv, notif: bit0(irq61) bit1(T+18)
- 2 sys                    0   1 recv
- 3 spi4_driver            0   3 recv
- 4 spi2_driver            0   3 recv
- 5 i2c_driver             0   3 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   5 recv, notif: bit0(T+879)
- 8 power                  0   6 notif: bit31(T+174)
- 9 hiffy                  0   5 notif: bit31(T+143)
-10 gimlet_seq             0   4 recv, notif: bit0
-11 hash_driver            0   2 recv
-12 hf                     0   3 recv
-13 sensor                 0   4 recv, notif: bit0(T+12)
-14 udpecho                0   6 notif: bit0
-15 udpbroadcast           0   6 notif: bit31(T+454)
-16 validate               0   5 recv
-17 idle                   0   7 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+12)
+ 1 net                          0   5 recv, notif: bit0(irq61) bit1(T+18)
+ 2 sys                          0   1 recv
+ 3 spi4_driver                  0   3 recv
+ 4 spi2_driver                  0   3 recv
+ 5 i2c_driver                   0   3 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   5 recv, notif: bit0(T+879)
+ 8 power                        0   6 notif: bit31(T+174)
+ 9 hiffy                        0   5 notif: bit31(T+143)
+10 gimlet_seq                   0   4 recv, notif: bit0
+11 hash_driver                  0   2 recv
+12 hf                           0   3 recv
+13 sensor                       0   4 recv, notif: bit0(T+12)
+14 udpecho                      0   6 notif: bit0
+15 udpbroadcast                 0   6 notif: bit31(T+454)
+16 validate                     0   5 recv
+17 idle                         0   7 RUNNING

--- a/tests/cmd/tasks/tasks.kernel-panic.0.stdout
+++ b/tests/cmd/tasks/tasks.kernel-panic.0.stdout
@@ -1,16 +1,16 @@
 system time = 10001
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+99)
- 1 sys                    0   1 recv
- 2 i2c_driver             0   2 recv
- 3 spi_driver             0   2 recv
- 4 net                    0   2 recv, notif: bit0(irq61) bit1
- 5 user_leds              0   2 recv
- 6 ping               10301   4 wait: reply from pong/gen0
- 7 pong                   0   3 RUNNING
- 8 udpecho                0   3 notif: bit0
- 9 hiffy                  0   5 ready
-10 hf                     0   4 notif: bit31(T+22)
-11 hash_driver            0   3 recv
-12 idle                   0   6 ready
-13 rng_driver             0   3 recv
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+99)
+ 1 sys                          0   1 recv
+ 2 i2c_driver                   0   2 recv
+ 3 spi_driver                   0   2 recv
+ 4 net                          0   2 recv, notif: bit0(irq61) bit1
+ 5 user_leds                    0   2 recv
+ 6 ping                     10301   4 wait: reply from pong/gen0
+ 7 pong                         0   3 RUNNING
+ 8 udpecho                      0   3 notif: bit0
+ 9 hiffy                        0   5 ready
+10 hf                           0   4 notif: bit31(T+22)
+11 hash_driver                  0   3 recv
+12 idle                         0   6 ready
+13 rng_driver                   0   3 recv

--- a/tests/cmd/tasks/tasks.kiowa.0.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.0.stdout
@@ -1,6 +1,6 @@
 system time = 120445
-ID TASK                 GEN PRI STATE    
- 0 runner                 0   0 RUNNING
- 1 suite                 51   2 recv
- 2 assist                 2   1 recv
- 3 idle                   0   3 ready
+ID TASK                       GEN PRI STATE    
+ 0 runner                       0   0 RUNNING
+ 1 suite                       51   2 recv
+ 2 assist                       2   1 recv
+ 3 idle                         0   3 ready

--- a/tests/cmd/tasks/tasks.kiowa.1.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.1.stdout
@@ -1,12 +1,12 @@
 system time = 256368
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 user_leds              0   2 recv
- 6 pong                   0   3 ready
- 7 ping                  17   4 ready
- 8 adt7420                0   3 wait: reply from i2c_driver/gen0
- 9 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 ready
+ 7 ping                        17   4 ready
+ 8 adt7420                      0   3 wait: reply from i2c_driver/gen0
+ 9 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.10.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.10.stdout
@@ -1,14 +1,14 @@
 system time = 12256713
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+87)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            8   2 FAULT: in syscall: bad caller lease index (was: ready)
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 notif: bit31(T+708)
- 8 hiffy                  0   3 wait: reply from spi4_driver/gen8
- 9 gimlet_seq             0   3 notif: bit31(T+8)
-10 hf                     0   3 recv
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  8   2 FAULT: in syscall: bad caller lease index (was: ready)
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 notif: bit31(T+708)
+ 8 hiffy                        0   3 wait: reply from spi4_driver/gen8
+ 9 gimlet_seq                   0   3 notif: bit31(T+8)
+10 hf                           0   3 recv
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.11.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.11.stdout
@@ -1,14 +1,14 @@
 system time = 1791860
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+40)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 pong                   0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
- 8 ping               14190   4 wait: send to pong/gen0
- 9 hiffy                  0   3 notif: bit31(T+140)
-10 hf                     0   3 notif: bit31(T+151)
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+40)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
+ 8 ping                     14190   4 wait: send to pong/gen0
+ 9 hiffy                        0   3 notif: bit31(T+140)
+10 hf                           0   3 notif: bit31(T+151)
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.12.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.12.stdout
@@ -1,14 +1,14 @@
 system time = 505162
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+38)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 RUNNING
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 notif: bit31(T+444)
- 8 hiffy                  0   3 wait: reply from gimlet_seq/gen0
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
-10 hf                     0   3 recv
-11 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+38)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 RUNNING
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 notif: bit31(T+444)
+ 8 hiffy                        0   3 wait: reply from gimlet_seq/gen0
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
+10 hf                           0   3 recv
+11 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.13.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.13.stdout
@@ -1,14 +1,14 @@
 system time = 2823724
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+76)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 RUNNING
- 7 thermal                0   3 ready
- 8 hiffy                  0   3 ready
- 9 gimlet_seq             0   3 recv
-10 hf                     0   3 recv
-11 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 RUNNING
+ 7 thermal                      0   3 ready
+ 8 hiffy                        0   3 ready
+ 9 gimlet_seq                   0   3 recv
+10 hf                           0   3 recv
+11 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.14.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.14.stdout
@@ -1,16 +1,16 @@
 system time = 56031
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+69)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 RUNNING
- 7 thermal                0   3 ready
- 8 power                  0   3 ready
- 9 hiffy                  0   3 ready
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 ready
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+69)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 RUNNING
+ 7 thermal                      0   3 ready
+ 8 power                        0   3 ready
+ 9 hiffy                        0   3 ready
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 ready
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.15.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.15.stdout
@@ -1,16 +1,16 @@
 system time = 2673946
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 RUNNING
- 7 thermal                0   3 ready
- 8 power                  0   3 ready
- 9 hiffy                  0   3 ready
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 ready
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 RUNNING
+ 7 thermal                      0   3 ready
+ 8 power                        0   3 ready
+ 9 hiffy                        0   3 ready
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 ready
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.16.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.16.stdout
@@ -1,16 +1,16 @@
 system time = 1166521
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+79)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 RUNNING
- 7 thermal                0   3 ready
- 8 power                  0   3 ready
- 9 hiffy                  0   3 ready
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 ready
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+79)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 RUNNING
+ 7 thermal                      0   3 ready
+ 8 power                        0   3 ready
+ 9 hiffy                        0   3 ready
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 ready
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.17.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.17.stdout
@@ -1,11 +1,11 @@
 system time = 643282
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+18)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+218)
- 6 ping                2834   4 wait: reply from usart_driver/gen0
- 7 hiffy                  0   3 notif: bit31(T+43)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+18)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+218)
+ 6 ping                      2834   4 wait: reply from usart_driver/gen0
+ 7 hiffy                        0   3 notif: bit31(T+43)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.18.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.18.stdout
@@ -1,11 +1,11 @@
 system time = 643309
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+91)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+191)
- 6 ping                2834   4 wait: reply from usart_driver/gen0
- 7 hiffy                  0   3 notif: bit31(T+16)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+91)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+191)
+ 6 ping                      2834   4 wait: reply from usart_driver/gen0
+ 7 hiffy                        0   3 notif: bit31(T+16)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.19.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.19.stdout
@@ -1,11 +1,11 @@
 system time = 40768
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+32)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+232)
- 6 ping                 180   4 ready
- 7 hiffy                  0   3 notif: bit31(T+63)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+32)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+232)
+ 6 ping                       180   4 ready
+ 7 hiffy                        0   3 notif: bit31(T+63)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.2.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.2.stdout
@@ -1,11 +1,11 @@
 system time = 2953610
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 user_leds              0   2 recv
- 6 pong                   0   3 ready
- 7 i2c_debug              0   3 wait: reply from i2c_driver/gen0
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 ready
+ 7 i2c_debug                    0   3 wait: reply from i2c_driver/gen0
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.20.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.20.stdout
@@ -1,16 +1,16 @@
 system time = 166727
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+73)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 RUNNING
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 recv, notif: bit0(T+284)
- 8 power                 32   3 wait: send to gimlet_seq/gen41
- 9 hiffy                  0   3 notif: bit31(T+23)
-10 gimlet_seq            41   3 wait: reply from spi2_driver/gen0
-11 hf                     0   3 recv
-12 sensor                 0   3 recv, notif: bit0(T+273)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+73)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 RUNNING
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 recv, notif: bit0(T+284)
+ 8 power                       32   3 wait: send to gimlet_seq/gen41
+ 9 hiffy                        0   3 notif: bit31(T+23)
+10 gimlet_seq                  41   3 wait: reply from spi2_driver/gen0
+11 hf                           0   3 recv
+12 sensor                       0   3 recv, notif: bit0(T+273)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.21.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.21.stdout
@@ -1,11 +1,11 @@
 system time = 40900
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 ready
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+100)
- 6 ping                 181   4 wait: reply from usart_driver/gen0
- 7 hiffy                  0   3 notif: bit31(T+182)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 ready
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+100)
+ 6 ping                       181   4 wait: reply from usart_driver/gen0
+ 7 hiffy                        0   3 notif: bit31(T+182)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.22.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.22.stdout
@@ -1,13 +1,13 @@
 system time = 4863516
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+84)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 ready
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 ping               40023   4 wait: reply from usart_driver/gen0
- 8 pong                   0   3 recv, notif: bit0(T+484)
- 9 hiffy                  0   3 notif: bit31(T+234)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+84)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 ready
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 ping                     40023   4 wait: reply from usart_driver/gen0
+ 8 pong                         0   3 recv, notif: bit0(T+484)
+ 9 hiffy                        0   3 notif: bit31(T+234)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.23.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.23.stdout
@@ -1,11 +1,11 @@
 system time = 1646441
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+59)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+59)
- 6 ping                7399   4 wait: reply from usart_driver/gen0
- 7 hiffy                  0   3 notif: bit31(T+170)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+59)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+59)
+ 6 ping                      7399   4 wait: reply from usart_driver/gen0
+ 7 hiffy                        0   3 notif: bit31(T+170)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.24.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.24.stdout
@@ -1,11 +1,11 @@
 system time = 1786487
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+13)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+13)
- 6 ping                8028   4 wait: reply from usart_driver/gen0
- 7 hiffy                  0   3 notif: bit31(T+48)
- 8 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+13)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+13)
+ 6 ping                      8028   4 wait: reply from usart_driver/gen0
+ 7 hiffy                        0   3 notif: bit31(T+48)
+ 8 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.25.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.25.stdout
@@ -1,16 +1,16 @@
 system time = 256549
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 recv, notif: bit0(T+462)
- 8 power                  0   3 notif: bit31(T+577)
- 9 hiffy                  0   3 FAULT: stack overflow; sp=0x20007ff8 (was: ready)
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 recv, notif: bit0(T+451)
-13 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 recv, notif: bit0(T+462)
+ 8 power                        0   3 notif: bit31(T+577)
+ 9 hiffy                        0   3 FAULT: stack overflow; sp=0x20007ff8 (was: ready)
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 recv, notif: bit0(T+451)
+13 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.26.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.26.stdout
@@ -1,14 +1,14 @@
 system time = 1100533
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+67)
- 1 sys                    0   1 recv
- 2 usart_driver           0   2 recv, notif: bit0(irq39)
- 3 i2c_driver             0   2 recv
- 4 spi_driver             0   2 recv
- 5 net                    0   2 recv, notif: bit0(irq61)
- 6 user_leds              0   2 recv
- 7 ping                9057   4 wait: reply from usart_driver/gen0
- 8 pong                   0   3 recv, notif: bit0(T+467)
- 9 udpecho                0   3 notif: bit0
-10 hiffy                  0   3 notif: bit31(T+237)
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+67)
+ 1 sys                          0   1 recv
+ 2 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 3 i2c_driver                   0   2 recv
+ 4 spi_driver                   0   2 recv
+ 5 net                          0   2 recv, notif: bit0(irq61)
+ 6 user_leds                    0   2 recv
+ 7 ping                      9057   4 wait: reply from usart_driver/gen0
+ 8 pong                         0   3 recv, notif: bit0(T+467)
+ 9 udpecho                      0   3 notif: bit0
+10 hiffy                        0   3 notif: bit31(T+237)
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.27.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.27.stdout
@@ -1,14 +1,14 @@
 system time = 25464
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+36)
- 1 hiffy                  0   3 notif: bit31(T+39)
- 2 idle                   0   5 RUNNING
- 3 syscon_driver          0   2 recv
- 4 gpio_driver            0   2 recv
- 5 user_leds              0   2 recv
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
- 7 i2c_driver             0   2 recv
- 8 rng_driver             0   2 recv
- 9 spi0_driver            0   2 notif: bit0(irq59)
-10 ping                  62   4 wait: reply from usart_driver/gen0
-11 pong                   0   3 recv, notif: bit0(T+36)
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
+ 1 hiffy                        0   3 notif: bit31(T+39)
+ 2 idle                         0   5 RUNNING
+ 3 syscon_driver                0   2 recv
+ 4 gpio_driver                  0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
+ 7 i2c_driver                   0   2 recv
+ 8 rng_driver                   0   2 recv
+ 9 spi0_driver                  0   2 notif: bit0(irq59)
+10 ping                        62   4 wait: reply from usart_driver/gen0
+11 pong                         0   3 recv, notif: bit0(T+36)

--- a/tests/cmd/tasks/tasks.kiowa.28.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.28.stdout
@@ -1,15 +1,15 @@
 system time = 40815
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+85)
- 1 sys                    0   1 recv
- 2 spi4_driver            0   2 recv
- 3 spi2_driver            0   2 FAULT: stack overflow; sp=0x2000ff98 (was: ready)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit31(T+1)
- 6 thermal                0   3 recv, notif: bit0(T+196)
- 7 power                  0   3 wait: send to gimlet_seq/gen0
- 8 hiffy                  0   3 notif: bit31(T+185)
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
-10 hf                     0   3 recv
-11 sensor                 0   3 recv, notif: bit0(T+185)
-12 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+85)
+ 1 sys                          0   1 recv
+ 2 spi4_driver                  0   2 recv
+ 3 spi2_driver                  0   2 FAULT: stack overflow; sp=0x2000ff98 (was: ready)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit31(T+1)
+ 6 thermal                      0   3 recv, notif: bit0(T+196)
+ 7 power                        0   3 wait: send to gimlet_seq/gen0
+ 8 hiffy                        0   3 notif: bit31(T+185)
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
+10 hf                           0   3 recv
+11 sensor                       0   3 recv, notif: bit0(T+185)
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.29.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.29.stdout
@@ -1,15 +1,15 @@
 system time = 12629
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+71)
- 1 sys                    0   1 recv
- 2 spi4_driver            0   2 recv
- 3 spi2_driver            0   2 FAULT: panicked at 'explicit panic', drv/stm32h7-spi-server/src/main.rs:438:21 (was: ready)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit31(T+7)
- 6 thermal                0   3 recv, notif: bit0(T+382)
- 7 power                  0   3 wait: send to gimlet_seq/gen0
- 8 hiffy                  0   3 notif: bit31(T+121)
- 9 gimlet_seq             0   3 wait: reply from spi2_driver/gen0
-10 hf                     0   3 recv
-11 sensor                 0   3 recv, notif: bit0(T+371)
-12 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+71)
+ 1 sys                          0   1 recv
+ 2 spi4_driver                  0   2 recv
+ 3 spi2_driver                  0   2 FAULT: panicked at 'explicit panic', drv/stm32h7-spi-server/src/main.rs:438:21 (was: ready)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit31(T+7)
+ 6 thermal                      0   3 recv, notif: bit0(T+382)
+ 7 power                        0   3 wait: send to gimlet_seq/gen0
+ 8 hiffy                        0   3 notif: bit31(T+121)
+ 9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
+10 hf                           0   3 recv
+11 sensor                       0   3 recv, notif: bit0(T+371)
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.30.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.30.stdout
@@ -1,15 +1,15 @@
 system time = 55566
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+34)
- 1 sys                    0   1 recv
- 2 spi4_driver            0   2 recv
- 3 spi2_driver          124   2 RUNNING
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit31(T+2)
- 6 thermal                0   3 ready
- 7 power                  2   3 ready
- 8 hiffy                  0   3 ready
- 9 gimlet_seq           124   3 wait: reply from spi2_driver/gen60
-10 hf                     0   3 recv
-11 sensor                 0   3 ready
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+34)
+ 1 sys                          0   1 recv
+ 2 spi4_driver                  0   2 recv
+ 3 spi2_driver                124   2 RUNNING
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit31(T+2)
+ 6 thermal                      0   3 ready
+ 7 power                        2   3 ready
+ 8 hiffy                        0   3 ready
+ 9 gimlet_seq                 124   3 wait: reply from spi2_driver/gen60
+10 hf                           0   3 recv
+11 sensor                       0   3 ready
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.31.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.31.stdout
@@ -1,8 +1,8 @@
 system time = 31738
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+62)
- 1 sys                    0   1 recv
- 2 pong                   0   4 recv, notif: bit0(T+262)
- 3 user_leds              0   3 recv
- 4 hiffy                  0   4 notif: bit31(T+13)
- 5 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+62)
+ 1 sys                          0   1 recv
+ 2 pong                         0   4 recv, notif: bit0(T+262)
+ 3 user_leds                    0   3 recv
+ 4 hiffy                        0   4 notif: bit31(T+13)
+ 5 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.4.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.4.stdout
@@ -1,13 +1,13 @@
 system time = 198778
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
- 4 i2c_driver             0   2 RUNNING
- 5 user_leds              0   2 recv
- 6 pong                   0   3 ready
- 7 ping                  24   4 ready
- 8 hiffy                  0   3 wait: reply from i2c_driver/gen0
- 9 i2c_debug              0   3 ready
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 ready
+ 7 ping                        24   4 ready
+ 8 hiffy                        0   3 wait: reply from i2c_driver/gen0
+ 9 i2c_debug                    0   3 ready
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.49.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.49.stdout
@@ -1,17 +1,17 @@
 system time = 323356
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: reply from i2c_driver/gen0
-12 power                  0   3 ready
-13 hiffy                  0   3 ready
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
+12 power                        0   3 ready
+13 hiffy                        0   3 ready
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.5.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.5.stdout
@@ -1,13 +1,13 @@
 system time = 5457089
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+411)
- 8 i2c_debug              0   3 notif: bit31(T+911)
- 9 adt7420                0   3 notif: bit31(T+361)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+411)
+ 8 i2c_debug                    0   3 notif: bit31(T+911)
+ 9 adt7420                      0   3 notif: bit31(T+361)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.50.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.50.stdout
@@ -1,17 +1,17 @@
 system time = 3607115
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 power                  0   3 ready
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 power                        0   3 ready
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.51.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.51.stdout
@@ -1,17 +1,17 @@
 system time = 438460
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 power                  0   3 ready
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 power                        0   3 ready
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.52.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.52.stdout
@@ -1,17 +1,17 @@
 system time = 66322
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+178)
-10 i2c_debug              0   3 notif: bit31(T+178)
-11 thermal                0   3 notif: bit31(T+807)
-12 power                  0   3 notif: bit31(T+807)
-13 hiffy                  0   3 notif: bit31(T+10)
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+178)
+10 i2c_debug                    0   3 notif: bit31(T+178)
+11 thermal                      0   3 notif: bit31(T+807)
+12 power                        0   3 notif: bit31(T+807)
+13 hiffy                        0   3 notif: bit31(T+10)
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.53.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.53.stdout
@@ -1,17 +1,17 @@
 system time = 20495
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: reply from i2c_driver/gen0
-12 power                  0   3 ready
-13 hiffy                  0   3 ready
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
+12 power                        0   3 ready
+13 hiffy                        0   3 ready
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.6.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.6.stdout
@@ -1,13 +1,13 @@
 system time = 1205360
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
- 4 i2c_driver             0   2 RUNNING
- 5 user_leds              0   2 recv
- 6 pong                   0   3 ready
- 7 ping                   4   4 ready
- 8 hiffy                  0   3 wait: reply from i2c_driver/gen0
- 9 i2c_debug              0   3 ready
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 ready
+ 7 ping                         4   4 ready
+ 8 hiffy                        0   3 wait: reply from i2c_driver/gen0
+ 9 i2c_debug                    0   3 ready
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.7.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.7.stdout
@@ -1,13 +1,13 @@
 system time = 272686
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq37)
- 4 i2c_driver             0   2 recv
- 5 user_leds              0   2 recv
- 6 pong                   0   3 recv, notif: bit0(T+314)
- 7 ping                   1   4 wait: reply from usart_driver/gen0
- 8 hiffy                  0   3 notif: bit31(T+71)
- 9 i2c_debug              0   3 notif: bit31(T+210)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq37)
+ 4 i2c_driver                   0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 recv, notif: bit0(T+314)
+ 7 ping                         1   4 wait: reply from usart_driver/gen0
+ 8 hiffy                        0   3 notif: bit31(T+71)
+ 9 i2c_debug                    0   3 notif: bit31(T+210)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.8.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.8.stdout
@@ -1,13 +1,13 @@
 system time = 772538
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 RUNNING
- 4 i2c_driver             0   2 recv
- 5 user_leds              0   2 recv
- 6 pong                   0   3 recv, notif: bit0(T+462)
- 7 ping                  40   4 wait: reply from usart_driver/gen0
- 8 hiffy                  0   3 notif: bit31(T+211)
- 9 i2c_debug              0   3 notif: bit31(T+212)
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 RUNNING
+ 4 i2c_driver                   0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 recv, notif: bit0(T+462)
+ 7 ping                        40   4 wait: reply from usart_driver/gen0
+ 8 hiffy                        0   3 notif: bit31(T+211)
+ 9 i2c_debug                    0   3 notif: bit31(T+212)
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.9.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.9.stdout
@@ -1,14 +1,14 @@
 system time = 260969
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+31)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 notif: bit0(irq36)
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 notif: bit31(T+851)
- 8 hiffy                  0   3 wait: reply from spi2_driver/gen0
- 9 gimlet_seq             0   3 notif: bit31(T+2)
-10 hf                     0   3 recv
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+31)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 notif: bit0(irq36)
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 notif: bit31(T+851)
+ 8 hiffy                        0   3 wait: reply from spi2_driver/gen0
+ 9 gimlet_seq                   0   3 notif: bit31(T+2)
+10 hf                           0   3 recv
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.idol.qpsi.1.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.idol.qpsi.1.stdout
@@ -1,14 +1,14 @@
 system time = 55965
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+35)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 notif: bit31(T+382)
- 8 hiffy                  1   3 FAULT:  (was: ready)
- 9 gimlet_seq             0   3 notif: bit31(T+3)
-10 hf                     0   3 recv
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+35)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 notif: bit31(T+382)
+ 8 hiffy                        1   3 FAULT:  (was: ready)
+ 9 gimlet_seq                   0   3 notif: bit31(T+3)
+10 hf                           0   3 recv
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.kiowa.rick.0.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.rick.0.stdout
@@ -1,16 +1,16 @@
 system time = 1342206
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                   14   2 FAULT: panicked at 'called `Result::unwrap()` on an `Err` value: BadArg', drv/stm32h7-rcc-api/src/lib.rs:56:50 (was: ready)
- 6 spi2_driver            0   2 ready
- 7 spi4_driver            0   2 ready
- 8 user_leds              0   2 ready
- 9 pong                   0   3 ready
-10 thermal                0   3 ready
-11 power                  0   3 ready
-12 hiffy                  0   3 ready
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                         14   2 FAULT: panicked at 'called `Result::unwrap()` on an `Err` value: BadArg', drv/stm32h7-rcc-api/src/lib.rs:56:50 (was: ready)
+ 6 spi2_driver                  0   2 ready
+ 7 spi4_driver                  0   2 ready
+ 8 user_leds                    0   2 ready
+ 9 pong                         0   3 ready
+10 thermal                      0   3 ready
+11 power                        0   3 ready
+12 hiffy                        0   3 ready
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.kiowa.stm32h743-nucleo.0.stdout
+++ b/tests/cmd/tasks/tasks.kiowa.stm32h743-nucleo.0.stdout
@@ -1,13 +1,13 @@
 system time = 10293
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+7)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+207)
- 8 hiffy                  0   3 notif: bit31(T+207)
- 9 hf                     0   3 notif: bit31(T+718)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+7)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+207)
+ 8 hiffy                        0   3 notif: bit31(T+207)
+ 9 hf                           0   3 notif: bit31(T+718)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.0.stdout
+++ b/tests/cmd/tasks/tasks.ouray.0.stdout
@@ -1,12 +1,12 @@
 system time = 575890
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 user_leds              0   2 recv
- 6 pong                   0   3 recv, notif: bit0(T+110)
- 7 ping                   4   4 wait: reply from usart_driver/gen0
- 8 i2c_debug              0   3 notif: bit31(T+110)
- 9 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 recv, notif: bit0(T+110)
+ 7 ping                         4   4 wait: reply from usart_driver/gen0
+ 8 i2c_debug                    0   3 notif: bit31(T+110)
+ 9 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.1.stdout
+++ b/tests/cmd/tasks/tasks.ouray.1.stdout
@@ -1,13 +1,13 @@
 system time = 263349
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 i2c_target             0   2 RUNNING
- 6 user_leds              0   2 recv
- 7 pong                   0   3 ready
- 8 i2c_debug              0   3 ready
- 9 adt7420                0   3 ready
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 i2c_target                   0   2 RUNNING
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 ready
+ 8 i2c_debug                    0   3 ready
+ 9 adt7420                      0   3 ready
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.10.stdout
+++ b/tests/cmd/tasks/tasks.ouray.10.stdout
@@ -1,9 +1,9 @@
 system time = 541258
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 usart_driver           0   2 RUNNING
- 3 user_leds              0   2 recv
- 4 ping                  58   4 wait: reply from usart_driver/gen0
- 5 pong                   0   3 recv, notif: bit0(T+242)
- 6 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 usart_driver                 0   2 RUNNING
+ 3 user_leds                    0   2 recv
+ 4 ping                        58   4 wait: reply from usart_driver/gen0
+ 5 pong                         0   3 recv, notif: bit0(T+242)
+ 6 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.11.stdout
+++ b/tests/cmd/tasks/tasks.ouray.11.stdout
@@ -1,15 +1,15 @@
 system time = 2896993
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
- 6 user_leds              0   2 recv
- 7 pong                   0   3 ready
- 8 i2c_debug              0   3 ready
- 9 adt7420                0   3 ready
-10 max31790               0   3 ready
-11 ds2482                 0   3 wait: reply from i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 ready
+ 8 i2c_debug                    0   3 ready
+ 9 adt7420                      0   3 ready
+10 max31790                     0   3 ready
+11 ds2482                       0   3 wait: reply from i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.12.stdout
+++ b/tests/cmd/tasks/tasks.ouray.12.stdout
@@ -1,13 +1,13 @@
 system time = 50976
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                   61   2 RUNNING
- 6 user_leds              0   2 ready
- 7 pong                   0   3 ready
- 8 i2c_debug              0   3 ready
- 9 thermal                0   3 ready
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                         61   2 RUNNING
+ 6 user_leds                    0   2 ready
+ 7 pong                         0   3 ready
+ 8 i2c_debug                    0   3 ready
+ 9 thermal                      0   3 ready
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.13.stdout
+++ b/tests/cmd/tasks/tasks.ouray.13.stdout
@@ -1,15 +1,15 @@
 system time = 1041634
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 not started
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: reply from i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 not started
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.14.stdout
+++ b/tests/cmd/tasks/tasks.ouray.14.stdout
@@ -1,15 +1,15 @@
 system time = 53379
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 not started
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+121)
-10 i2c_debug              0   3 notif: bit31(T+621)
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 not started
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+121)
+10 i2c_debug                    0   3 notif: bit31(T+621)
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.15.stdout
+++ b/tests/cmd/tasks/tasks.ouray.15.stdout
@@ -1,15 +1,15 @@
 system time = 170019523
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+477)
-10 i2c_debug              0   3 notif: bit31(T+477)
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+477)
+10 i2c_debug                    0   3 notif: bit31(T+477)
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.16.stdout
+++ b/tests/cmd/tasks/tasks.ouray.16.stdout
@@ -1,15 +1,15 @@
 system time = 12289080
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 notif: bit0(irq84)
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+420)
-10 i2c_debug              0   3 notif: bit31(T+920)
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+420)
+10 i2c_debug                    0   3 notif: bit31(T+920)
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.17.stdout
+++ b/tests/cmd/tasks/tasks.ouray.17.stdout
@@ -1,15 +1,15 @@
 system time = 12356272
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.18.stdout
+++ b/tests/cmd/tasks/tasks.ouray.18.stdout
@@ -1,15 +1,15 @@
 system time = 87365
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 notif: bit3(irq95/irq96)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+135)
-10 i2c_debug              0   3 notif: bit31(T+635)
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+135)
+10 i2c_debug                    0   3 notif: bit31(T+635)
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.19.stdout
+++ b/tests/cmd/tasks/tasks.ouray.19.stdout
@@ -1,15 +1,15 @@
 system time = 1217
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 notif: bit0(irq84)
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+283)
-10 i2c_debug              0   3 notif: bit31(T+783)
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+283)
+10 i2c_debug                    0   3 notif: bit31(T+783)
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.2.stdout
+++ b/tests/cmd/tasks/tasks.ouray.2.stdout
@@ -1,10 +1,10 @@
 system time = 65738550
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
- 3 user_leds              0   2 recv
- 4 ping                  25   4 wait: reply from pong/gen0
- 5 log                    0   3 RUNNING
- 6 pong                   0   3 wait: reply from log/gen0
- 7 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
+ 3 user_leds                    0   2 recv
+ 4 ping                        25   4 wait: reply from pong/gen0
+ 5 log                          0   3 RUNNING
+ 6 pong                         0   3 wait: reply from log/gen0
+ 7 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.20.stdout
+++ b/tests/cmd/tasks/tasks.ouray.20.stdout
@@ -1,15 +1,15 @@
 system time = 4038
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 ready
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: send to i2c_driver/gen0
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 ready
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: send to i2c_driver/gen0
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.21.stdout
+++ b/tests/cmd/tasks/tasks.ouray.21.stdout
@@ -1,16 +1,16 @@
 system time = 61893323
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+177)
-10 i2c_debug              0   3 notif: bit31(T+677)
-11 thermal                0   3 notif: bit31(T+590)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+177)
+10 i2c_debug                    0   3 notif: bit31(T+677)
+11 thermal                      0   3 notif: bit31(T+590)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.22.stdout
+++ b/tests/cmd/tasks/tasks.ouray.22.stdout
@@ -1,16 +1,16 @@
 system time = 61921802
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.23.stdout
+++ b/tests/cmd/tasks/tasks.ouray.23.stdout
@@ -1,16 +1,16 @@
 system time = 184021
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+479)
-10 i2c_debug              0   3 notif: bit31(T+979)
-11 thermal                0   3 notif: bit31(T+916)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+479)
+10 i2c_debug                    0   3 notif: bit31(T+979)
+11 thermal                      0   3 notif: bit31(T+916)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.24.stdout
+++ b/tests/cmd/tasks/tasks.ouray.24.stdout
@@ -1,16 +1,16 @@
 system time = 2957351
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.25.stdout
+++ b/tests/cmd/tasks/tasks.ouray.25.stdout
@@ -1,16 +1,16 @@
 system time = 16250
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+250)
-10 i2c_debug              0   3 notif: bit31(T+750)
-11 thermal                0   3 notif: bit31(T+162)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+250)
+10 i2c_debug                    0   3 notif: bit31(T+750)
+11 thermal                      0   3 notif: bit31(T+162)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.26.stdout
+++ b/tests/cmd/tasks/tasks.ouray.26.stdout
@@ -1,16 +1,16 @@
 system time = 174278
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+222)
-10 i2c_debug              0   3 notif: bit31(T+722)
-11 thermal                0   3 notif: bit31(T+523)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+222)
+10 i2c_debug                    0   3 notif: bit31(T+722)
+11 thermal                      0   3 notif: bit31(T+523)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.27.stdout
+++ b/tests/cmd/tasks/tasks.ouray.27.stdout
@@ -1,16 +1,16 @@
 system time = 257977
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 notif: bit0(irq84)
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+23)
-10 i2c_debug              0   3 notif: bit31(T+23)
-11 thermal                0   3 notif: bit31(T+182)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+23)
+10 i2c_debug                    0   3 notif: bit31(T+23)
+11 thermal                      0   3 notif: bit31(T+182)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.29.stdout
+++ b/tests/cmd/tasks/tasks.ouray.29.stdout
@@ -1,16 +1,16 @@
 system time = 1137995
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+5)
-10 i2c_debug              0   3 notif: bit31(T+5)
-11 thermal                0   3 notif: bit31(T+199)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+5)
+10 i2c_debug                    0   3 notif: bit31(T+5)
+11 thermal                      0   3 notif: bit31(T+199)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.3.stdout
+++ b/tests/cmd/tasks/tasks.ouray.3.stdout
@@ -1,9 +1,9 @@
 system time = 23
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
- 3 user_leds              0   2 recv
- 4 ping                   1   4 RUNNING
- 5 pong                   0   3 recv, notif: bit0(T+477)
- 6 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
+ 3 user_leds                    0   2 recv
+ 4 ping                         1   4 RUNNING
+ 5 pong                         0   3 recv, notif: bit0(T+477)
+ 6 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.30.stdout
+++ b/tests/cmd/tasks/tasks.ouray.30.stdout
@@ -1,16 +1,16 @@
 system time = 1346098
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 notif: bit0(irq84)
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+402)
-10 i2c_debug              0   3 notif: bit31(T+902)
-11 thermal                0   3 notif: bit31(T+731)
-12 net                    0   2 notif: bit31(T+1)
-13 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 notif: bit0(irq84)
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+402)
+10 i2c_debug                    0   3 notif: bit31(T+902)
+11 thermal                      0   3 notif: bit31(T+731)
+12 net                          0   2 notif: bit31(T+1)
+13 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.33.stdout
+++ b/tests/cmd/tasks/tasks.ouray.33.stdout
@@ -1,14 +1,14 @@
 system time = 289452420
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             60   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   60   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.35.stdout
+++ b/tests/cmd/tasks/tasks.ouray.35.stdout
@@ -1,14 +1,14 @@
 system time = 290381949
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             35   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   35   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.36.stdout
+++ b/tests/cmd/tasks/tasks.ouray.36.stdout
@@ -1,14 +1,14 @@
 system time = 302579193
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             17   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   17   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.37.stdout
+++ b/tests/cmd/tasks/tasks.ouray.37.stdout
@@ -1,14 +1,14 @@
 system time = 335837028
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 ready
- 4 user_leds              7   2 wait: reply from gpio_driver/gen0
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 ready
+ 4 user_leds                    7   2 wait: reply from gpio_driver/gen0
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.38.stdout
+++ b/tests/cmd/tasks/tasks.ouray.38.stdout
@@ -1,14 +1,14 @@
 system time = 335883880
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             59   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   59   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.39.stdout
+++ b/tests/cmd/tasks/tasks.ouray.39.stdout
@@ -1,14 +1,14 @@
 system time = 19544
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds              2   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                    2   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.4.stdout
+++ b/tests/cmd/tasks/tasks.ouray.4.stdout
@@ -1,9 +1,9 @@
 system time = 48664
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 usart_driver           0   2 RUNNING
- 3 user_leds              0   2 recv
- 4 ping                   1   4 wait: reply from usart_driver/gen0
- 5 pong                   0   3 recv, notif: bit0(T+336)
- 6 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 usart_driver                 0   2 RUNNING
+ 3 user_leds                    0   2 recv
+ 4 ping                         1   4 wait: reply from usart_driver/gen0
+ 5 pong                         0   3 recv, notif: bit0(T+336)
+ 6 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.40.stdout
+++ b/tests/cmd/tasks/tasks.ouray.40.stdout
@@ -1,14 +1,14 @@
 system time = 21440
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds              3   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                    3   2 FAULT: stack overflow; sp=0x20002ba0 (was: ready)
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.41.stdout
+++ b/tests/cmd/tasks/tasks.ouray.41.stdout
@@ -1,14 +1,14 @@
 system time = 24581
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             13   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   13   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.42.stdout
+++ b/tests/cmd/tasks/tasks.ouray.42.stdout
@@ -1,14 +1,14 @@
 system time = 26336
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             22   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   22   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.43.stdout
+++ b/tests/cmd/tasks/tasks.ouray.43.stdout
@@ -1,14 +1,14 @@
 system time = 27649
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 RUNNING
- 1 idle                   0   5 ready
- 2 syscon_driver          0   2 recv
- 3 gpio_driver            0   2 recv
- 4 user_leds             24   2 ready
- 5 usart_driver           0   2 ready
- 6 i2c_driver             0   2 ready
- 7 rng_driver             0   2 ready
- 8 spi_driver             0   2 ready
- 9 ping                   0   4 ready
-10 pong                   0   3 ready
-11 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 RUNNING
+ 1 idle                         0   5 ready
+ 2 syscon_driver                0   2 recv
+ 3 gpio_driver                  0   2 recv
+ 4 user_leds                   24   2 ready
+ 5 usart_driver                 0   2 ready
+ 6 i2c_driver                   0   2 ready
+ 7 rng_driver                   0   2 ready
+ 8 spi_driver                   0   2 ready
+ 9 ping                         0   4 ready
+10 pong                         0   3 ready
+11 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.44.stdout
+++ b/tests/cmd/tasks/tasks.ouray.44.stdout
@@ -1,15 +1,15 @@
 system time = 348745
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+55)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver            52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              1   2 recv
- 9 pong                   0   3 FAULT: panicked at 'explicit panic', drv/user-leds-api/src/lib.rs:38:18 (was: ready)
-10 i2c_debug              0   3 notif: bit31(T+363)
-11 thermal                0   3 notif: bit31(T+363)
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+55)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                  52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    1   2 recv
+ 9 pong                         0   3 FAULT: panicked at 'explicit panic', drv/user-leds-api/src/lib.rs:38:18 (was: ready)
+10 i2c_debug                    0   3 notif: bit31(T+363)
+11 thermal                      0   3 notif: bit31(T+363)
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.45.stdout
+++ b/tests/cmd/tasks/tasks.ouray.45.stdout
@@ -1,15 +1,15 @@
 system time = 83329
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 FAULT: stack overflow; sp=0x20000fa0 (was: ready)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
-10 i2c_debug              0   3 notif: bit31(T+671)
-11 thermal                0   3 notif: bit31(T+552)
-12 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 FAULT: stack overflow; sp=0x20000fa0 (was: ready)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
+10 i2c_debug                    0   3 notif: bit31(T+671)
+11 thermal                      0   3 notif: bit31(T+552)
+12 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.46.stdout
+++ b/tests/cmd/tasks/tasks.ouray.46.stdout
@@ -1,6 +1,6 @@
 system time = 17
-ID TASK                 GEN PRI STATE    
- 0 runner                 0   0 ready
- 1 suite                 18   2 ready
- 2 assist                18   1 RUNNING
- 3 idle                   0   3 ready
+ID TASK                       GEN PRI STATE    
+ 0 runner                       0   0 ready
+ 1 suite                       18   2 ready
+ 2 assist                      18   1 RUNNING
+ 3 idle                         0   3 ready

--- a/tests/cmd/tasks/tasks.ouray.47.stdout
+++ b/tests/cmd/tasks/tasks.ouray.47.stdout
@@ -1,13 +1,13 @@
 system time = 226724
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+76)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 RUNNING
- 6 spi                    0   3 wait: reply from spi_driver/gen0
- 7 user_leds              0   2 recv
- 8 pong                   0   3 recv, notif: bit0(T+276)
- 9 i2c_debug              0   3 notif: bit31(T+276)
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 RUNNING
+ 6 spi                          0   3 wait: reply from spi_driver/gen0
+ 7 user_leds                    0   2 recv
+ 8 pong                         0   3 recv, notif: bit0(T+276)
+ 9 i2c_debug                    0   3 notif: bit31(T+276)
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.48.stdout
+++ b/tests/cmd/tasks/tasks.ouray.48.stdout
@@ -1,13 +1,13 @@
 system time = 18946
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 notif: bit0(irq84)
- 6 spi                    0   3 wait: reply from spi_driver/gen0
- 7 user_leds              0   2 recv
- 8 pong                   0   3 recv, notif: bit0(T+54)
- 9 i2c_debug              0   3 notif: bit31(T+54)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 notif: bit0(irq84)
+ 6 spi                          0   3 wait: reply from spi_driver/gen0
+ 7 user_leds                    0   2 recv
+ 8 pong                         0   3 recv, notif: bit0(T+54)
+ 9 i2c_debug                    0   3 notif: bit31(T+54)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.49.stdout
+++ b/tests/cmd/tasks/tasks.ouray.49.stdout
@@ -1,17 +1,17 @@
 system time = 323356
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: reply from i2c_driver/gen0
-12 power                  0   3 ready
-13 hiffy                  0   3 ready
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
+12 power                        0   3 ready
+13 hiffy                        0   3 ready
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.5.stdout
+++ b/tests/cmd/tasks/tasks.ouray.5.stdout
@@ -1,13 +1,13 @@
 system time = 5457089
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+411)
- 8 i2c_debug              0   3 notif: bit31(T+911)
- 9 adt7420                0   3 notif: bit31(T+361)
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+411)
+ 8 i2c_debug                    0   3 notif: bit31(T+911)
+ 9 adt7420                      0   3 notif: bit31(T+361)
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.50.stdout
+++ b/tests/cmd/tasks/tasks.ouray.50.stdout
@@ -1,17 +1,17 @@
 system time = 3607115
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 power                  0   3 ready
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 power                        0   3 ready
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.51.stdout
+++ b/tests/cmd/tasks/tasks.ouray.51.stdout
@@ -1,17 +1,17 @@
 system time = 438460
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 ready
-12 power                  0   3 ready
-13 hiffy                  0   3 wait: reply from i2c_driver/gen0
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 ready
+12 power                        0   3 ready
+13 hiffy                        0   3 wait: reply from i2c_driver/gen0
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.52.stdout
+++ b/tests/cmd/tasks/tasks.ouray.52.stdout
@@ -1,17 +1,17 @@
 system time = 66322
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 RUNNING
- 7 spi                    0   3 wait: reply from spi_driver/gen0
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+178)
-10 i2c_debug              0   3 notif: bit31(T+178)
-11 thermal                0   3 notif: bit31(T+807)
-12 power                  0   3 notif: bit31(T+807)
-13 hiffy                  0   3 notif: bit31(T+10)
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 RUNNING
+ 7 spi                          0   3 wait: reply from spi_driver/gen0
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+178)
+10 i2c_debug                    0   3 notif: bit31(T+178)
+11 thermal                      0   3 notif: bit31(T+807)
+12 power                        0   3 notif: bit31(T+807)
+13 hiffy                        0   3 notif: bit31(T+10)
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.53.stdout
+++ b/tests/cmd/tasks/tasks.ouray.53.stdout
@@ -1,17 +1,17 @@
 system time = 20495
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 spd                    0   2 notif: bit1(irq33/irq34)
- 6 spi_driver             0   2 recv
- 7 spi                    0   3 ready
- 8 user_leds              0   2 recv
- 9 pong                   0   3 ready
-10 i2c_debug              0   3 ready
-11 thermal                0   3 wait: reply from i2c_driver/gen0
-12 power                  0   3 ready
-13 hiffy                  0   3 ready
-14 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 spd                          0   2 notif: bit1(irq33/irq34)
+ 6 spi_driver                   0   2 recv
+ 7 spi                          0   3 ready
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 ready
+10 i2c_debug                    0   3 ready
+11 thermal                      0   3 wait: reply from i2c_driver/gen0
+12 power                        0   3 ready
+13 hiffy                        0   3 ready
+14 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.54.stdout
+++ b/tests/cmd/tasks/tasks.ouray.54.stdout
@@ -1,10 +1,10 @@
 system time = 166704
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 usart_driver           0   2 recv, notif: bit0(irq38)
- 3 user_leds              0   2 recv
- 4 ping                  59   4 FAULT: divide by zero (was: ready)
- 5 pong                   0   3 recv, notif: bit0(T+296)
- 6 hiffy                  0   3 notif: bit31(T+203)
- 7 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 usart_driver                 0   2 recv, notif: bit0(irq38)
+ 3 user_leds                    0   2 recv
+ 4 ping                        59   4 FAULT: divide by zero (was: ready)
+ 5 pong                         0   3 recv, notif: bit0(T+296)
+ 6 hiffy                        0   3 notif: bit31(T+203)
+ 7 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.6.stdout
+++ b/tests/cmd/tasks/tasks.ouray.6.stdout
@@ -1,13 +1,13 @@
 system time = 9405072
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 i2c_target             0   2 wait: reply from i2c_driver/gen0
- 6 user_leds              0   2 recv
- 7 pong                   0   3 ready
- 8 i2c_debug              0   3 ready
- 9 adt7420                0   3 ready
-10 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 i2c_target                   0   2 wait: reply from i2c_driver/gen0
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 ready
+ 8 i2c_debug                    0   3 ready
+ 9 adt7420                      0   3 ready
+10 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.63.stdout
+++ b/tests/cmd/tasks/tasks.ouray.63.stdout
@@ -1,13 +1,13 @@
 system time = 78902779
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+221)
- 8 hiffy                  0   3 notif: bit31(T+175)
- 9 ping                  20   4 wait: reply from usart_driver/gen0
-10 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+221)
+ 8 hiffy                        0   3 notif: bit31(T+175)
+ 9 ping                        20   4 wait: reply from usart_driver/gen0
+10 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.64.stdout
+++ b/tests/cmd/tasks/tasks.ouray.64.stdout
@@ -1,16 +1,16 @@
 system time = 154939
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    1   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:300:17 (was: ready)
- 6 spi2_driver            0   2 recv
- 7 spi4_driver            0   2 recv
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+61)
-10 thermal                0   3 notif: bit31(T+609)
-11 power                  0   3 notif: bit31(T+608)
-12 hiffy                  0   3 notif: bit31(T+171)
-13 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          1   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:300:17 (was: ready)
+ 6 spi2_driver                  0   2 recv
+ 7 spi4_driver                  0   2 recv
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+61)
+10 thermal                      0   3 notif: bit31(T+609)
+11 power                        0   3 notif: bit31(T+608)
+12 hiffy                        0   3 notif: bit31(T+171)
+13 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.65.stdout
+++ b/tests/cmd/tasks/tasks.ouray.65.stdout
@@ -1,16 +1,16 @@
 system time = 134568
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    2   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:312:17 (was: ready)
- 6 spi2_driver            0   2 recv
- 7 spi4_driver            0   2 recv
- 8 user_leds              0   2 recv
- 9 pong                   0   3 recv, notif: bit0(T+432)
-10 thermal                0   3 notif: bit31(T+661)
-11 power                  0   3 notif: bit31(T+660)
-12 hiffy                  0   3 notif: bit31(T+42)
-13 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          2   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:312:17 (was: ready)
+ 6 spi2_driver                  0   2 recv
+ 7 spi4_driver                  0   2 recv
+ 8 user_leds                    0   2 recv
+ 9 pong                         0   3 recv, notif: bit0(T+432)
+10 thermal                      0   3 notif: bit31(T+661)
+11 power                        0   3 notif: bit31(T+660)
+12 hiffy                        0   3 notif: bit31(T+42)
+13 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.66.stdout
+++ b/tests/cmd/tasks/tasks.ouray.66.stdout
@@ -1,15 +1,15 @@
 system time = 17903
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+97)
- 1 hiffy                  0   3 notif: bit31(T+101)
- 2 idle                   0   5 RUNNING
- 3 syscon_driver          0   2 recv
- 4 gpio_driver            0   2 recv
- 5 user_leds              0   2 recv
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
- 7 i2c_driver             0   2 recv
- 8 rng_driver             0   2 recv
- 9 spi_driver             0   2 recv, notif: bit0(irq59)
-10 ping                  44   4 wait: reply from usart_driver/gen0
-11 pong                   0   3 recv, notif: bit0(T+97)
-12 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+97)
+ 1 hiffy                        0   3 notif: bit31(T+101)
+ 2 idle                         0   5 RUNNING
+ 3 syscon_driver                0   2 recv
+ 4 gpio_driver                  0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
+ 7 i2c_driver                   0   2 recv
+ 8 rng_driver                   0   2 recv
+ 9 spi_driver                   0   2 recv, notif: bit0(irq59)
+10 ping                        44   4 wait: reply from usart_driver/gen0
+11 pong                         0   3 recv, notif: bit0(T+97)
+12 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.67.stdout
+++ b/tests/cmd/tasks/tasks.ouray.67.stdout
@@ -1,15 +1,15 @@
 system time = 46973
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+27)
- 1 hiffy                  0   3 notif: bit31(T+31)
- 2 idle                   0   5 RUNNING
- 3 syscon_driver          0   2 recv
- 4 gpio_driver            0   2 recv
- 5 user_leds              0   2 recv
- 6 usart_driver           0   2 recv, notif: bit0(irq14)
- 7 i2c_driver             0   2 recv
- 8 rng_driver             0   2 recv
- 9 spi_driver             0   2 recv, notif: bit0(irq59)
-10 ping                  50   4 wait: reply from usart_driver/gen0
-11 pong                   0   3 recv, notif: bit0(T+27)
-12 spam                   0   3 not started
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+27)
+ 1 hiffy                        0   3 notif: bit31(T+31)
+ 2 idle                         0   5 RUNNING
+ 3 syscon_driver                0   2 recv
+ 4 gpio_driver                  0   2 recv
+ 5 user_leds                    0   2 recv
+ 6 usart_driver                 0   2 recv, notif: bit0(irq14)
+ 7 i2c_driver                   0   2 recv
+ 8 rng_driver                   0   2 recv
+ 9 spi_driver                   0   2 recv, notif: bit0(irq59)
+10 ping                        50   4 wait: reply from usart_driver/gen0
+11 pong                         0   3 recv, notif: bit0(T+27)
+12 spam                         0   3 not started

--- a/tests/cmd/tasks/tasks.ouray.68.stdout
+++ b/tests/cmd/tasks/tasks.ouray.68.stdout
@@ -1,14 +1,14 @@
 system time = 223859
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+41)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+141)
- 8 hiffy                  0   3 notif: bit31(T+169)
- 9 hf                     0   3 recv
-10 ping                  44   4 wait: reply from usart_driver/gen0
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+41)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+141)
+ 8 hiffy                        0   3 notif: bit31(T+169)
+ 9 hf                           0   3 recv
+10 ping                        44   4 wait: reply from usart_driver/gen0
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.69.stdout
+++ b/tests/cmd/tasks/tasks.ouray.69.stdout
@@ -1,14 +1,14 @@
 system time = 1008605
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+95)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 recv
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+395)
- 8 hiffy                  0   3 notif: bit31(T+26)
- 9 hf                     0   3 recv
-10 ping                  31   4 wait: reply from usart_driver/gen0
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+95)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 recv
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+395)
+ 8 hiffy                        0   3 notif: bit31(T+26)
+ 9 hf                           0   3 recv
+10 ping                        31   4 wait: reply from usart_driver/gen0
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.7.stdout
+++ b/tests/cmd/tasks/tasks.ouray.7.stdout
@@ -1,12 +1,12 @@
 system time = 4318592
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 RUNNING
- 5 user_leds              0   2 recv
- 6 pong                   0   3 ready
- 7 adt7420                0   3 wait: reply from i2c_driver/gen0
- 8 i2c_debug              0   3 ready
- 9 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 RUNNING
+ 5 user_leds                    0   2 recv
+ 6 pong                         0   3 ready
+ 7 adt7420                      0   3 wait: reply from i2c_driver/gen0
+ 8 i2c_debug                    0   3 ready
+ 9 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.70.stdout
+++ b/tests/cmd/tasks/tasks.ouray.70.stdout
@@ -1,14 +1,14 @@
 system time = 606213
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+87)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spi_driver             0   2 RUNNING
- 6 user_leds              0   2 recv
- 7 pong                   0   3 ready
- 8 ping                4777   4 ready
- 9 hiffy                  0   3 wait: reply from spi_driver/gen0
-10 hf                     0   3 ready
-11 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spi_driver                   0   2 RUNNING
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 ready
+ 8 ping                      4777   4 ready
+ 9 hiffy                        0   3 wait: reply from spi_driver/gen0
+10 hf                           0   3 ready
+11 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.71.stdout
+++ b/tests/cmd/tasks/tasks.ouray.71.stdout
@@ -1,14 +1,14 @@
 system time = 58463
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+37)
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 spd                    0   2 notif: bit31(T+7)
- 6 spi_driver             0   2 RUNNING
- 7 user_leds              0   2 recv
- 8 pong                   0   3 ready
- 9 hiffy                  0   3 wait: reply from spi_driver/gen0
-10 hf                     0   3 ready
-11 idle                   0   5 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+37)
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 spd                          0   2 notif: bit31(T+7)
+ 6 spi_driver                   0   2 RUNNING
+ 7 user_leds                    0   2 recv
+ 8 pong                         0   3 ready
+ 9 hiffy                        0   3 wait: reply from spi_driver/gen0
+10 hf                           0   3 ready
+11 idle                         0   5 ready

--- a/tests/cmd/tasks/tasks.ouray.8.stdout
+++ b/tests/cmd/tasks/tasks.ouray.8.stdout
@@ -1,14 +1,14 @@
 system time = 27971
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+29)
- 8 i2c_debug              0   3 notif: bit31(T+29)
- 9 adt7420                0   3 notif: bit31(T+29)
-10 max31790               0   3 notif: bit31(T+30)
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+29)
+ 8 i2c_debug                    0   3 notif: bit31(T+29)
+ 9 adt7420                      0   3 notif: bit31(T+29)
+10 max31790                     0   3 notif: bit31(T+30)
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.ouray.9.stdout
+++ b/tests/cmd/tasks/tasks.ouray.9.stdout
@@ -1,14 +1,14 @@
 system time = 1049327
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0
- 1 rcc_driver             0   1 recv
- 2 gpio_driver            0   2 recv
- 3 usart_driver           0   2 recv, notif: bit0(irq39)
- 4 i2c_driver             0   2 recv
- 5 i2c_target             0   2 notif: bit1(irq33/irq34)
- 6 user_leds              0   2 recv
- 7 pong                   0   3 recv, notif: bit0(T+173)
- 8 i2c_debug              0   3 notif: bit31(T+673)
- 9 adt7420                0   3 notif: bit31(T+673)
-10 max31790               0   3 notif: bit31(T+674)
-11 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0
+ 1 rcc_driver                   0   1 recv
+ 2 gpio_driver                  0   2 recv
+ 3 usart_driver                 0   2 recv, notif: bit0(irq39)
+ 4 i2c_driver                   0   2 recv
+ 5 i2c_target                   0   2 notif: bit1(irq33/irq34)
+ 6 user_leds                    0   2 recv
+ 7 pong                         0   3 recv, notif: bit0(T+173)
+ 8 i2c_debug                    0   3 notif: bit31(T+673)
+ 9 adt7420                      0   3 notif: bit31(T+673)
+10 max31790                     0   3 notif: bit31(T+674)
+11 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.spoopy.0.stdout
+++ b/tests/cmd/tasks/tasks.spoopy.0.stdout
@@ -1,17 +1,17 @@
 system time = 444064
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+36)
- 1 net                    0   2 recv, notif: bit0(irq61) bit1(T+179)
- 2 sys                    0   1 recv
- 3 spi4_driver            0   2 recv
- 4 spi2_driver            0   2 recv
- 5 i2c_driver             0   2 recv
- 6 spd                    0   2 notif: bit0(irq31/irq32)
- 7 thermal                0   3 recv, notif: bit0(T+943)
- 8 power                  0   3 notif: bit31(T+618)
- 9 hiffy                  0   3 notif: bit31(T+172)
-10 gimlet_seq             0   3 recv
-11 hf                     0   3 recv
-12 sensor                 0   3 recv, notif: bit0(T+936)
-13 udpecho                0   3 notif: bit0
-14 idle                   0   5 RUNNING
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
+ 1 net                          0   2 recv, notif: bit0(irq61) bit1(T+179)
+ 2 sys                          0   1 recv
+ 3 spi4_driver                  0   2 recv
+ 4 spi2_driver                  0   2 recv
+ 5 i2c_driver                   0   2 recv
+ 6 spd                          0   2 notif: bit0(irq31/irq32)
+ 7 thermal                      0   3 recv, notif: bit0(T+943)
+ 8 power                        0   3 notif: bit31(T+618)
+ 9 hiffy                        0   3 notif: bit31(T+172)
+10 gimlet_seq                   0   3 recv
+11 hf                           0   3 recv
+12 sensor                       0   3 recv, notif: bit0(T+936)
+13 udpecho                      0   3 notif: bit0
+14 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.static-tasks.0.stdout
+++ b/tests/cmd/tasks/tasks.static-tasks.0.stdout
@@ -1,17 +1,17 @@
 system time = 0
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 wait: send to jefe/gen0
- 1 sys                    0   1 FAULT: illegal instruction (was: ready)
- 2 i2c_driver             0   2 FAULT: illegal instruction (was: ready)
- 3 spi_driver             0   2 FAULT: illegal instruction (was: ready)
- 4 user_leds              0   2 FAULT: illegal instruction (was: ready)
- 5 pong                   0   3 FAULT: illegal instruction (was: ready)
- 6 uartecho               0   3 RUNNING
- 7 hiffy                  0   4 ready
- 8 hf                     0   3 ready
- 9 net                    0   3 ready
-10 udpecho                0   4 ready
-11 validate               0   3 ready
-12 idle                   0   5 ready
-13 rng_driver             0   3 ready
-14 update_server          0   3 ready
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 wait: send to jefe/gen0
+ 1 sys                          0   1 FAULT: illegal instruction (was: ready)
+ 2 i2c_driver                   0   2 FAULT: illegal instruction (was: ready)
+ 3 spi_driver                   0   2 FAULT: illegal instruction (was: ready)
+ 4 user_leds                    0   2 FAULT: illegal instruction (was: ready)
+ 5 pong                         0   3 FAULT: illegal instruction (was: ready)
+ 6 uartecho                     0   3 RUNNING
+ 7 hiffy                        0   4 ready
+ 8 hf                           0   3 ready
+ 9 net                          0   3 ready
+10 udpecho                      0   4 ready
+11 validate                     0   3 ready
+12 idle                         0   5 ready
+13 rng_driver                   0   3 ready
+14 update_server                0   3 ready

--- a/tests/cmd/tasks/tasks.static-tasks.1.stdout
+++ b/tests/cmd/tasks/tasks.static-tasks.1.stdout
@@ -1,17 +1,17 @@
 system time = 695346
-ID TASK                 GEN PRI STATE    
- 0 jefe                   0   0 recv, notif: bit0 bit1(T+54)
- 1 sys                    0   1 recv
- 2 i2c_driver             0   2 recv
- 3 spi_driver             0   2 recv
- 4 user_leds              0   2 recv
- 5 pong                   0   3 recv, notif: bit0(T+154)
- 6 uartecho               0   3 notif: bit0(irq38)
- 7 hiffy                  0   4 notif: bit31(T+175)
- 8 hf                     0   3 recv
- 9 net                    0   3 notif: bit31(T+2)
-10 udpecho                0   4 wait: send to net/gen0
-11 validate               0   3 recv
-12 idle                   0   5 ready
-13 rng_driver             0   3 recv
-14 update_server          0   3 recv
+ID TASK                       GEN PRI STATE    
+ 0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
+ 1 sys                          0   1 recv
+ 2 i2c_driver                   0   2 recv
+ 3 spi_driver                   0   2 recv
+ 4 user_leds                    0   2 recv
+ 5 pong                         0   3 recv, notif: bit0(T+154)
+ 6 uartecho                     0   3 notif: bit0(irq38)
+ 7 hiffy                        0   4 notif: bit31(T+175)
+ 8 hf                           0   3 recv
+ 9 net                          0   3 notif: bit31(T+2)
+10 udpecho                      0   4 wait: send to net/gen0
+11 validate                     0   3 recv
+12 idle                         0   5 ready
+13 rng_driver                   0   3 recv
+14 update_server                0   3 recv


### PR DESCRIPTION
I want to name a task `control-plane-agent`, which at 19 characters was previously truncated. The full `humility tasks` output will still fit into 80 columns if the `STATE` is <= 42 chars wide.