### PR TITLE
Use workspace dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 name: Continuous integration
 
 env:
-  MSRV: 1.58.0
+  MSRV: 1.65.0
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,6 @@ dependencies = [
  "parse_int",
  "serde",
  "serde-xml-rs",
- "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,24 +81,37 @@ members = [
     "xtask",
 ]
 
-[profile.release]
-debug = true
-
-[profile.ci]
-inherits = "release"
-debug = false
-
-[build-dependencies]
-cargo_metadata = "0.12.0"
-anyhow = "1.0.32"
-
-[dependencies]
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
+[workspace.dependencies]
+# `git`-based deps
 hif = { git = "https://github.com/oxidecomputer/hif" }
+idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
+lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "a07e8d39caf27dd83c314e121755d481a3f52263" }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
 spd = { git = "https://github.com/oxidecomputer/spd" }
+serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
+tlvc = { git = "https://github.com/oxidecomputer/tlvc" }
+tlvc-text = {git = "https://github.com/oxidecomputer/tlvc"}
+vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+
+#
+# We depend on the oxide-stable branch of Oxide's fork of probe-rs to assure
+# that we can float necessary patches on probe-rs.
+#
+probe-rs = { git = "https://github.com/oxidecomputer/probe-rs.git", branch = "oxide-v0.12.0" }
+
+#
+# We need the fix for https://github.com/capstone-rust/capstone-rs/issues/84,
+# which upstream seems uninterested in fixing.
+#
+capstone = {git = "https://github.com/oxidecomputer/capstone-rs.git"}
+
+# Local `path`-based deps
 humility = { path = "./humility-core", package = "humility-core" }
 humility-cortex = { path = "./humility-arch-cortex" }
 humility-cmd = { path = "./humility-cmd" }
+humility_load_derive = { path = "./load_derive" }
 cmd-apptable = { path = "./cmd/apptable", package = "humility-cmd-apptable" }
 cmd-auxflash = { path = "./cmd/auxflash", package = "humility-cmd-auxflash" }
 cmd-dashboard = { path = "./cmd/dashboard", package = "humility-cmd-dashboard" }
@@ -151,29 +164,158 @@ cmd-update = { path = "./cmd/update", package = "humility-cmd-update" }
 cmd-validate = { path = "./cmd/validate", package = "humility-cmd-validate" }
 cmd-vpd = { path = "./cmd/vpd", package = "humility-cmd-vpd" }
 
-fallible-iterator = "0.2.0"
-log = {version = "0.4.8", features = ["std"]}
-env_logger = "0.9.0"
-bitfield = "0.13.2"
-clap = "3.0.12"
-csv = "1.1.3"
-serde = "1.0.126"
-parse_int = "0.4.0"
-multimap = "0.8.1"
-num-traits = "0.2"
-num-derive = "0.3"
-jep106 = "0.2"
-toml = "0.5"
+# crates.io deps
 anyhow = { version = "1.0.44", features = ["backtrace"] }
-scroll = "0.10"
-indicatif = "0.15"
+atty = "0.2"
+bitfield = "0.13.2"
+byteorder = "1.3.4"
+cargo_metadata = "0.12.0"
+clap = { version = "3.0.12", features = ["derive", "env"] }
 colored = "2.0.0"
+crc-any = "2.3.5"
+crossterm = "0.20.0"
+csv = "1.1.3"
+ctrlc = "3.1.5"
+env_logger = "0.9.0"
+fallible-iterator = "0.2.0"
+gimli = "0.22.0"
+goblin = "0.2"
+ihex = "3.0"
 indexmap = { version = "1.7", features = ["serde-1"] }
+indicatif = "0.15"
+itertools = "0.10.1"
+jep106 = "0.2"
+lazy_static = "1.4.0"
+libc = "0.2"
+log = {version = "0.4.8", features = ["std"]}
+multimap = "0.8.1"
+num-derive = "0.3"
+num-traits = "0.2"
+parse_int = "0.4.0"
+paste = "0.1"
+path-slash = "0.1.4"
+postcard = "0.7.0"
+proc-macro2 = "1.0"
+quote = "1.0"
 reedline = "0.3.0"
