### PR TITLE
humility-core: update "are we ROM?" message

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3439,7 +3439,8 @@ impl HubrisArchive {
                 if self.instr_mod(pc).is_none() {
                     bail!(
                         "target does not appear booted and PC 0x{:x} is \
-                        unknown; is system executing in ROM?",
+                        unknown; is system executing boot ROM or other \
+                        program?",
                         pc
                     );
                 }

--- a/tests/cmd/hiffy-list/hiffy-list.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/hiffy-list/hiffy-list.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility hiffy failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility hiffy failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?

--- a/tests/cmd/map/map.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/map/map.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility map failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility map failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?

--- a/tests/cmd/spd/spd.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/spd/spd.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility spd failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility spd failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?

--- a/tests/cmd/stackmargin/stackmargin.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/stackmargin/stackmargin.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility stackmargin failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility stackmargin failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?

--- a/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility tasks failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility tasks failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?

--- a/tests/cmd/tasks/tasks.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/tasks/tasks.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility tasks failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing in ROM?
+humility tasks failed: target does not appear booted and PC 0x1ff0a6e0 is unknown; is system executing boot ROM or other program?


### PR DESCRIPTION
I believe this message was trying to hint to the user that the chip might be running in e.g. a boot ROM, but it just said "ROM," which confused me because our code also runs out of read-only memory.

Added more words to the warning to try not to confuse folks.