### PR TITLE
Parse auxflash size from TOML file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4284,6 +4284,32 @@ impl HubrisArchive {
             }
         }
 
+        if let Some(auxflash) = self.manifest.auxflash.as_ref() {
+            const ONE_MIB: usize = 1024 * 1024;
+            if auxflash.memory_size % ONE_MIB == 0 {
+                println!(
+                    " auxiliary flash => {} bytes ({} MiB), {} slots",
+                    auxflash.memory_size,
+                    auxflash.memory_size / ONE_MIB,
+                    auxflash.slot_count
+                );
+            } else {
+                println!(
+                    " auxiliary flash => {} bytes, {} slots",
+                    auxflash.memory_size, auxflash.slot_count
+                );
+            }
+            let bytes_per_slot = auxflash.memory_size / auxflash.slot_count;
+            if bytes_per_slot % ONE_MIB == 0 {
+                println!(
+                    "                    ({} MiB/slot)",
+                    bytes_per_slot / ONE_MIB
+                );
+            } else {
+                println!("                    ({} bytes/slot)", bytes_per_slot);
+            }
+        }
+
         Ok(())
     }
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.4
+humility 0.9.5
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.4
+humility 0.9.5
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.4
+humility 0.9.5
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.4
+humility 0.9.5
 
 ```


### PR DESCRIPTION
This fixes an issue where Humility would assume the wrong auxflash size.

Note that there was a brief time period (September 13-15) where the
auxflash size both *was not* in the TOML file **and** was 1 MiB (rather
than the 2 MiB default now in Humility); archives from that narrow window will
probably emit errors upon use.
