### PR TITLE
bump patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.6"
+version = "0.9.7"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.6
+humility 0.9.7
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.6
+humility 0.9.7
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.6
+humility 0.9.7
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.6
+humility 0.9.7
 
 ```


### PR DESCRIPTION
#267 is required for `humility manifest` to correctly print task features on archives using TOML inheritance; it's worth bumping the version so folks know to get on the correct one.