### PR TITLE
Bump max hubris archive to v5, bump version to 0.9.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,7 +1022,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.7"
+version = "0.9.8"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -36,7 +36,7 @@ const OXIDE_NT_BASE: u32 = 0x1de << 20;
 const OXIDE_NT_HUBRIS_ARCHIVE: u32 = OXIDE_NT_BASE + 1;
 const OXIDE_NT_HUBRIS_REGISTERS: u32 = OXIDE_NT_BASE + 2;
 
-const MAX_HUBRIS_VERSION: u32 = 4;
+const MAX_HUBRIS_VERSION: u32 = 5;
 
 #[derive(Default, Debug)]
 pub struct HubrisManifest {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.7
+humility 0.9.8
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.7
+humility 0.9.8
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.7
+humility 0.9.8
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.7
+humility 0.9.8
 
 ```


### PR DESCRIPTION
As [Matt pointed out](https://github.com/oxidecomputer/hubris/pull/956#issuecomment-1332316572), #266 (which is preparing to accept https://github.com/oxidecomputer/hubris/pull/956) allows us to accept a backwards-incompatible change to `app.toml`, which means we ought to bump the hubris archive version as a part of that PR. This is the corresponding humility PR to allow us to accept that new version (v5).