+regex = "1.5.5"
+ron = "0.7"
+rusb = "0.8.1"
+rustc-demangle = "0.1.21"
+scroll = "0.10"
+serde = { version = "1.0.126", features = ["derive"] }
+serde_json = "1.0"
+serde-xml-rs = "0.5.1"
+sha2 = "0.10.1"
+splitty = "0.1.0"
+srec = "0.2"
+ssmarshal = {version = "1"}
+structopt = "0.3"
+strum = "0.22"
+strum_macros = "0.22"
+syn = "1.0"
+tempfile = "3.3"
+termimad = "0.14"
+toml = "0.5"
+trycmd = "0.13.2"
+tui = { version = "0.16", default-features = false }
+winapi = "0.3.9"
+zerocopy = "0.6.1"
+zip = "0.5"
+
+[profile.release]
+debug = true
+
+[profile.ci]
+inherits = "release"
+debug = false
+
+[build-dependencies]
+cargo_metadata = { workspace = true }
+anyhow = { workspace = true }
+
+[dependencies]
+pmbus = { workspace = true }
+hif = { workspace = true }
+spd = { workspace = true }
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-apptable = { workspace = true }
+cmd-auxflash = { workspace = true }
+cmd-dashboard = { workspace = true }
+cmd-diagnose = { workspace = true }
+cmd-debugmailbox = { workspace = true }
+cmd-doc = { workspace = true }
+cmd-dump = { workspace = true }
+cmd-tofino-eeprom = { workspace = true }
+cmd-etm = { workspace = true }
+cmd-exec = { workspace = true }
+cmd-extract = { workspace = true }
+cmd-flash = { workspace = true }
+cmd-gdb = { workspace = true }
+cmd-gpio = { workspace = true }
+cmd-hash = { workspace = true }
+cmd-hiffy = { workspace = true }
+cmd-i2c = { workspace = true }
+cmd-isp = { workspace = true }
+cmd-itm = { workspace = true }
+cmd-jefe = { workspace = true }
+cmd-lpc55gpio = { workspace = true }
+cmd-lpc55-pfr = { workspace = true }
+cmd-manifest = { workspace = true }
+cmd-map = { workspace = true }
+cmd-monorail = { workspace = true }
+cmd-net = { workspace = true }
+cmd-openocd = { workspace = true }
+cmd-pmbus = { workspace = true }
+cmd-power = { workspace = true }
+cmd-probe = { workspace = true }
+cmd-qspi = { workspace = true }
+cmd-readmem = { workspace = true }
+cmd-readvar = { workspace = true }
+cmd-registers = { workspace = true }
+cmd-reset = { workspace = true }
+cmd-rencm = { workspace = true }
+cmd-rendmp = { workspace = true }
+cmd-ringbuf = { workspace = true }
+cmd-rpc = { workspace = true }
+cmd-sensors = { workspace = true }
+cmd-spctrl = { workspace = true }
+cmd-spd = { workspace = true }
+cmd-spi = { workspace = true }
+cmd-stackmargin = { workspace = true }
+cmd-stmsecure = { workspace = true }
+cmd-tasks = { workspace = true }
+cmd-test = { workspace = true }
+cmd-trace = { workspace = true }
+cmd-update = { workspace = true }
+cmd-validate = { workspace = true }
+cmd-vpd = { workspace = true }
+
+fallible-iterator = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+bitfield = { workspace = true }
+clap = { workspace = true }
+csv = { workspace = true }
+serde = { workspace = true }
+parse_int = { workspace = true }
+multimap = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+jep106 = { workspace = true }
+toml = { workspace = true }
+anyhow = { workspace = true }
+scroll = { workspace = true }
+indicatif = { workspace = true }
+colored = { workspace = true }
+indexmap = { workspace = true }
+reedline = { workspace = true }
 
 [patch.crates-io]
 libusb1-sys = { git = "https://github.com/oxidecomputer/rusb", branch = "probe-rs-0.12-libusb-v1.0.26" }
 hidapi = { git = "https://github.com/oxidecomputer/hidapi-rs", branch = "oxide-stable" }
 
 [dev-dependencies]
-trycmd = "0.13.2"
+trycmd = { workspace = true }

--- a/cmd/apptable/Cargo.toml
+++ b/cmd/apptable/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "print Hubris apptable"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 description = "manipulate auxiliary flash"
 
 [dependencies]
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-colored = "2.0.0"
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
+anyhow = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }
 
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-hiffy = { path = "../hiffy" }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
 
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
+hif = { workspace = true }
+idol = { workspace = true }
+tlvc = { workspace = true }

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -15,6 +15,8 @@ use colored::Colorize;
 use humility::cli::Subcommand;
 use indicatif::{ProgressBar, ProgressStyle};
 
+use cmd_hiffy as humility_cmd_hiffy;
+
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::hiffy::HiffyContext;

--- a/cmd/dashboard/Cargo.toml
+++ b/cmd/dashboard/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 description = "dashboard for Hubris sensor data"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-log = {version = "0.4.8", features = ["std"]}
-crossterm = "0.20"
-tui = { version = "0.16", default-features = false, features = ['crossterm'] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+log = { workspace = true }
+crossterm = { workspace = true }
+tui = { workspace = true, features = ["crossterm"] }

--- a/cmd/debugmailbox/Cargo.toml
+++ b/cmd/debugmailbox/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 description = "interact with the debug mailbox on the LPC55"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
-num-traits = "0.2"
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
-strum = "0.22"
-strum_macros = "0.22"
-parse_int = "0.4.0"
-byteorder = "1.3.4"
-zerocopy = "0.6.1"
-probe-rs = { git = "https://github.com/oxidecomputer/probe-rs.git", branch = "oxide-v0.12.0" }
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true, features = [ "full-syntax" ] }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+parse_int = { workspace = true }
+byteorder = { workspace = true }
+zerocopy = { workspace = true }
+probe-rs = { workspace = true }

