### PR TITLE
Print notification names when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.25"
+version = "0.9.26"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.25"
+version = "0.9.26"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -443,7 +443,7 @@ fn explain_sched_state(
         }
         SchedState::InRecv(tid) => {
             let notmask = *regs.get(&(task_index, ARMRegister::R6)).unwrap();
-            explain_recv(hubris, tid, notmask, irqs, timer);
+            explain_recv(hubris, task_index, tid, notmask, irqs, timer);
         }
     }
     Ok(())
@@ -560,6 +560,7 @@ fn explain_fault_source(e: doppel::FaultSource) {
 /// - Make common cases unobtrusive and easy to scan.
 fn explain_recv(
     hubris: &HubrisArchive,
+    task_index: u32,
     src: Option<TaskId>,
     notmask: u32,
     irqs: Option<&Vec<(u32, u32)>>,
@@ -612,12 +613,23 @@ fn explain_recv(
         }
     }
 
+    let task_mod = hubris.lookup_module(HubrisTask::Task(task_index));
+    let notification_names = if let Ok(task_mod) = task_mod {
+        hubris.manifest.task_notifications.get(&task_mod.name)
+    } else {
+        None
+    };
+    let notification_name = |s: usize| -> Option<&str> {
+        notification_names.and_then(|n| n.get(s)).map(|s| s.as_str())
+    };
+
     // Display notification bits, along with meaning where we can.
     if notmask != 0 {
         print!("{}notif:", if outer_first { "" } else { ", " });
         for nt in note_types {
             print!(" bit{}", nt.bit);
-            if !nt.irqs.is_empty() || nt.timer.is_some() {
+            let name = notification_name(nt.bit);
+            if !nt.irqs.is_empty() || nt.timer.is_some() || name.is_some() {
                 print!("(");
                 let mut first = true;
                 if let Some(ts) = nt.timer {
@@ -627,6 +639,9 @@ fn explain_recv(
                 for irq in &nt.irqs {
                     print!("{}irq{}", if !first { "/" } else { "" }, irq);
                     first = false;
+                }
+                if let Some(name) = name {
+                    print!("{}{name}", if !first { "/" } else { "" });
                 }
                 print!(")");
             }

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -626,11 +626,8 @@ fn explain_recv(
     // Display notification bits, along with meaning where we can.
     if notmask != 0 {
         print!("{}notif:", if outer_first { "" } else { ", " });
-        for (i, nt) in note_types.iter().enumerate() {
+        for nt in note_types {
             let name = notification_name(nt.bit);
-            if i > 0 {
-                print!(",");
-            }
             if let Some(name) = name {
                 print!(" {name}");
             } else {

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -626,22 +626,26 @@ fn explain_recv(
     // Display notification bits, along with meaning where we can.
     if notmask != 0 {
         print!("{}notif:", if outer_first { "" } else { ", " });
-        for nt in note_types {
-            print!(" bit{}", nt.bit);
+        for (i, nt) in note_types.iter().enumerate() {
             let name = notification_name(nt.bit);
-            if !nt.irqs.is_empty() || nt.timer.is_some() || name.is_some() {
+            if i > 0 {
+                print!(",");
+            }
+            if let Some(name) = name {
+                print!(" {name}");
+            } else {
+                print!(" bit{}", nt.bit);
+            }
+            if !nt.irqs.is_empty() || nt.timer.is_some() {
                 print!("(");
                 let mut first = true;
                 if let Some(ts) = nt.timer {
-                    print!("T{:+}", ts);
+                    print!("{}T{:+}", if !first { "/" } else { "" }, ts);
                     first = false;
                 }
                 for irq in &nt.irqs {
                     print!("{}irq{}", if !first { "/" } else { "" }, irq);
                     first = false;
-                }
-                if let Some(name) = name {
-                    print!("{}{name}", if !first { "/" } else { "" });
                 }
                 print!(")");
             }

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -48,6 +48,7 @@ pub struct HubrisManifest {
     pub target: Option<String>,
     pub task_features: HashMap<String, Vec<String>>,
     pub task_irqs: HashMap<String, Vec<(u32, u32)>>,
+    pub task_notifications: HashMap<String, Vec<String>>,
     pub peripherals: BTreeMap<String, u32>,
     pub peripherals_byaddr: BTreeMap<u32, String>,
     pub i2c_devices: Vec<HubrisI2cDevice>,
@@ -2666,6 +2667,10 @@ impl HubrisArchive {
 
                 self.manifest.task_irqs.insert(name.clone(), task_irqs);
             }
+
+            self.manifest
+                .task_notifications
+                .insert(name.clone(), task.notifications.clone());
         }
 
         if let Some(ref config) = config.config {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.25
+humility 0.9.26
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.25
+humility 0.9.26
 
 ```
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
@@ -1,6 +1,6 @@
 system time = 42126
 ID TASK                       GEN PRI STATE    
- 0 jefe                         0   0 recv, notif: bit0(T+74) bit1
+ 0 jefe                         0   0 recv, notif: bit0(T+74/timer) bit1(fault)
    |
    +--->  0x200008b8 0x08005a98 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:333
@@ -84,7 +84,7 @@ ID TASK                       GEN PRI STATE
                     descriptor: 0x8004434 (&kern::descs::TaskDesc)
                 }
 
- 2 usart_driver                 0   2 recv, notif: bit0
+ 2 usart_driver                 0   2 recv, notif: bit0(usart-irq)
    |
    +--->  0x20000ab8 0x0800633e userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:333

--- a/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
@@ -1,6 +1,6 @@
 system time = 42126
 ID TASK                       GEN PRI STATE    
- 0 jefe                         0   0 recv, notif: bit0(T+74/timer) bit1(fault)
+ 0 jefe                         0   0 recv, notif: timer(T+74) fault
    |
    +--->  0x200008b8 0x08005a98 userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:333
@@ -84,7 +84,7 @@ ID TASK                       GEN PRI STATE
                     descriptor: 0x8004434 (&kern::descs::TaskDesc)
                 }
 
- 2 usart_driver                 0   2 recv, notif: bit0(usart-irq)
+ 2 usart_driver                 0   2 recv, notif: usart-irq
    |
    +--->  0x20000ab8 0x0800633e userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:333

--- a/tests/cmd/tasks/tasks.v6.stdout
+++ b/tests/cmd/tasks/tasks.v6.stdout
@@ -1,6 +1,6 @@
 system time = 42126
 ID TASK                       GEN PRI STATE    
- 0 jefe                         0   0 recv, notif: bit0(T+74/timer) bit1(fault)
+ 0 jefe                         0   0 recv, notif: timer(T+74) fault
  1 sys                          0   1 recv
- 2 usart_driver                 0   2 recv, notif: bit0(usart-irq)
+ 2 usart_driver                 0   2 recv, notif: usart-irq
  3 idle                         0   5 RUNNING

--- a/tests/cmd/tasks/tasks.v6.stdout
+++ b/tests/cmd/tasks/tasks.v6.stdout
@@ -1,6 +1,6 @@
 system time = 42126
 ID TASK                       GEN PRI STATE    
- 0 jefe                         0   0 recv, notif: bit0(T+74) bit1
+ 0 jefe                         0   0 recv, notif: bit0(T+74/timer) bit1(fault)
  1 sys                          0   1 recv
- 2 usart_driver                 0   2 recv, notif: bit0
+ 2 usart_driver                 0   2 recv, notif: bit0(usart-irq)
  3 idle                         0   5 RUNNING

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.25
+humility 0.9.26
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.25
+humility 0.9.26
 
 ```


### PR DESCRIPTION
If we know the name of a notification that's being waited upon, print it in the "extra information" section.