### PR TITLE
Fix spurious re-builds.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,9 @@ fn main() -> Result<()> {
     use cargo_metadata::MetadataCommand;
     let mut cmds = BTreeSet::new();
 
+    // MetadataCommand doesn't emit this, so we should
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
     let metadata =
         MetadataCommand::new().manifest_path("./Cargo.toml").exec().unwrap();
 
@@ -59,8 +62,6 @@ fn dcmds() -> Vec<CommandDescription> {{
     }
 
     write!(output, "    ]\n}}")?;
-
-    println!("cargo:rerun-if-changed=Cargo.toml");
 
     Ok(())
 }

--- a/cmd/repl/src/lib.rs
+++ b/cmd/repl/src/lib.rs
@@ -12,7 +12,7 @@
 //! `humility repl` takes the same top level arguments as any other subcommand, and will remember them
 //! inside of the prompt. For example:
 //!
-//! ```
+//! ```console
 //! $ humility -a ../path/to/hubris/archive.zip repl
 //! humility: attached via ST-Link V2-1
 //! Welcome to the humility REPL! Try out some subcommands, or 'quit' to quit!
@@ -53,6 +53,3 @@
 //! command, which will show you recent commands you've put into the prompt.
 //!
 //! The repl is still very early days! We'll be adding more features in the future.
-
-// we don't actually use this for the repl due to coherence issues.
-fn main() {}


### PR DESCRIPTION
First of all, this patch removes a line in build.rs; I believe that this is vestigial in #118 from when a different strategy was used to build docs. In any case, I don't remember why I added it exactly, and with no other context... let's just remove that.

The main change here is to move the repl's package from main.rs to lib.rs. Why, you ask? Well, the documentation command's build.rs emits

    println!(
        "cargo:rerun-if-changed={}",
        path.parent().unwrap().join("src/lib.rs").display()
    );

for every package. This makes sense, as every single package is a library.

... except, of course, for the repl package. It is entirely a dummy package, purely to get those docs from. I happened to make it as a binary instead of a library, probably beacuse that's what `cargo new` defaults to.

By simply moving it into lib.rs and removing the un-used main function, everything now builds properly.

Fixes #245.

Thanks to @mkeeter and @cbiffle for poking at this. And special thanks to @jgallagher, who found the smoking gun.