--- a/cmd/diagnose/Cargo.toml
+++ b/cmd/diagnose/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "analyze a system to detect common problems"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/doc/Cargo.toml
+++ b/cmd/doc/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 description = "print command documentation"
 
 [build-dependencies]
-cargo_metadata = "0.12.0"
-anyhow = "1.0.32"
+cargo_metadata = { workspace = true }
+anyhow = { workspace = true }
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-termimad = "0.14"
-lazy_static = "1.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+termimad = { workspace = true }
+lazy_static = { workspace = true }

--- a/cmd/dump/Cargo.toml
+++ b/cmd/dump/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "generate Hubris dump"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -67,7 +67,7 @@ fn dumpcmd(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let subargs = DumpArgs::try_parse_from(subargs)?;
 
-    let _info = core.halt()?;
+    core.halt()?;
     humility::msg!("core halted");
 
     let rval = hubris.dump(core, subargs.dumpfile.as_deref());

--- a/cmd/etm/Cargo.toml
+++ b/cmd/etm/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "commands for ARM's Embedded Trace Macrocell (ETM)"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-csv = "1.1.3"
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
-colored = "2.0.0"
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+csv = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }
+colored = { workspace = true }

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -589,7 +589,7 @@ fn etmcmd(context: &mut humility::ExecutionContext) -> Result<()> {
     // For all of the other commands, we need to actually attach to the chip.
     //
     let mut core = attach_live(&context.cli, hubris)?;
-    let _info = core.halt()?;
+    core.halt()?;
 
     humility::msg!("core halted");
 

--- a/cmd/exec/Cargo.toml
+++ b/cmd/exec/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "execute command within context of an environment"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-splitty = "0.1.0"
-serde_json = "1.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+splitty = { workspace = true }
+serde_json = { workspace = true }

--- a/cmd/extract/Cargo.toml
+++ b/cmd/extract/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "extract all or part of a Hubris archive"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-zip = "0.5"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+zip = { workspace = true }

--- a/cmd/flash/Cargo.toml
+++ b/cmd/flash/Cargo.toml
@@ -5,20 +5,20 @@ edition = "2021"
 description = "flash archive onto attached device"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-auxflash = { path = "../auxflash" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
-num-traits = "0.2"
-serde = { version = "1.0.126", features = ["derive"] }
-tempfile = "3.3"
-ron = "0.7"
-path-slash = "0.1.4"
-srec = "0.2"
-ihex = "3.0"
-goblin = "0.2"
-regex = "1.5.5"
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-auxflash = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+serde = { workspace = true }
+tempfile = { workspace = true }
+ron = { workspace = true }
+path-slash = { workspace = true }
+srec = { workspace = true }
+ihex = { workspace = true }
+goblin = { workspace = true }
+regex = { workspace = true }

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -395,8 +395,7 @@ fn program_auxflash(
     core: &mut dyn Core,
     data: &[u8],
 ) -> Result<()> {
-    let mut worker =
-        humility_cmd_auxflash::AuxFlashHandler::new(hubris, core, 15_000)?;
+    let mut worker = cmd_auxflash::AuxFlashHandler::new(hubris, core, 15_000)?;
 
     // At this point, we've already rebooted into the new image.
     //

--- a/cmd/gdb/Cargo.toml
+++ b/cmd/gdb/Cargo.toml
@@ -7,10 +7,10 @@ description = "Attach to a running system using GDB"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-openocd = { path = "../openocd" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-ctrlc = "3.1.5"
-tempfile = "3.3"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-openocd = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+ctrlc = { workspace = true }
+tempfile = { workspace = true }

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -19,9 +19,10 @@
 
 use std::process::{Command, Stdio};
 
+use cmd_openocd::get_probe_serial;
+
 use humility::cli::Subcommand;
 use humility_cmd::{Archive, Command as HumilityCmd};
-use humility_cmd_openocd::get_probe_serial;
 
 use anyhow::{bail, Context, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};

--- a/cmd/gpio/Cargo.toml
+++ b/cmd/gpio/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "GPIO pin manipulation"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -278,10 +278,7 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
                             Ok(ref val) => {
                                 let arr: &[u8; 2] = val[0..2].try_into()?;
                                 let v = u16::from_le_bytes(*arr);
-                                format!(
-                                    "{}",
-                                    if v & (1 << pin) != 0 { 1 } else { 0 }
-                                )
+                                format!("{}", (v >> pin) & 1)
                             }
                         }
                     );
@@ -317,10 +314,7 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
                             let v = u16::from_le_bytes(*arr);
 
                             for i in 0..16 {
-                                print!(
-                                    "{:4}",
-                                    if v & (1 << i) != 0 { 1 } else { 0 }
-                                )
+                                print!("{:4}", (v >> i) & 1)
                             }
                             println!();
                         }

--- a/cmd/hash/Cargo.toml
+++ b/cmd/hash/Cargo.toml
@@ -5,13 +5,12 @@ edition = "2021"
 description = "Access to the HASH block"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-sha2 = "0.10.1"
-# hex-literal = {}
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+sha2 = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }

