### PR TITLE
Handle --list-targets properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/cli.rs
+++ b/humility-core/src/cli.rs
@@ -4,7 +4,7 @@
 
 use clap::{AppSettings, Parser};
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(name = "humility", max_term_width = 80)]
 #[clap(global_setting(AppSettings::NoAutoVersion))]
 pub struct Cli {
@@ -70,7 +70,7 @@ pub struct Cli {
     pub cmd: Option<Subcommand>,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub enum Subcommand {
     #[clap(external_subcommand)]
     Other(Vec<String>),

--- a/src/cmd_repl.rs
+++ b/src/cmd_repl.rs
@@ -111,7 +111,7 @@ fn eval(
         None => return Ok(String::new()),
     };
 
-    if let Some(s) = version(&cli)? {
+    if let Some(s) = version(&cli) {
         return Ok(s);
     }
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.0
+humility 0.9.1
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.0
+humility 0.9.1
 
 ```
 

--- a/tests/cmd/list-targets/env.json
+++ b/tests/cmd/list-targets/env.json
@@ -1,0 +1,51 @@
+{
+    "sn4": {
+        "description": "Gimlet Rev B, serial number 4",
+        "probe": "0483:3754:001100184741500820383733",
+        "archive": "/gimlet/hubris/archives/gimlet-4-build-gimlet.zip",
+        "cmds": {
+            "power": {
+                "on": "humility -t meanwell hiffy -c Meanwell.power_on -a index=2",
+                "off": "humility -t meanwell hiffy -c Meanwell.power_off -a index=2"
+            },
+            "console": "/bin/sh -c \"/gimlet/bin/sp3-uart $(/gimlet/bin/ftdiports FT5WTGN6 A)\""
+        }
+    },
+    "sn4-rot": {
+        "description": "Gimlet Rev B, serial number 4 (RoT)",
+        "probe": "1fc9:0143:XAEPYT3E3JX0D",
+        "archive": {
+                "imagea": "/gimlet/hubris/archives/gimlet-4-build-gimlet-rot-imagea.zip",
+                "stage0": "/gimlet/hubris/archives/gimlet-4-build-gimlet-rot-stage0.zip"
+        }
+    },
+    "sn9": {
+        "description": "Gimlet Rev B, serial number 9",
+        "probe": "0483:374e:002F001A4741500520383733",
+        "archive": "/gimlet/hubris/archives/gimlet-9-build-gimlet.zip",
+        "cmds": {
+            "power": {
+                "on": "humility -t meanwell hiffy -c Meanwell.power_on -a index=0",
+                "off": "humility -t meanwell hiffy -c Meanwell.power_off -a index=0"
+            },
+            "console": "/bin/sh -c \"/gimlet/bin/sp3-uart $(/gimlet/bin/ftdiports FT5WTIBN A)\""
+        }
+    },
+    "sn14": {
+        "description": "Gimlet Rev B, serial number 14",
+        "probe": "0483:374e:002A003D4741500520383733",
+        "archive": "/gimlet/hubris/archives/gimlet-14-build-gimlet.zip",
+        "cmds": {
+            "power": {
+                "on": "humility -t meanwell hiffy -c Meanwell.power_on -a index=1",
+                "off": "humility -t meanwell hiffy -c Meanwell.power_off -a index=1"
+            },
+            "console": "/bin/sh -c \"/gimlet/bin/sp3-uart $(/gimlet/bin/ftdiports FT51SXZR A)\""
+        }
+    },
+    "meanwell": {
+        "description": "Gimletlet connected to Meanwell for remote power control",
+        "probe": "0483:374e:0036001C4741500620383733",
+        "archive": "/gimlet/hubris/archives/build-gimletlet-meanwell.zip"
+    }
+}

--- a/tests/cmd/list-targets/list-targets.stdout
+++ b/tests/cmd/list-targets/list-targets.stdout
@@ -1,0 +1,6 @@
+TARGET          DESCRIPTION
+sn4             Gimlet Rev B, serial number 4
+sn4-rot         Gimlet Rev B, serial number 4 (RoT)
+sn9             Gimlet Rev B, serial number 9
+sn14            Gimlet Rev B, serial number 14
+meanwell        Gimletlet connected to Meanwell for remote power control

--- a/tests/cmd/list-targets/list-targets.toml
+++ b/tests/cmd/list-targets/list-targets.toml
@@ -1,0 +1,4 @@
+fs.base = "."
+
+bin.name = "humility"
+args = "--list-targets --environment=env.json"

--- a/tests/cmd/nosubcommand.trycmd
+++ b/tests/cmd/nosubcommand.trycmd
@@ -3,6 +3,6 @@ When we don't have a subcommand, we should get the help:
 ```
 $ humility
 ? failed
-Error: humility failed: subcommand expected (--help to list)
+humility failed: subcommand expected (--help to list)
 
 ```

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.0
+humility 0.9.1
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.0
+humility 0.9.1
 
 ```


### PR DESCRIPTION
It turns out that this is handled in the creation of the ExecutionContext, and so we have to do that earlier than we did before. This also means cloning the Cli.

I'd love to make this cleaner, but this at least fixes the regression, and adds a test.