### PR TITLE
Improve PMBus handling for PSC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -767,11 +767,9 @@ fn summarize(
         "#FLT".bold()
     );
 
-    let mut total_width = 3 + 4 + 1;
     for (_, header) in commands.iter() {
         if let Some(header) = header {
             print!(" {:>width$}", header.bold(), width = width);
-            total_width += 1 + width;
         }
     }
 
@@ -789,10 +787,10 @@ fn summarize(
             width,
         ) {
             println!(
-                " -- {} {:>width$} -- ",
-                "error:".red(),
+                " {0}  {1} {2}  {0} ",
+                "--".dimmed(),
+                "error:".yellow(),
                 e,
-                width = total_width
             );
         }
 

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -759,18 +759,26 @@ fn summarize(
     let results = context.run(core, ops.as_slice(), None)?;
     let mut base = 0;
 
-    print!("{:13} {:16} {:3} {:4}", "DEVICE", "RAIL", "PG?", "#FLT");
+    print!(
+        "{:13} {:16} {:3} {:4}",
+        "DEVICE".bold(),
+        "RAIL".bold(),
+        "PG?".bold(),
+        "#FLT".bold()
+    );
 
+    let mut total_width = 3 + 4 + 1;
     for (_, header) in commands.iter() {
         if let Some(header) = header {
-            print!(" {:>width$}", header, width = width);
+            print!(" {:>width$}", header.bold(), width = width);
+            total_width += 1 + width;
         }
     }
 
     println!();
 
     for (device, driver, rail, calls) in &work {
-        summarize_rail(
+        if let Err(e) = summarize_rail(
             subargs,
             device,
             driver,
@@ -779,7 +787,14 @@ fn summarize(
             &results[base..base + calls.len()],
             func,
             width,
-        )?;
+        ) {
+            println!(
+                " -- {} {:>width$} -- ",
+                "error:".red(),
+                e,
+                width = total_width
+            );
+        }
 
         base += calls.len();
     }

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -36,7 +36,7 @@ const OXIDE_NT_BASE: u32 = 0x1de << 20;
 const OXIDE_NT_HUBRIS_ARCHIVE: u32 = OXIDE_NT_BASE + 1;
 const OXIDE_NT_HUBRIS_REGISTERS: u32 = OXIDE_NT_BASE + 2;
 
-const MAX_HUBRIS_VERSION: u32 = 3;
+const MAX_HUBRIS_VERSION: u32 = 4;
 
 #[derive(Default, Debug)]
 pub struct HubrisManifest {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.2
+humility 0.9.3
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.2
+humility 0.9.3
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.2
+humility 0.9.3
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.2
+humility 0.9.3
 
 ```


### PR DESCRIPTION
When bringing up the PSC firmware, I ran into a few issues.

Both Hubris and Humility assume that for an I2C device with a `power = { rails = [ ... ] }` field, all sensors (voltage / current / temperature / etc) correspond one-to-one with power rails.

This is problematic for the power shelves, which have two rails (54V and 12V), two fans (uncorrelated to voltage rails), and _three_ temperature sensors (also unrelated to rails!).

This PR adds support for an optional `sensors = [ ... ]` field within power, e.g.
```toml
[[config.i2c.devices]]
bus = "backplane"
name = "psu0mcu"
address = 0b1011_000
device = "mwocp68"
description = "PSU 0 MCU"
power = { rails = [ "V54_PSU0", "V12_PSU0" ], sensors = ["voltage", "current"] }
sensors = { voltage = 2, current = 2, temperature = 3, speed = 2 }
```

The `sensors` field indicates that only `voltage` and `current` correspond one-to-one with rails; other sensor types are treated as independent.

If the `sensors` field is blank (i.e. all of our existing TOML files), then every sensor corresponds one-to-one with rails, matching the current behavior.

In addition, `humility pmbus --summarize` is modified to not `bail!` on an error; instead, it prints the error and continues.  This makes working with the PSC nicer, because not all 6 PSUs will be populated at all times.

<img width="659" alt="Screen Shot 2022-10-26 at 3 13 52 PM" src="https://user-images.githubusercontent.com/745333/198117401-17e8cfe0-3cc5-4524-9653-8da5c3e303c4.png">

