### PR TITLE
Use correct reply size in `humility rpc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.18"
+version = "0.9.19"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.18
+humility 0.9.19
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.18
+humility 0.9.19
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.18
+humility 0.9.19
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.18
+humility 0.9.19
 
 ```


### PR DESCRIPTION
Related to #300: for hubpack-encoded replies, it's possible for the encoding size to be greater than the typesize. This PR fixes the `nreply` calculation in `humility rpc` for encoded replies.

Note that even with this change, if the reply is _less_ than the maximum hubpack encoded size, currently the hubris task will return an `NReplyMismatch` error. I'll open a fix for that in hubris shortly.