### PR TITLE
Don't die on invalid input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ mod cmd_repl;
 fn main() -> Result<()> {
     let (commands, m, args) = match parse_args(&mut std::env::args_os()) {
         Some(s) => s,
-        None => std::process::exit(0),
+        None => std::process::exit(1),
     };
 
     if let Some(s) = version(&args) {
@@ -83,13 +83,10 @@ where
 
     let m = match command.try_get_matches_from(input.into_iter()) {
         Ok(m) => m,
-        Err(e) => match e.kind() {
-            clap::ErrorKind::DisplayHelp => {
-                e.print().unwrap();
-                return None;
-            }
-            _ => e.exit(),
-        },
+        Err(e) => {
+            e.print().unwrap();
+            return None;
+        }
     };
 
     let _args = Cli::from_arg_matches(&m);


### PR DESCRIPTION
I previously had attempted to special case the help error, and died on the rest. Of course, this means when we're in the repl, we'd exit out, which is not intended behavior.

Instead we now just print and return no matter what.

FIxes #256