--- a/cmd/hiffy/Cargo.toml
+++ b/cmd/hiffy/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 description = "manipulate HIF execution"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-atty = "0.2"
-colored = "2.0.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+atty = { workspace = true }
+colored = { workspace = true }

--- a/cmd/i2c/Cargo.toml
+++ b/cmd/i2c/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 description = "scan for and read I2C devices"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }

--- a/cmd/isp/Cargo.toml
+++ b/cmd/isp/Cargo.toml
@@ -5,22 +5,19 @@ edition = "2021"
 description = "run ISP commands on the LPC55"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
-num-traits = "0.2"
-serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
-crc-any = "2.3.5"
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
-strum = "0.22"
-strum_macros = "0.22"
-parse_int = "0.4.0"
-byteorder = "1.3.4"
-zerocopy = "0.6.1"
-
-[dependencies.lpc55_areas]
-git = "https://github.com/oxidecomputer/lpc55_support"
-rev = "a07e8d39caf27dd83c314e121755d481a3f52263"
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+serialport = { workspace = true }
+crc-any = { workspace = true }
+num-derive = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+parse_int = { workspace = true }
+byteorder = { workspace = true }
+zerocopy = { workspace = true }
+lpc55_areas = { workspace = true }

--- a/cmd/itm/Cargo.toml
+++ b/cmd/itm/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 description = "commands for ARM's Instrumentation Trace Macrocell (ITM)"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-csv = "1.1.3"
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+csv = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }

--- a/cmd/jefe/Cargo.toml
+++ b/cmd/jefe/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "influence jefe externally"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }

--- a/cmd/lpc55-pfr/Cargo.toml
+++ b/cmd/lpc55-pfr/Cargo.toml
@@ -5,20 +5,17 @@ edition = "2021"
 description = "Modify the protected flash region on the LPC55 (without ISP)"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
-num-traits = "0.2"
-num-derive = { version = "0.3.0", features = [ "full-syntax" ] }
-strum = "0.22"
-strum_macros = "0.22"
-parse_int = "0.4.0"
-byteorder = "1.3.4"
-zerocopy = "0.6.1"
-[dependencies.lpc55_areas]
-git = "https://github.com/oxidecomputer/lpc55_support"
-rev = "a07e8d39caf27dd83c314e121755d481a3f52263"
-
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
+parse_int = { workspace = true }
+byteorder = { workspace = true }
+zerocopy = { workspace = true }
+lpc55_areas = {workspace = true }

--- a/cmd/lpc55gpio/Cargo.toml
+++ b/cmd/lpc55gpio/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "LPC55 GPIO pin manipulation"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/manifest/Cargo.toml
+++ b/cmd/manifest/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "print archive manifest"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/map/Cargo.toml
+++ b/cmd/map/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "print memory map, with association of regions to tasks"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/monorail/Cargo.toml
+++ b/cmd/monorail/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2021"
 description = "Management network control and debugging"
 
 [dependencies]
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-colored = "2.0.0"
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
-regex = "1.5"
+anyhow = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }
+regex = { workspace = true }
 
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-hiffy = { path = "../hiffy" }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
 
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }
-vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }
+hif = { workspace = true }
+idol = { workspace = true }
+vsc7448-info = { workspace = true }
+vsc7448-types = { workspace = true }

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -168,6 +168,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::TryInto;
 
+use cmd_hiffy as humility_cmd_hiffy;
+
 use humility::cli::Subcommand;
 use humility::core::Core;
 use humility::reflect::*;

--- a/cmd/net/Cargo.toml
+++ b/cmd/net/Cargo.toml
@@ -7,13 +7,13 @@ description = "Management network device-side control and debugging"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-parse_int = "0.4.0"
-colored = "2.0.0"
+anyhow = { workspace = true }
+clap = { workspace = true }
+parse_int = { workspace = true }
+colored = { workspace = true }
 
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-hiffy = { path = "../hiffy" }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
 
-hif = { git = "https://github.com/oxidecomputer/hif" }
+hif = { workspace = true }

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -42,6 +42,8 @@ use anyhow::{bail, Context, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};
 use colored::Colorize;
 
+use cmd_hiffy as humility_cmd_hiffy;
+
 use humility::cli::Subcommand;
 use humility::reflect::*;
 use humility_cmd::hiffy::HiffyContext;

--- a/cmd/openocd/Cargo.toml
+++ b/cmd/openocd/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "Run OpenOCD for the given archive"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-ctrlc = "3.1.5"
-regex = "1.5"
-tempfile = "3.3"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+ctrlc = { workspace = true }
+regex = { workspace = true }
+tempfile = { workspace = true }

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 description = "scan for and read PMBus devices"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-colored = "2.0.0"
-indexmap = { version = "1.7", features = ["serde-1"] }
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+pmbus = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+colored = { workspace = true }
+indexmap = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/power/Cargo.toml
+++ b/cmd/power/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "show power-related information"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+log = { workspace = true }

