### PR TITLE
Listen on ports 8 and 8888 for udpbroadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.23"
+version = "0.9.24"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.23"
+version = "0.9.24"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -129,31 +129,20 @@ struct Target {
     ip: IpAddr,
 }
 
-fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
-    let socket = UdpSocket::bind("[::]:8")?;
-    let timeout = Duration::from_millis(rpc_args.timeout as u64);
+fn rpc_listen_one(
+    timeout: Duration,
+    interface: u32,
+    port: u32,
+) -> Result<BTreeSet<Target>> {
+    let socket = UdpSocket::bind(&format!("[::]:{port}"))?;
     socket.set_read_timeout(Some(timeout))?;
 
-    // For some reason, macOS requires the interface to be non-zero:
-    // https://users.rust-lang.org/t/ipv6-upnp-multicast-for-rust-dlna-server-macos/24425
-    // https://bluejekyll.github.io/blog/posts/multicasting-in-rust/
-    let interface = match &rpc_args.interface {
-        None => {
-            if cfg!(target_os = "macos") {
-                bail!("Must specify interface with `-i` on macOS");
-            } else {
-                0
-            }
-        }
-        Some(iface) => decode_iface(iface)?,
-    };
     socket.join_multicast_v6(
         &Ipv6Addr::new(0xff02, 0, 0, 0, 0, 0, 0, 1),
         interface,
     )?;
 
     let mut seen = BTreeSet::new();
-    humility::msg!("listening for {} seconds...", timeout.as_secs());
 
     let timeout = Instant::now() + timeout;
     let mut buf = [0u8; 1024];
@@ -187,9 +176,6 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
                 match e.kind() {
                     std::io::ErrorKind::WouldBlock
                     | std::io::ErrorKind::TimedOut => {
-                        if seen.is_empty() {
-                            humility::msg!("timed out, exiting");
-                        }
                         break;
                     }
                     e => panic!("Got error {:?}", e),
@@ -200,15 +186,63 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
     Ok(seen)
 }
 
-fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
-    println!(
-        "       {}         |            {}           | {}",
-        "MAC".bold(),
-        "IPv6".bold(),
-        "Compatible".bold()
+fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
+    // For some reason, macOS requires the interface to be non-zero:
+    // https://users.rust-lang.org/t/ipv6-upnp-multicast-for-rust-dlna-server-macos/24425
+    // https://bluejekyll.github.io/blog/posts/multicasting-in-rust/
+    let interface = match &rpc_args.interface {
+        None => {
+            if cfg!(target_os = "macos") {
+                bail!("Must specify interface with `-i` on macOS");
+            } else {
+                0
+            }
+        }
+        Some(iface) => decode_iface(iface)?,
+    };
+
+    let timeout = Duration::from_millis(rpc_args.timeout as u64);
+    let ports = [8, 8888];
+    humility::msg!(
+        "listening for {} seconds on ports {:?}...",
+        timeout.as_secs(),
+        ports
     );
 
-    println!("-------------------|---------------------------| -----------");
+    let threads = ports
+        .iter()
+        .map(|&port| {
+            std::thread::spawn(move || -> Result<BTreeSet<Target>> {
+                rpc_listen_one(timeout, interface, port)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let mut seen = BTreeSet::new();
+    for t in threads {
+        let out = t.join().unwrap()?;
+        seen.extend(out.into_iter());
+    }
+    if seen.is_empty() {
+        humility::msg!("timed out, exiting");
+    }
+
+    Ok(seen)
+}
+
+fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
+    if !seen.is_empty() {
+        println!(
+            "       {}         |            {}           | {}",
+            "MAC".bold(),
+            "IPv6".bold(),
+            "Compatible".bold()
+        );
+
+        println!(
+            "-------------------|---------------------------| -----------"
+        );
+    }
 
     for target in seen {
         for (i, byte) in target.mac.iter().enumerate() {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.23
+humility 0.9.24
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.23
+humility 0.9.24
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.23
+humility 0.9.24
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.23
+humility 0.9.24
 
 ```


### PR DESCRIPTION
This will let us fix https://github.com/oxidecomputer/hubris/issues/1087 without breaking `humility rpc --listen`.

This code spawns one thread per port, instead of trying to listen to multiple ports simultaneously, because it's easier.

I also changed the table-printing code to skip the header if nothing was returned, which I think was a regression.