### PR TITLE
fix OpenOCD target to allow HIF operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.20"
+version = "0.9.21"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -808,7 +808,7 @@ impl<'a> HiffyContext<'a> {
             }
         }
 
-        core.write_8(self.text.addr, &buf[0..])?;
+        core.write_8(self.text.addr, &buf[0..current])?;
 
         if let Some(data) = data {
             core.write_8(self.data.addr, data)?;

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.20
+humility 0.9.21
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.20
+humility 0.9.21
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.20
+humility 0.9.21
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.20
+humility 0.9.21
 
 ```


### PR DESCRIPTION
Draft commit message:

```
When running with GDB (e.g., via "humility gdb"), one is also running
with the OpenOCD target.  Annoyingly, this target bombs out if/when
any writes are attempted.  While this was perhaps reasonable at one
point, with the widespread use of HIF and "humility hiffy" to induce
behavior, this failure makes using GDB practically impossible.  This
fix allows for writes with the OpenOCD target (albeit inefficiently)
-- and also cleans up one very unnecessary (and very large!) write
with respect to HIF text.  With this fix, HIF-/Idol-intensive
operations like "humility dashboard' and "humility sensors" are able
to run in the presence of OpenOCD/GDB.
```
