### PR TITLE
Add `get_idol_command` to `HubrisArchive`, reducing boilerplate

### DIFF
--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -23,7 +23,7 @@ use humility::cli::Subcommand;
 use humility::core::Core;
 use humility::hubris::HubrisArchive;
 use humility_cmd::hiffy::HiffyContext;
-use humility_cmd::idol::{IdolArgument, IdolOperation};
+use humility_cmd::idol::{HubrisIdol, IdolArgument};
 
 use super::UartConsoleArgs;
 use super::UartConsoleCommand;
@@ -54,13 +54,7 @@ impl<'a> UartConsoleHandler<'a> {
     }
 
     fn uart_read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let op = IdolOperation::new(
-            self.hubris,
-            "ControlPlaneAgent",
-            "uart_read",
-            None,
-        )
-        .context("Could not find `ControlPlaneAgent.uart_read` operation")?;
+        let op = self.hubris.get_idol_command("ControlPlaneAgent.uart_read")?;
 
         let value = humility_cmd_hiffy::hiffy_call(
             self.hubris,
@@ -83,13 +77,8 @@ impl<'a> UartConsoleHandler<'a> {
     }
 
     fn uart_write(&mut self, buf: &[u8]) -> Result<usize> {
-        let op = IdolOperation::new(
-            self.hubris,
-            "ControlPlaneAgent",
-            "uart_write",
-            None,
-        )
-        .context("Could not find `ControlPlaneAgent.uart_write` operation")?;
+        let op =
+            self.hubris.get_idol_command("ControlPlaneAgent.uart_write")?;
 
         let buf = &buf[..usize::min(buf.len(), HIFFY_BUF_SIZE)];
 
@@ -188,15 +177,9 @@ impl<'a> UartConsoleHandler<'a> {
     }
 
     fn detach(&mut self) -> Result<()> {
-        let op = IdolOperation::new(
-            self.hubris,
-            "ControlPlaneAgent",
-            "set_humility_uart_client",
-            None,
-        )
-        .context(
-            "Could not find `ControlPlaneAgent.set_humility_uart_client` operation",
-        )?;
+        let op = self
+            .hubris
+            .get_idol_command("ControlPlaneAgent.set_humility_uart_client")?;
 
         let value = humility_cmd_hiffy::hiffy_call(
             self.hubris,
@@ -214,15 +197,9 @@ impl<'a> UartConsoleHandler<'a> {
     }
 
     fn current_client(&mut self) -> Result<()> {
-        let op = IdolOperation::new(
-            self.hubris,
-            "ControlPlaneAgent",
-            "get_uart_client",
-            None,
-        )
-        .context(
-            "Could not find `ControlPlaneAgent.get_uart_client` operation",
-        )?;
+        let op = self
+            .hubris
+            .get_idol_command("ControlPlaneAgent.get_uart_client")?;
 
         let value = humility_cmd_hiffy::hiffy_call(
             self.hubris,

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -38,7 +38,7 @@
 //! VSC8552; this is indicated with `--` in the relevant table positions.
 use std::collections::BTreeMap;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{Command as ClapCommand, CommandFactory, Parser};
 use colored::Colorize;
 
@@ -47,7 +47,7 @@ use cmd_hiffy as humility_cmd_hiffy;
 use humility::cli::Subcommand;
 use humility::reflect::*;
 use humility_cmd::hiffy::HiffyContext;
-use humility_cmd::idol::IdolOperation;
+use humility_cmd::idol::HubrisIdol;
 use humility_cmd::{Archive, Attach, Command, Validate};
 
 #[derive(Parser, Debug)]
@@ -85,11 +85,7 @@ fn net_ip(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut hiffy_context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
-    let op = IdolOperation::new(hubris, "Net", "get_mac_address", None)
-        .context(
-            "Could not find `get_mac_address`, \
-                  is your Hubris archive new enough?",
-        )?;
+    let op = hubris.get_idol_command("Net.get_mac_address")?;
 
     let value = humility_cmd_hiffy::hiffy_call(
         hubris,
@@ -148,12 +144,7 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut hiffy_context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
-    let op_mac_count =
-        IdolOperation::new(hubris, "Net", "read_ksz8463_mac_count", None)
-            .context(
-                "Could not find `read_ksz8463_mac_count`, \
-                  is your Hubris archive new enough?",
-            )?;
+    let op_mac_count = hubris.get_idol_command("Net.read_ksz8463_mac_count")?;
 
     // We need to make two HIF calls:
     // - Read the number of entries in the MAC table
@@ -189,7 +180,7 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
 
     humility::msg!("Reading {} MAC addresses...", mac_count);
 
-    let op = IdolOperation::new(hubris, "Net", "read_ksz8463_mac", None)?;
+    let op = hubris.get_idol_command("Net.read_ksz8463_mac")?;
     let funcs = hiffy_context.functions()?;
     let send = funcs.get("Send", 4)?;
 
@@ -279,11 +270,7 @@ fn net_status(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut hiffy_context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
-    let op = IdolOperation::new(hubris, "Net", "management_link_status", None)
-        .context(
-            "Could not find `management_link_status`, \
-                  is your Hubris archive new enough?",
-        )?;
+    let op = hubris.get_idol_command("Net.management_link_status")?;
 
     let value = humility_cmd_hiffy::hiffy_call(
         hubris,
@@ -364,11 +351,7 @@ fn net_counters(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut hiffy_context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
-    let op = IdolOperation::new(hubris, "Net", "management_counters", None)
-        .context(
-            "Could not find `get_mac_address`, \
-                  is your Hubris archive new enough?",
-        )?;
+    let op = hubris.get_idol_command("Net.management_counters")?;
 
     let value = humility_cmd_hiffy::hiffy_call(
         hubris,

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -8,14 +8,14 @@
 //! can measure voltage, displaying voltage, current (if measured) and
 //! temperature (if measured).
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::cli::Subcommand;
 use humility::hubris::*;
 use humility_cmd::hiffy::*;
-use humility_cmd::idol;
+use humility_cmd::idol::{self, HubrisIdol};
 use humility_cmd::{Archive, Attach, Command, Validate};
 use std::collections::BTreeMap;
 
@@ -49,8 +49,7 @@ fn power(context: &mut humility::ExecutionContext) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let mut ops = vec![];
     let funcs = context.functions()?;
-    let op = idol::IdolOperation::new(hubris, "Sensor", "get", None)
-        .context("is the 'sensor' task present?")?;
+    let op = hubris.get_idol_command("Sensor.get")?;
 
     let ok = hubris.lookup_basetype(op.ok)?;
 

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -23,7 +23,7 @@
 //! `--tabular`.  In its default output (with one sensor per row), error
 //! counts are also displayed.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
 use hif::*;
@@ -31,7 +31,7 @@ use humility::cli::Subcommand;
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::hiffy::*;
-use humility_cmd::idol;
+use humility_cmd::idol::{self, HubrisIdol};
 use humility_cmd::{Archive, Attach, Command, Validate};
 use itertools::izip;
 use std::collections::HashSet;
@@ -168,8 +168,7 @@ fn print(
     let mut err_ops = vec![];
     let funcs = context.functions()?;
     let nerrbits = 32;
-    let op = idol::IdolOperation::new(hubris, "Sensor", "get", None)
-        .context("is the 'sensor' task present?")?;
+    let op = hubris.get_idol_command("Sensor.get")?;
 
     let ok = hubris.lookup_basetype(op.ok)?;
 
@@ -226,9 +225,7 @@ fn print(
         all_ops.push(ops);
     }
 
-    if let Ok(errop) =
-        idol::IdolOperation::new(hubris, "Sensor", "get_nerrors", None)
-    {
+    if let Ok(errop) = hubris.get_idol_command("Sensor.get_nerrors") {
         let ok = hubris.lookup_basetype(errop.ok)?;
 
         if ok.encoding != HubrisEncoding::Unsigned {

--- a/cmd/update/src/lib.rs
+++ b/cmd/update/src/lib.rs
@@ -20,8 +20,7 @@ use cmd_hiffy as humility_cmd_hiffy;
 
 use humility::cli::Subcommand;
 use humility_cmd::hiffy::*;
-use humility_cmd::idol::IdolArgument;
-use humility_cmd::idol::IdolOperation;
+use humility_cmd::idol::{HubrisIdol, IdolArgument};
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_cmd_hiffy::HiffyLease;
 
@@ -63,12 +62,10 @@ fn update(context: &mut humility::ExecutionContext) -> Result<()> {
     let subargs = UpdateArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
-    let start =
-        IdolOperation::new(hubris, "Update", "prep_image_update", None)?;
-    let write = IdolOperation::new(hubris, "Update", "write_one_block", None)?;
-    let finish =
-        IdolOperation::new(hubris, "Update", "finish_image_update", None)?;
-    let block_size = IdolOperation::new(hubris, "Update", "block_size", None)?;
+    let start = hubris.get_idol_command("Update.prep_image_update")?;
+    let write = hubris.get_idol_command("Update.write_one_block")?;
+    let finish = hubris.get_idol_command("Update.finish_image_update")?;
+    let block_size = hubris.get_idol_command("Update.block_size")?;
 
     let blk_size = match humility_cmd_hiffy::hiffy_call(
         hubris,

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -42,7 +42,7 @@
 //! ```
 //!
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Command as ClapCommand;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
@@ -51,7 +51,7 @@ use humility::cli::Subcommand;
 use humility::hubris::*;
 use humility_cmd::hiffy::*;
 use humility_cmd::i2c::I2cArgs;
-use humility_cmd::idol;
+use humility_cmd::idol::{self, HubrisIdol};
 use humility_cmd::{Archive, Attach, Command, Validate};
 
 #[derive(Parser, Debug)]
@@ -158,8 +158,7 @@ fn validate(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let op = idol::IdolOperation::new(hubris, "Validate", "validate_i2c", None)
-        .context("is the 'validate' task present?")?;
+    let op = hubris.get_idol_command("Validate.validate_i2c")?;
     let mut ops = vec![];
 
     let mut devices = vec![];

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -202,9 +202,7 @@ fn vpd_write(
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let op = hubris
-        .get_idol_command("Vpd.write")
-        .context("is the 'vpd' task present?")?;
+    let op = hubris.get_idol_command("Vpd.write")?;
     let target = target(hubris, subargs)?;
 
     let bytes = if let Some(ref filename) = subargs.write {

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -78,7 +78,7 @@ use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect;
 use humility_cmd::hiffy::*;
-use humility_cmd::idol;
+use humility_cmd::idol::{self, HubrisIdol};
 use humility_cmd::{Archive, Attach, Command, Validate};
 use indicatif::{ProgressBar, ProgressStyle};
 use std::fs;
@@ -202,7 +202,8 @@ fn vpd_write(
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let op = idol::IdolOperation::new(hubris, "Vpd", "write", None)
+    let op = hubris
+        .get_idol_command("Vpd.write")
         .context("is the 'vpd' task present?")?;
     let target = target(hubris, subargs)?;
 
@@ -322,8 +323,7 @@ fn vpd_read(
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let funcs = context.functions()?;
-    let op = idol::IdolOperation::new(hubris, "Vpd", "read", None)
-        .context("is the 'vpd' task present?")?;
+    let op = hubris.get_idol_command("Vpd.read")?;
     let target = target(hubris, subargs)?;
 
     //

--- a/humility-cmd/src/idol.rs
+++ b/humility-cmd/src/idol.rs
@@ -593,3 +593,27 @@ pub fn lookup_reply<'a>(
         Reply::Simple(ok) => Ok((lookup_ok(&ok.ty.0)?, None)),
     }
 }
+
+/// Extention trait to add `get_idol_command` to a `HubrisArchive`
+pub trait HubrisIdol {
+    fn get_idol_command(&self, name: &str) -> Result<IdolOperation>;
+}
+
+impl HubrisIdol for HubrisArchive {
+    fn get_idol_command(&self, name: &str) -> Result<IdolOperation> {
+        let mut iter = name.split('.');
+        let interface = iter
+            .next()
+            .ok_or_else(|| anyhow!("Interface name cannot be empty"))?;
+        let op = iter
+            .next()
+            .ok_or_else(|| anyhow!("Operation name cannot be empty"))?;
+        IdolOperation::new(self, interface, op, None).with_context(|| {
+            format!(
+                "Could not find `{interface}.{op}`; \
+                 the task may be missing or your Hubris archive \
+                 may be out of date",
+            )
+        })
+    }
+}


### PR DESCRIPTION
The most common way to build an `IdolOperation` is `IdolOperation::new(hubris, "Interface", "function", None)?;`

This PR uses an extension trait to add `get_idol_command` to `HubrisArchive`, which handles this common case.