### PR TITLE
Add `--halt` option to reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,7 @@ dependencies = [
  "parse_int",
  "probe-rs",
  "regex",
+ "ron 0.7.1",
  "rusb",
  "rustc-demangle",
  "scroll",

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -31,6 +31,7 @@ idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 regex = "1.5"
 colored = "2.0.0"
 clap = "3.0.12"
+ron = "0.7"
 
 #
 # We depend on the oxide-stable branch of Oxide's fork of probe-rs to assure


### PR DESCRIPTION
It's useful to be able to halt immediately after reset. Doing so requires that we know are attached to a specific chip. Bring some of the logic that we have for chip detection in flashing into core hubris so it can be used elsewhere.