### PR TITLE
Add `readvar --as-c-string` to pretty-print arrays that contain strings

### DIFF
--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -50,6 +50,10 @@ struct ReadvarArgs {
     /// values in decimal instead of hex
     #[clap(long, short)]
     decimal: bool,
+    /// interpret array contents as a C string (ignored if variable is not an
+    /// array)
+    #[clap(long)]
+    as_c_string: bool,
     /// list variables
     #[clap(long, short)]
     list: bool,
@@ -75,6 +79,7 @@ fn readvar_dump(
     let fmt = HubrisPrintFormat {
         newline: true,
         hex,
+        interpret_as_c_string: subargs.as_c_string,
         ..HubrisPrintFormat::default()
     };
     let name = subargs.variable.as_ref().unwrap();

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -5476,6 +5476,7 @@ pub struct HubrisPrintFormat {
     pub newline: bool,
     pub hex: bool,
     pub no_name: bool,
+    pub interpret_as_c_string: bool,
 }
 
 impl HubrisPrintFormat {


### PR DESCRIPTION
Now instead of this:

```
$ pfexec ./humility readvar LAST_HOST_BOOT_FAIL
LAST_HOST_BOOT_FAIL (0x2401c10d) = MaybeUninit<[u8; 4096]> {
    value: [
        0x43,
        0x6f,
        0x75,
        0x6c,
        0x64,
        0x20,
        0x6e,
        0x6f,
        0x74,
        0x20,
        0x66,
        0x69,
        0x6e,
        0x64,
        0x20,
        0x61,
        0x20,
        0x76,
        0x61,
        0x6c,
        0x69,
        0x64,
        0x20,
        0x70,
        0x68,
        0x61,
        0x73,
        0x65,
        0x32,
        0x20,
        0x69,
        0x6d,
        0x61,
        0x67,
        0x65,
        0x20,
        0x6f,
        0x6e,
        0x20,
        0x64,
        0x69,
        0x73,
        0x6b,
        0x3a,
        0x31,
        0x0,
        0x0,
        0x0,
        ... snip 4000+ more 0x00s ...
    ]
}
```

we can do this:

```
$ pfexec ./humility readvar LAST_HOST_BOOT_FAIL --as-c-string
LAST_HOST_BOOT_FAIL (0x2401c10d) = MaybeUninit<[u8; 4096]> {
    value: "Could not find a valid phase2 image on disk:1"
}
```

Fixes #285.