--- a/cmd/probe/Cargo.toml
+++ b/cmd/probe/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "probe for any attached devices"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
-num-traits = "0.2"
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }

--- a/cmd/qspi/Cargo.toml
+++ b/cmd/qspi/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "QSPI status, reading and writing"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
-sha2 = "0.10.1"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }
+sha2 = { workspace = true }

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -240,7 +240,7 @@ fn deltas(
     compare: &[(u32, Vec<u8>)],
     mut diff: impl FnMut(u32, &[u8]) -> Result<()>,
 ) -> Result<()> {
-    let filelen = fs::metadata(filename.to_string())?.len() as u32;
+    let filelen = fs::metadata(filename)?.len() as u32;
     let mut file = File::open(filename)?;
 
     let mut offset = 0;
@@ -464,7 +464,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
         let qspi_hash = funcs.get("QspiHash", 2)?;
         let qspi_read_id = funcs.get("QspiReadId", 0)?;
         // Address is optional and defaults to zero.
-        let addr = subargs.addr.or(Some(0)).unwrap() as u32;
+        let addr = subargs.addr.unwrap_or(0) as u32;
         // nbytes is optional and defaults to the size of the entire flash.
         let nbytes =
             optional_nbytes(core, &mut context, qspi_read_id, subargs.nbytes)?;
@@ -654,7 +654,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
         // Address is optional and defaults to zero.
         // The default can/should be done in `#[clap(...` for "address"
         // if that works for the other users of the -a flag.
-        let mut address = subargs.addr.or(Some(0)).unwrap() as u32;
+        let mut address = subargs.addr.unwrap_or(0) as u32;
         println!("addr={:?}", address);
 
         let nbytes =
@@ -729,7 +729,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
             updates += 1;
 
             for (i, block_result) in results.iter().enumerate() {
-                match &*block_result {
+                match block_result {
                     Err(err) => bail!(
                         "failed to read block {} at offset {}: {}",
                         i,
@@ -966,12 +966,10 @@ impl DeviceIdData {
     pub fn size(&self) -> Result<usize> {
         match self.memory_capacity {
             // This is currently limited to the codes returned from Micron MT25Q parts.
-            0 => {
-                return Err(anyhow!(
-                    "unknown size code=0x{:02x?}",
-                    self.memory_capacity
-                ))
-            }
+            0 => Err(anyhow!(
+                "unknown size code=0x{:02x?}",
+                self.memory_capacity
+            )),
             _ => Ok(1usize << (self.memory_capacity)),
         }
     }

--- a/cmd/readmem/Cargo.toml
+++ b/cmd/readmem/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "read and display memory region"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/readvar/Cargo.toml
+++ b/cmd/readvar/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "read and display a specified Hubris variable"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -66,7 +66,7 @@ fn readvar_dump(
     let mut buf: Vec<u8> = vec![];
     buf.resize_with(variable.size, Default::default);
 
-    let _info = core.halt()?;
+    core.halt()?;
     core.read_8(variable.addr, buf.as_mut_slice())?;
     core.run()?;
 

--- a/cmd/registers/Cargo.toml
+++ b/cmd/registers/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "print Hubris registers"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-num-traits = "0.2"
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+num-traits = { workspace = true }

--- a/cmd/rencm/Cargo.toml
+++ b/cmd/rencm/Cargo.toml
@@ -5,16 +5,15 @@ edition = "2021"
 description = "query Renesas 8A3400X ClockMatrix parts"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-itertools = "0.10.1"
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
-serde-xml-rs = "0.5.1"
-serde = { version = "1.0.126", features = ["derive"] }
-serde_derive = "1.0.133"
-csv = "1.1.3"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+idt8a3xxxx = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+itertools = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }
+serde-xml-rs = { workspace = true }
+serde = { workspace = true }
+csv = { workspace = true }

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -26,7 +26,7 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fs;
 
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use serde_xml_rs::from_str;
 
 #[derive(Parser, Debug)]

--- a/cmd/rendmp/Cargo.toml
+++ b/cmd/rendmp/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 description = "Renesas digital muliphase controller operations"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
-num-traits = "0.2"
-num-derive = "0.3"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+pmbus = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }

--- a/cmd/reset/Cargo.toml
+++ b/cmd/reset/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "Reset the chip using external pins"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-num-traits = "0.2"
-log = "0.4"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+num-traits = { workspace = true }
+log = { workspace = true }

--- a/cmd/ringbuf/Cargo.toml
+++ b/cmd/ringbuf/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "read and display a specified ring buffer"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+log = { workspace = true }

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -83,7 +83,7 @@ fn ringbuf_dump(
     let mut buf: Vec<u8> = vec![];
     buf.resize_with(ringbuf_var.size, Default::default);
 
-    let _info = core.halt()?;
+    core.halt()?;
     core.read_8(ringbuf_var.addr, buf.as_mut_slice())?;
     core.run()?;
 

--- a/cmd/rpc/Cargo.toml
+++ b/cmd/rpc/Cargo.toml
@@ -5,24 +5,24 @@ edition = "2021"
 description = "execute Idol calls over a network"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-hiffy = { path = "../hiffy" }
-humility-cmd-net = { path = "../net" }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
+cmd-net = { workspace = true }
 
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+hif = { workspace = true }
+idol = { workspace = true }
 
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-colored = "2.0.0"
-indexmap = "1.7"
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
-zerocopy = "0.6.1"
+anyhow = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+indexmap = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }
+zerocopy = { workspace = true }
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2"
+libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["netioapi"] }
+winapi = { workspace = true, features = ["netioapi"] }

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -54,6 +54,9 @@ use std::collections::BTreeSet;
 use std::net::{Ipv6Addr, ToSocketAddrs, UdpSocket};
 use std::time::{Duration, Instant};
 
+use cmd_hiffy as humility_cmd_hiffy;
+use cmd_net as humility_cmd_net;
+
 use anyhow::{anyhow, bail, Result};
 use clap::App;
 use clap::IntoApp;

--- a/cmd/sensors/Cargo.toml
+++ b/cmd/sensors/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "query sensors and sensor data"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+log = { workspace = true }

--- a/cmd/spctrl/Cargo.toml
+++ b/cmd/spctrl/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "RoT -> SP control"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }

--- a/cmd/spd/Cargo.toml
+++ b/cmd/spd/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 description = "scan for and read SPD devices"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-spd = { git = "https://github.com/oxidecomputer/spd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-jep106 = "0.2"
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+spd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+jep106 = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -179,7 +179,7 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
         let nspd = spd_data.size / SPD_SIZE;
         let mut bytes = vec![0u8; spd_data.size];
 
-        let _info = core.halt()?;
+        core.halt()?;
         let rval = core.read_8(spd_data.addr, &mut bytes);
         core.run()?;
 

--- a/cmd/spi/Cargo.toml
+++ b/cmd/spi/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "SPI reading and writing"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }

--- a/cmd/stackmargin/Cargo.toml
+++ b/cmd/stackmargin/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "calculate and print stack margins by task"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/stmsecure/Cargo.toml
+++ b/cmd/stmsecure/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "change secure region settings on the stm32h7"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }

--- a/cmd/tasks/Cargo.toml
+++ b/cmd/tasks/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 description = "list Hubris tasks"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-num-traits = "0.2"
-log = "0.4"
-colored = "2.0.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+num-traits = { workspace = true }
+log = { workspace = true }
+colored = { workspace = true }

--- a/cmd/test/Cargo.toml
+++ b/cmd/test/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "run Hubristest suite and parse results"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/tofino-eeprom/Cargo.toml
+++ b/cmd/tofino-eeprom/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 description = "read and write to the Tofino SPI EEPROM"
 
 [dependencies]
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-indicatif = "0.15"
-log = {version = "0.4.8", features = ["std"]}
-parse_int = "0.4.0"
+anyhow = { workspace = true }
+clap = { workspace = true }
+indicatif = { workspace = true }
+log = { workspace = true }
+parse_int = { workspace = true }
 
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-humility-cmd-hiffy = { path = "../hiffy" }
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
 
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+hif = { workspace = true }
+idol = { workspace = true }

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -11,6 +11,8 @@ use clap::{Command as ClapCommand, CommandFactory, Parser};
 use humility::cli::Subcommand;
 use indicatif::{ProgressBar, ProgressStyle};
 
+use cmd_hiffy as humility_cmd_hiffy;
+
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::hiffy::HiffyContext;

--- a/cmd/trace/Cargo.toml
+++ b/cmd/trace/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 description = "trace Hubris operations"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cortex = { path = "../../humility-arch-cortex" }
-humility-cmd = { path = "../../humility-cmd" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
+humility = { workspace = true }
+humility-cortex = { workspace = true }
+humility-cmd = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }

--- a/cmd/update/Cargo.toml
+++ b/cmd/update/Cargo.toml
@@ -5,13 +5,12 @@ edition = "2021"
 description = "apply an update"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-clap = { version = "3.2.21", features = ["derive", "env"] }
-parse_int = "0.4.0"
-log = {version = "0.4.8", features = ["std"]}
-indicatif = "0.15"
-humility-cmd-hiffy = { path = "../hiffy" }
-
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+parse_int = { workspace = true }
+log = { workspace = true }
+indicatif = { workspace = true }
+cmd-hiffy = { workspace = true }

--- a/cmd/update/src/lib.rs
+++ b/cmd/update/src/lib.rs
@@ -16,6 +16,8 @@
 //! ```
 //!
 
+use cmd_hiffy as humility_cmd_hiffy;
+
 use humility::cli::Subcommand;
 use humility_cmd::hiffy::*;
 use humility_cmd::idol::IdolArgument;

--- a/cmd/validate/Cargo.toml
+++ b/cmd/validate/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 description = "validate presence and operation of devices"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-colored = "2.0.0"
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+colored = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+log = { workspace = true }

--- a/cmd/vpd/Cargo.toml
+++ b/cmd/vpd/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 description = "read or write vital product data (VPD)"
 
 [dependencies]
-humility = { path = "../../humility-core", package = "humility-core" }
-humility-cmd = { path = "../../humility-cmd" }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-parse_int = "0.4.0"
-indexmap = "1.7"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-log = {version = "0.4.8", features = ["std"]}
-tlvc = {git = "https://github.com/oxidecomputer/tlvc"}
-tlvc-text = {git = "https://github.com/oxidecomputer/tlvc"}
-zerocopy = "0.6.1"
-indicatif = "0.15"
-colored = "2.0.0"
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+hif = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+indexmap = { workspace = true }
+idol = { workspace = true }
+log = { workspace = true }
+tlvc = { workspace = true }
+tlvc-text = { workspace = true }
+zerocopy = { workspace = true }
+indicatif = { workspace = true }
+colored = { workspace = true }

--- a/humility-arch-cortex/Cargo.toml
+++ b/humility-arch-cortex/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-humility = { path = "../humility-core", package = "humility-core" }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-bitfield = "0.13.2"
-multimap = "0.8.1"
-paste = "0.1"
-num-traits = "0.2"
-num-derive = "0.3"
-jep106 = "0.2"
-log = {version = "0.4.8", features = ["std"]}
+humility = { workspace = true }
+anyhow = { workspace = true }
+bitfield = { workspace = true }
+multimap = { workspace = true }
+paste = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+jep106 = { workspace = true }
+log = { workspace = true }

--- a/humility-arch-cortex/src/etm.rs
+++ b/humility-arch-cortex/src/etm.rs
@@ -384,7 +384,7 @@ fn encode(hdr: ETM3Header) -> u8 {
     }
 }
 
-fn set(table: &mut Vec<Option<ETM3Header>>, hdr: ETM3Header) {
+fn set(table: &mut [Option<ETM3Header>], hdr: ETM3Header) {
     let val = encode(hdr) as usize;
 
     match table[val] {
@@ -782,15 +782,12 @@ pub fn etm_ingest(
             ETM3PacketState::Complete => {}
         }
 
-        match (state, hdr) {
-            (IngestState::ISyncSearching, ETM3Header::ISync) => {
-                //
-                // We have our ISync packet -- we can now ingest everything
-                // (starting with this packet).
-                //
-                state = IngestState::Ingesting;
-            }
-            (_, _) => {}
+        if let (IngestState::ISyncSearching, ETM3Header::ISync) = (state, hdr) {
+            //
+            // We have our ISync packet -- we can now ingest everything
+            // (starting with this packet).
+            //
+            state = IngestState::Ingesting;
         }
 
         if state == IngestState::Ingesting {

--- a/humility-arch-cortex/src/itm.rs
+++ b/humility-arch-cortex/src/itm.rs
@@ -122,7 +122,7 @@ pub enum ITMPayload {
     },
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ITMHeader {
     Sync,
     Overflow,
@@ -191,7 +191,7 @@ fn encode(hdr: ITMHeader) -> u8 {
     }
 }
 
-fn set(table: &mut Vec<Option<ITMHeader>>, hdr: ITMHeader) {
+fn set(table: &mut [Option<ITMHeader>], hdr: ITMHeader) {
     let val = encode(hdr) as usize;
 
     match table[val] {

--- a/humility-arch-cortex/src/scs.rs
+++ b/humility-arch-cortex/src/scs.rs
@@ -71,7 +71,7 @@ register_offs!(SWTF_CTRL, 0x0,
     pub es0, set_es0: 0;
 );
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CoreSightClass {
     ROM,
     Component,
@@ -390,7 +390,7 @@ register!(CPUID, 0xe000_ed00,
 // therefore are willing to hard-code special case handling for, to some
 // extent.
 //
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Vendor {
     ST,
     NXP,

--- a/humility-cmd/Cargo.toml
+++ b/humility-cmd/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-humility = { path = "../humility-core", package = "humility-core" }
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-hif = { git = "https://github.com/oxidecomputer/hif" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-indexmap = { version = "1.7", features = ["serde-1"] }
-postcard = "0.7.0"
-parse_int = "0.4.0"
-ssmarshal = {version = "1"}
-colored = "2.0.0"
-log = {version = "0.4.8", features = ["std"]}
-serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0"
-zerocopy = "0.6.1"
+humility = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+hif = { workspace = true }
+idol = { workspace = true }
+indexmap = { workspace = true }
+postcard = { workspace = true }
+parse_int = { workspace = true }
+ssmarshal = { workspace = true }
+colored = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+zerocopy = { workspace = true }

--- a/humility-cmd/src/idol.rs
+++ b/humility-cmd/src/idol.rs
@@ -119,7 +119,7 @@ impl<'a> IdolOperation<'a> {
         member: &HubrisStructMember,
         arg: (&String, &AttributedTy),
         val: &IdolArgument,
-        payload: &mut Vec<u8>,
+        payload: &mut [u8],
     ) -> Result<()> {
         // Now, we have to decide how to pack the argument into the payload
         //

--- a/humility-cmd/src/test.rs
+++ b/humility-cmd/src/test.rs
@@ -11,14 +11,14 @@ use std::fs::OpenOptions;
 use std::io::BufWriter;
 use std::io::Write;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum TestSource {
     KernelLog,
     UserLog,
     Suite,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum TestToken {
     Meta,
     Expect,

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -5,42 +5,42 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-structopt = "0.3"
-serde = { version = "1.0.126", features = ["derive"] }
-serde_json = "1.0"
-goblin = "0.2.1"
-rustc-demangle = "0.1.21"
-anyhow = { version = "1.0.44", features = ["backtrace"] }
-gimli = "0.22.0"
-fallible-iterator = "0.2.0"
-humility_load_derive = {path = "../load_derive"}
-indexmap = { version = "1.7", features = ["serde-1"] }
-scroll = "0.10"
-ssmarshal = {version = "1"}
-multimap = "0.8.1"
-num-traits = "0.2"
-num-derive = "0.3"
-indicatif = "0.15"
-toml = "0.5"
-bitfield = "0.13.2"
-log = {version = "0.4.8", features = ["std"]}
-zip = "0.5"
-rusb = "0.8.1"
-parse_int = "0.4.0"
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
-regex = "1.5"
-colored = "2.0.0"
-clap = "3.0.12"
-ron = "0.7"
+structopt = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+goblin = { workspace = true }
+rustc-demangle = { workspace = true }
+anyhow = { workspace = true }
+gimli = { workspace = true }
+fallible-iterator = { workspace = true }
+humility_load_derive = { workspace = true }
+indexmap = { workspace = true }
+scroll = { workspace = true }
+ssmarshal = { workspace = true }
+multimap = { workspace = true }
+num-traits = { workspace = true }
+num-derive = { workspace = true }
+indicatif = { workspace = true }
+toml = { workspace = true }
+bitfield = { workspace = true }
+log = { workspace = true }
+zip = { workspace = true }
+rusb = { workspace = true }
+parse_int = { workspace = true }
+idol = { workspace = true }
+regex = { workspace = true }
+colored = { workspace = true }
+clap = { workspace = true }
+ron = { workspace = true }
 
 #
 # We depend on the oxide-stable branch of Oxide's fork of probe-rs to assure
 # that we can float necessary patches on probe-rs.
 #
-probe-rs = { git = "https://github.com/oxidecomputer/probe-rs.git", branch = "oxide-v0.12.0" }
+probe-rs = { workspace = true }
 
 #
 # We need the fix for https://github.com/capstone-rust/capstone-rs/issues/84,
 # which upstream seems uninterested in fixing.
 #
-capstone = {git = "https://github.com/oxidecomputer/capstone-rs.git"}
+capstone = { workspace = true }

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -479,7 +479,7 @@ impl std::ops::Index<&str> for Struct {
     type Output = Value;
 
     fn index(&self, name: &str) -> &Self::Output {
-        &*self.members[name]
+        &self.members[name]
     }
 }
 

--- a/load_derive/Cargo.toml
+++ b/load_derive/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
-proc-macro2 = "1.0"
-quote = "1.0"
+syn = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.58.0"
+channel = "1.65.0"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,6 @@ version = "1.0.0"
 edition = "2018"
 
 [dependencies]
-clap = { version = "3.0.12", features = ["derive", "env"] }
-anyhow = "1.0.32"
-cargo_metadata = "0.12.0"
+clap = { workspace = true }
+anyhow = { workspace = true }
+cargo_metadata = { workspace = true }


### PR DESCRIPTION
Changes all of humility's dependencies to reference top-level workspace dependencies. I believe all of these changes are safe (with the primary evidence being the lack of changes to `Cargo.lock`, except for intentionally removing an unnecessary dependency on `serde_derive`), but maybe that's not 100% guaranteed in terms of cargo features? I'm not sure they would necessarily show up in `Cargo.lock` if I missed something there.

There's one hitch: top-level humility renames all of the `humility-cmd-xyz` to just `cmd-xyz`, but there are a handful of commands that reference _other_ commands, and they were using the longer names with the `humility-` prefix. I can't figure out how to make this work without changing one or the other: the [workspace dependency docs](https://doc.rust-lang.org/nightly/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace) say the only flags that can be combined with `workspace = true` are `optional` and `features`, and true to that statement, adding `package = blah` to try to rename them does not work. I settled with adding a rename import to the handful of commands that needed this, but am open to other suggestions.