### PR TITLE
Use default_value_t instead of default_value

### DIFF
--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -32,7 +32,7 @@ const WRITE_CHUNK_SIZE: usize = 2048; // limited by HIFFY_DATA_SIZE
 struct AuxFlashArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "15000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -52,7 +52,7 @@ use tui::{
 struct DashboardArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -46,13 +46,13 @@ pub fn init() -> (Command, ClapCommand<'static>) {
 struct DiagnoseArgs {
     /// timeout to wait for interactions with the supervisor task to complete
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,
 
     /// number of milliseconds to sleep trying to catch crashes
-    #[clap(long, short, default_value = "15", value_name = "ms")]
+    #[clap(long, short, default_value_t = 15, value_name = "ms")]
     sleep_ms: u64,
 
     /// suppresses automatic coredump generation

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -35,7 +35,7 @@ struct EtmArgs {
     /// sets ETM trace identifier
     #[clap(
         long, short, value_name = "identifier",
-        default_value = "0x54", parse(try_from_str = parse_int::parse),
+        default_value_t = 0x54, parse(try_from_str = parse_int::parse),
     )]
     traceid: u8,
     /// ingest ETM data as CSV

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -60,7 +60,7 @@ struct FlashArgs {
     /// reset delay
     #[clap(
         long = "reset-delay", short = 'd',
-        default_value = "100", value_name = "timeout_ms",
+        default_value_t = 100, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     reset_delay: u64,

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -109,7 +109,7 @@ use std::convert::TryInto;
 struct GpioArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -90,7 +90,7 @@ struct HashArgs {
 
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -59,7 +59,7 @@ use std::io::Read;
 struct HiffyArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -113,7 +113,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 pub struct I2cArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -96,7 +96,7 @@ enum IspCmd {
 struct IspArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,
@@ -105,7 +105,7 @@ struct IspArgs {
     #[clap(long, value_name = "port")]
     port: PathBuf,
 
-    #[clap(short = 'b', default_value = "57600")]
+    #[clap(short = 'b', default_value_t = 57600)]
     baud_rate: u32,
 
     #[clap(subcommand)]

--- a/cmd/itm/src/lib.rs
+++ b/cmd/itm/src/lib.rs
@@ -70,7 +70,7 @@ struct ItmArgs {
 
     /// sets ITM trace identifier
     #[clap(
-        long, short, default_value = "0x3a", value_name = "identifier",
+        long, short, default_value_t = 0x3a, value_name = "identifier",
         parse(try_from_str = parse_int::parse)
     )]
     traceid: u8,

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -95,7 +95,7 @@ use std::num::NonZeroU32;
 struct JefeArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -19,7 +19,7 @@ use std::convert::TryInto;
 struct GpioArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -188,7 +188,7 @@ use vsc7448_types::Field;
 struct MonorailArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -65,7 +65,7 @@ enum NetCommand {
 struct NetArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -25,7 +25,7 @@ use std::fmt::Write;
 struct PmbusArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -24,7 +24,7 @@ use std::collections::BTreeMap;
 struct PowerArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -105,7 +105,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 struct QspiArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "30000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 30000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -34,7 +34,7 @@ use serde_xml_rs::from_str;
 struct RencmArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -89,7 +89,7 @@ use std::time::{Duration, Instant};
 struct RendmpArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -71,7 +71,7 @@ use zerocopy::{AsBytes, U16, U64};
 struct RpcArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -40,7 +40,7 @@ use std::time::Duration;
 struct SensorsArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -76,7 +76,7 @@ enum SpCtrlCmd {
 struct SpCtrlArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -18,7 +18,7 @@ use hif::*;
 struct SpdArgs {
     /// sets timeout
     #[clap(
-        long, short, default_value = "5000", value_name = "timeout_ms",
+        long, short, default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -50,7 +50,7 @@ use hif::*;
 struct SpiArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -30,7 +30,7 @@ const EEPROM_SIZE_BYTES: usize = 65536;
 struct EepromArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "15000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/update/src/lib.rs
+++ b/cmd/update/src/lib.rs
@@ -38,7 +38,7 @@ extern crate log;
 struct UpdateArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "50000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 50000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -59,7 +59,7 @@ use humility_cmd::{Archive, Attach, Command, Validate};
 struct ValidateArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -91,7 +91,7 @@ use std::fs;
 struct VpdArgs {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -23,7 +23,7 @@ use vsc7448_types::Field;
 struct Vsc7448Args {
     /// sets timeout
     #[clap(
-        long, short = 'T', default_value = "5000", value_name = "timeout_ms",
+        long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         parse(try_from_str = parse_int::parse)
     )]
     timeout: u32,


### PR DESCRIPTION
This adds a pinch more type safety and removes a tiny amount of runtime string parsing.