### PR TITLE
IBC blackbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.27"
+version = "0.9.28"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "humility-cmd-hash",
  "humility-cmd-hiffy",
  "humility-cmd-i2c",
+ "humility-cmd-ibc",
  "humility-cmd-isp",
  "humility-cmd-itm",
  "humility-cmd-jefe",
@@ -1403,6 +1404,23 @@ dependencies = [
  "indicatif",
  "log",
  "parse_int",
+]
+
+[[package]]
+name = "humility-cmd-ibc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "colored",
+ "hif",
+ "humility-cmd",
+ "humility-cmd-hiffy",
+ "humility-core",
+ "idol",
+ "log",
+ "parse_int",
+ "pmbus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "log",
  "parse_int",
  "pmbus",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.27"
+version = "0.9.28"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
     "cmd/hiffy",
     "cmd/rpc",
     "cmd/i2c",
+    "cmd/ibc",
     "cmd/itm",
     "cmd/jefe",
     "cmd/lpc55gpio",
@@ -134,6 +135,7 @@ cmd-gpio = { path = "./cmd/gpio", package = "humility-cmd-gpio" }
 cmd-hash = { path = "./cmd/hash", package = "humility-cmd-hash" }
 cmd-hiffy = { path = "./cmd/hiffy", package = "humility-cmd-hiffy" }
 cmd-i2c = { path = "./cmd/i2c", package = "humility-cmd-i2c" }
+cmd-ibc = { path = "./cmd/ibc", package = "humility-cmd-ibc" }
 cmd-isp = { path = "./cmd/isp", package = "humility-cmd-isp" }
 cmd-itm = { path = "./cmd/itm", package = "humility-cmd-itm" }
 cmd-jefe = { path = "./cmd/jefe", package = "humility-cmd-jefe" }
@@ -269,6 +271,7 @@ cmd-gpio = { workspace = true }
 cmd-hash = { workspace = true }
 cmd-hiffy = { workspace = true }
 cmd-i2c = { workspace = true }
+cmd-ibc = { workspace = true }
 cmd-isp = { workspace = true }
 cmd-itm = { workspace = true }
 cmd-jefe = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility hash](#humility-hash): Access to the HASH block
 - [humility hiffy](#humility-hiffy): manipulate HIF execution
 - [humility i2c](#humility-i2c): scan for and read I2C devices
+- [humility ibc](#humility-ibc): interface to the BMR491 power regulator
 - [humility isp](#humility-isp): run ISP commands on the LPC55
 - [humility itm](#humility-itm): commands for ARM's Instrumentation Trace Macrocell (ITM)
 - [humility jefe](#humility-jefe): influence jefe externally
@@ -855,6 +856,71 @@ humility: attached via ST-Link V3
 last selected mux/segment for I2C2, port F: mux 3, segment 2
 ```
 
+
+
+### `humility ibc`
+
+Interface to BMR491 power regulator
+
+This regulator is present on Gimlet and Sidecar PCAs.  Right now,
+`humility ibc` only exposes one subcommand: `black-box`.
+
+`humility ibc black-box` allows you to read out the blackbox log from the
+power converter.  This can be used to debug previous faults.  The log is
+stored in non-volatile memory, so it should be persistent through power
+loss.
+
+Here's an example:
+```rust
+matt@igor ~ (sn5) $ pfexec ./humility -tsn5 ibc black-box
+humility: attached to 0483:374e:001B00083156501320323443 via ST-Link V3
+FAULT EVENT
+  EVENT_INDEX:        0
+  TIMESTAMP           0x000001ca = 45.5 sec
+  EVENT_ID            0x0000
+  STATUS_WORD         0x0010
+  STATUS_IOUT         0x0080
+  V_IN                0xf869 = 52.50V
+  V_OUT               0x5f00 = 11.88V
+  I_OUT               0x004e = 78.00A
+  TEMPERATURE         0x001c = 28.00°C
+FAULT EVENT
+  EVENT_INDEX:        1
+  TIMESTAMP           0x000001d4 = 46.6 sec
+  EVENT_ID            0x0001
+  STATUS_WORD         0x0001
+  STATUS_MFG          0x0001
+    b0 = BOOT_EVENT
+  V_IN                0xf83c = 30.00V
+  V_OUT               0x0000 = 0.00V
+  I_OUT               0x0000 = 0.00A
+  TEMPERATURE         0x0000 = 0.00°C
+FAULT EVENT
+  EVENT_INDEX:        2
+  TIMESTAMP           0x000002c4 = 1 min, 10.0 sec
+  EVENT_ID            0x0002
+  STATUS_WORD         0x0010
+  STATUS_IOUT         0x0080
+  V_IN                0xf877 = 59.50V
+  V_OUT               0x5f00 = 11.88V
+  I_OUT               0x0070 = 112.00A
+  TEMPERATURE         0x002c = 44.00°C
+FAULT EVENT
+  EVENT_INDEX:        3
+  TIMESTAMP           0x27ffb2c4 = 776 day, 16 hr, 48 min, 6.6 sec
+  EVENT_ID            0x0003
+  STATUS_WORD         0x0001
+  STATUS_MFG          0x0002
+    b1 = INPUT_LOW_EVENT
+  V_IN                0xf86b = 53.50V
+  V_OUT               0x6000 = 12.00V
+  I_OUT               0x0000 = 0.00A
+  TEMPERATURE         0x0016 = 22.00°C
+```
+
+The log doesn't appear to be _completely_ reliable, so take it with a grain
+of salt and with the datasheet close at hand.  For example, the machine in
+the example above had **not** be up for 776 days.
 
 
 ### `humility isp`

--- a/cmd/doc/build.rs
+++ b/cmd/doc/build.rs
@@ -14,6 +14,9 @@ fn main() -> Result<()> {
     use cargo_metadata::MetadataCommand;
     let mut cmds = BTreeMap::new();
 
+    // MetadataCommand doesn't emit this, so we should
+    println!("cargo:rerun-if-changed=Cargo.toml",);
+
     let metadata =
         MetadataCommand::new().manifest_path("./Cargo.toml").exec().unwrap();
 

--- a/cmd/ibc/Cargo.toml
+++ b/cmd/ibc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "humility-cmd-ibc"
 version = "0.1.0"
 edition = "2021"
-description = "device-specific operations on the BMR491"
+description = "device-specific operations for the BMR491"
 
 [dependencies]
 anyhow.workspace = true
@@ -10,6 +10,7 @@ clap.workspace = true
 colored.workspace = true
 log.workspace = true
 parse_int.workspace = true
+zerocopy.workspace = true
 
 humility.workspace = true
 humility-cmd.workspace = true

--- a/cmd/ibc/Cargo.toml
+++ b/cmd/ibc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "humility-cmd-ibc"
 version = "0.1.0"
 edition = "2021"
-description = "device-specific operations for the BMR491"
+description = "interface to the BMR491 power regulator"
 
 [dependencies]
 anyhow.workspace = true

--- a/cmd/ibc/Cargo.toml
+++ b/cmd/ibc/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "humility-cmd-ibc"
+version = "0.1.0"
+edition = "2021"
+description = "device-specific operations on the BMR491"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+colored.workspace = true
+log.workspace = true
+parse_int.workspace = true
+
+humility.workspace = true
+humility-cmd.workspace = true
+cmd-hiffy.workspace = true
+
+hif.workspace = true
+idol.workspace = true
+pmbus.workspace = true

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -15,7 +15,7 @@
 //! loss.
 //!
 //! Here's an example:
-//! ```
+//! ```console
 //! matt@igor ~ (sn5) $ pfexec ./humility -tsn5 ibc black-box
 //! humility: attached to 0483:374e:001B00083156501320323443 via ST-Link V3
 //! FAULT EVENT

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -11,17 +11,18 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use humility::cli::Subcommand;
 use humility_cmd::CommandKind;
+use zerocopy::{
+    byteorder::{BigEndian, U16, U32},
+    AsBytes, FromBytes,
+};
 
-use cmd_hiffy as humility_cmd_hiffy;
 use hif::*;
 
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::hiffy::HiffyContext;
 use humility_cmd::i2c::I2cArgs;
-use humility_cmd::idol::{HubrisIdol, IdolArgument};
 use humility_cmd::{Archive, Attach, Command, Validate};
-use humility_cmd_hiffy::HiffyLease;
 
 #[derive(Parser, Debug)]
 #[clap(name = "ibc", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -47,7 +48,6 @@ enum IbcSubcommand {
 }
 
 pub struct IbcHandler<'a> {
-    hubris: &'a HubrisArchive,
     device: &'a HubrisI2cDevice,
     core: &'a mut dyn Core,
     context: HiffyContext<'a>,
@@ -67,13 +67,9 @@ impl<'a> IbcHandler<'a> {
             .ok_or_else(|| anyhow!("could not find 'bmr491' device"))?;
         println!("{device:?}");
         let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self { hubris, device, core, context })
+        Ok(Self { device, core, context })
     }
     pub fn blackbox(&mut self, verbose: bool) -> Result<()> {
-        if verbose {
-            humility::msg!("hi");
-        }
-
         let funcs = self.context.functions()?;
         let write_func = funcs.get("I2cWrite", 8)?;
         let read_func = funcs.get("I2cRead", 7)?;
@@ -84,8 +80,6 @@ impl<'a> IbcHandler<'a> {
             pmbus::commands::bmr491::CommandCode::MFR_EVENT_INDEX as u8;
         const READ_EVENT: u8 =
             pmbus::commands::bmr491::CommandCode::MFR_READ_EVENT as u8;
-
-        // We want to loop over the 48 slots (24 fault, 24 event)
 
         let mut ops = vec![];
         ops.push(Op::Push(hargs.controller));
@@ -99,7 +93,39 @@ impl<'a> IbcHandler<'a> {
         }
         ops.push(Op::Push(hargs.address.unwrap()));
 
-        // Let's unroll the loop here to avoid having to think about it in HIF
+        // We must read VOUT_MODE to interpret later data
+        ops.push(Op::Push(
+            pmbus::commands::bmr491::CommandCode::VOUT_MODE as u8,
+        ));
+        ops.push(Op::Push(1)); // Number of bytes to read
+        ops.push(Op::Call(read_func.id));
+        ops.push(Op::DropN(2));
+
+        // The IBC contains 48 slots in its black box.  The lower 24 are fault
+        // slots, and the upper 24 are life-cycle events.  By writing special
+        // indexes to EVENT_INDEX, we can read back the index of the newest
+        // record in each section
+        ops.push(Op::Push(EVENT_INDEX));
+        ops.push(Op::Push(255)); // Special to get newest fault index
+        ops.push(Op::Push(1)); // Number of words to write
+        ops.push(Op::Call(write_func.id));
+        ops.push(Op::DropN(2));
+
+        ops.push(Op::Push(1)); // Number of bytes to read
+        ops.push(Op::Call(read_func.id));
+        ops.push(Op::DropN(1));
+
+        ops.push(Op::Push(254)); // Special to get newest life-cycle index
+        ops.push(Op::Push(1)); // Number of words to write
+        ops.push(Op::Call(write_func.id));
+        ops.push(Op::DropN(2));
+
+        ops.push(Op::Push(1)); // Number of bytes to read
+        ops.push(Op::Call(read_func.id));
+        ops.push(Op::DropN(2));
+
+        // Now, read all of the actual events!
+        // We'll unroll the loop here to avoid having to think about it in HIF
         for i in 0..48 {
             ops.push(Op::Push(EVENT_INDEX));
             ops.push(Op::Push(i)); // This is our actual index
@@ -117,9 +143,144 @@ impl<'a> IbcHandler<'a> {
         ops.push(Op::Done);
 
         let results = self.context.run(self.core, ops.as_slice(), None)?;
-        println!("{results:?}");
+
+        let vout_mode = results[0].as_ref().unwrap()[0];
+
+        // Results are alternating between writing EVENT_INDEX and reading
+        // READ_EVENT
+        for (i, r) in results.iter().skip(1).step_by(2).enumerate() {
+            if let Err(e) = r {
+                bail!("Failed to read event {i}: {e}");
+            }
+        }
+        let newest_fault_event_index = results[2].as_ref().unwrap()[0];
+        let newest_lifecycle_event_index = results[4].as_ref().unwrap()[0];
+
+        let mut events = vec![];
+        for (i, r) in results.iter().skip(6).step_by(2).enumerate() {
+            match r {
+                Ok(r) => {
+                    events.push(IbcEvent::read_from(&r[1..]).ok_or_else(
+                        || anyhow!("Failed to decode IbcEvent from {r:?}"),
+                    )?);
+                }
+                Err(e) => bail!("Failed to read event {i}: {e}"),
+            }
+        }
+        for i in 0..=newest_fault_event_index {
+            let e = events[i as usize];
+            println!("{}", "FAULT EVENT".red());
+            println!("  EVENT_INDEX:        {i}");
+            self.print_event(e, verbose, vout_mode);
+        }
+        for i in 24..=newest_lifecycle_event_index {
+            let e = events[i as usize];
+            println!("{}", "LIFECYCLE EVENT".green());
+            println!("  EVENT_INDEX:        {i}");
+            self.print_event(e, verbose, vout_mode);
+        }
 
         Ok(())
+    }
+
+    fn print_event(&self, e: IbcEvent, verbose: bool, vout_mode: u8) {
+        println!(
+            "  TIMESTAMP           {:#010x} = {}",
+            e.timestamp.get(),
+            Self::format_time(e.timestamp.get())
+        );
+        println!("  EVENT_ID            {:#06x}", e.event_id.get());
+        println!("  STATUS_WORD         {:#06x}", e.status_word.get());
+        let statuses = [
+            ("STATUS_VOUT", e.status_vout),
+            ("STATUS_IOUT", e.status_iout),
+            ("STATUS_INPUT", e.status_input),
+            ("STATUS_TEMPERATURE", e.status_temperature),
+            ("STATUS_CML", e.status_cml),
+            ("STATUS_OTHER", e.status_other),
+            ("STATUS_MFG", e.status_mfr),
+        ];
+
+        for (name, value) in statuses {
+            if value == 0 && !verbose {
+                continue;
+            }
+            print!("  {: <18}  ", name);
+            let v = format!("{:#06x}", value);
+            if value == 0 {
+                println!("{}", v.dimmed());
+            } else {
+                println!("{v}");
+            }
+        }
+        if e.status_word.get() == 0x0001 {
+            for (i, flag) in [
+                "BOOT_EVENT",
+                "INPUT_LOW_EVENT",
+                "CANCEL_EVENT",
+                "ERASE_EVENT",
+                "CLR_EVENT",
+                "ERASE_OVFL_EVENT",
+            ]
+            .iter()
+            .enumerate()
+            {
+                // TODO: some of these flags are only valid in the life-cycle
+                // section
+                if e.status_mfr & (1 << i) != 0 {
+                    println!("    b{i} = {flag}");
+                }
+            }
+        }
+
+        let dev = pmbus::commands::Device::Bmr491;
+        use pmbus::commands::bmr491::CommandCode;
+        let vout_mode_cb =
+            || pmbus::commands::VOUT_MODE::CommandData(vout_mode);
+
+        let values = [
+            ("V_IN", CommandCode::READ_VIN, e.vin_value.get()),
+            ("V_OUT", CommandCode::READ_VOUT, e.vout_value.get()),
+            ("I_OUT", CommandCode::READ_IOUT, e.iout_value.get()),
+            (
+                "TEMPERATURE",
+                CommandCode::READ_TEMPERATURE_1,
+                e.temperature_value.get(),
+            ),
+        ];
+
+        for (name, command, value) in values {
+            dev.interpret(
+                command as u8,
+                value.as_bytes(),
+                vout_mode_cb,
+                |_field, value| {
+                    println!("  {: <18}  {:#06x} = {value}", name, value.raw())
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    fn format_time(timestamp: u32) -> String {
+        let time_sec = timestamp / 10;
+        let seconds = time_sec % 60;
+        let minutes = (time_sec / 60) % 60;
+        let hours = (time_sec / 3600) % 24;
+        let days = time_sec / (3600 * 24);
+        let mut out = String::new();
+        if days > 0 {
+            out += &format!("{days} day, ");
+        }
+        if hours > 0 {
+            out += &format!("{hours} hr, ");
+        }
+        if minutes > 0 {
+            out += &format!("{minutes} min, ");
+        }
+        out += &format!("{seconds}.{} sec", time_sec % 10);
+
+        out
     }
 }
 
@@ -131,10 +292,11 @@ impl<'a> IbcHandler<'a> {
 /// any further.
 ///
 /// See page 19 of the BMR491 technical specification
+#[derive(Copy, Clone, Debug, FromBytes)]
 struct IbcEvent {
-    event_id: u16,
-    timestamp: u32,
-    status_word: u16,
+    event_id: U16<BigEndian>,
+    timestamp: U32<BigEndian>,
+    status_word: U16<BigEndian>,
     status_vout: u8,
     status_iout: u8,
     status_input: u8,
@@ -142,10 +304,10 @@ struct IbcEvent {
     status_cml: u8,
     status_other: u8,
     status_mfr: u8,
-    vin_value: u16,
-    vout_value: u16,
-    iout_value: u16,
-    temperature_value: u16,
+    vin_value: U16<BigEndian>,
+    vout_value: U16<BigEndian>,
+    iout_value: U16<BigEndian>,
+    temperature_value: U16<BigEndian>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -172,7 +334,7 @@ pub fn init() -> Command {
         run: ibc,
         kind: CommandKind::Attached {
             archive: Archive::Required,
-            attach: Attach::Any, // TODO
+            attach: Attach::LiveOnly,
             validate: Validate::Booted,
         },
     }

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -108,7 +108,7 @@ impl<'a> IbcHandler<'a> {
             ops.push(Op::DropN(3));
 
             ops.push(Op::Push(READ_EVENT));
-            ops.push(Op::Push(1)); // Number of bytes to read
+            ops.push(Op::Push(24)); // Number of bytes to read
             ops.push(Op::Call(read_func.id));
             ops.push(Op::DropN(2));
         }

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -4,7 +4,67 @@
 
 //! ## `humility ibc`
 //!
-//! Tools to interact with the BMR491 IBC
+//! Interface to BMR491 power regulator
+//!
+//! This regulator is present on Gimlet and Sidecar PCAs.  Right now,
+//! `humility ibc` only exposes one subcommand: `black-box`.
+//!
+//! `humility ibc black-box` allows you to read out the blackbox log from the
+//! power converter.  This can be used to debug previous faults.  The log is
+//! stored in non-volatile memory, so it should be persistent through power
+//! loss.
+//!
+//! Here's an example:
+//! ```
+//! matt@igor ~ (sn5) $ pfexec ./humility -tsn5 ibc black-box
+//! humility: attached to 0483:374e:001B00083156501320323443 via ST-Link V3
+//! FAULT EVENT
+//!   EVENT_INDEX:        0
+//!   TIMESTAMP           0x000001ca = 45.5 sec
+//!   EVENT_ID            0x0000
+//!   STATUS_WORD         0x0010
+//!   STATUS_IOUT         0x0080
+//!   V_IN                0xf869 = 52.50V
+//!   V_OUT               0x5f00 = 11.88V
+//!   I_OUT               0x004e = 78.00A
+//!   TEMPERATURE         0x001c = 28.00°C
+//! FAULT EVENT
+//!   EVENT_INDEX:        1
+//!   TIMESTAMP           0x000001d4 = 46.6 sec
+//!   EVENT_ID            0x0001
+//!   STATUS_WORD         0x0001
+//!   STATUS_MFG          0x0001
+//!     b0 = BOOT_EVENT
+//!   V_IN                0xf83c = 30.00V
+//!   V_OUT               0x0000 = 0.00V
+//!   I_OUT               0x0000 = 0.00A
+//!   TEMPERATURE         0x0000 = 0.00°C
+//! FAULT EVENT
+//!   EVENT_INDEX:        2
+//!   TIMESTAMP           0x000002c4 = 1 min, 10.0 sec
+//!   EVENT_ID            0x0002
+//!   STATUS_WORD         0x0010
+//!   STATUS_IOUT         0x0080
+//!   V_IN                0xf877 = 59.50V
+//!   V_OUT               0x5f00 = 11.88V
+//!   I_OUT               0x0070 = 112.00A
+//!   TEMPERATURE         0x002c = 44.00°C
+//! FAULT EVENT
+//!   EVENT_INDEX:        3
+//!   TIMESTAMP           0x27ffb2c4 = 776 day, 16 hr, 48 min, 6.6 sec
+//!   EVENT_ID            0x0003
+//!   STATUS_WORD         0x0001
+//!   STATUS_MFG          0x0002
+//!     b1 = INPUT_LOW_EVENT
+//!   V_IN                0xf86b = 53.50V
+//!   V_OUT               0x6000 = 12.00V
+//!   I_OUT               0x0000 = 0.00A
+//!   TEMPERATURE         0x0016 = 22.00°C
+//! ```
+//!
+//! The log doesn't appear to be _completely_ reliable, so take it with a grain
+//! of salt and with the datasheet close at hand.  For example, the machine in
+//! the example above had **not** be up for 776 days.
 
 use anyhow::{anyhow, bail, Result};
 use clap::{CommandFactory, Parser};

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -101,8 +101,8 @@ impl<'a> IbcHandler<'a> {
 
         // Let's unroll the loop here to avoid having to think about it in HIF
         for i in 0..48 {
-            ops.push(Op::Push(i)); // This is our actual index
             ops.push(Op::Push(EVENT_INDEX));
+            ops.push(Op::Push(i)); // This is our actual index
             ops.push(Op::Push(1)); // Number of words to write
             ops.push(Op::Call(write_func.id));
             ops.push(Op::DropN(3));

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -1,0 +1,179 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility ibc`
+//!
+//! Tools to interact with the BMR491 IBC
+
+use anyhow::{anyhow, bail, Result};
+use clap::{CommandFactory, Parser};
+use colored::Colorize;
+use humility::cli::Subcommand;
+use humility_cmd::CommandKind;
+
+use cmd_hiffy as humility_cmd_hiffy;
+use hif::*;
+
+use humility::core::Core;
+use humility::hubris::*;
+use humility_cmd::hiffy::HiffyContext;
+use humility_cmd::i2c::I2cArgs;
+use humility_cmd::idol::{HubrisIdol, IdolArgument};
+use humility_cmd::{Archive, Attach, Command, Validate};
+use humility_cmd_hiffy::HiffyLease;
+
+#[derive(Parser, Debug)]
+#[clap(name = "ibc", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct IbcArgs {
+    /// sets timeout
+    #[clap(
+        long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
+        parse(try_from_str = parse_int::parse)
+    )]
+    timeout: u32,
+
+    #[clap(subcommand)]
+    cmd: IbcSubcommand,
+}
+
+#[derive(Parser, Debug)]
+enum IbcSubcommand {
+    /// Prints the auxiliary flash status
+    BlackBox {
+        #[clap(long, short)]
+        verbose: bool,
+    },
+}
+
+pub struct IbcHandler<'a> {
+    hubris: &'a HubrisArchive,
+    device: &'a HubrisI2cDevice,
+    core: &'a mut dyn Core,
+    context: HiffyContext<'a>,
+}
+
+impl<'a> IbcHandler<'a> {
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        core: &'a mut dyn Core,
+        hiffy_timeout: u32,
+    ) -> Result<Self> {
+        let device = hubris
+            .manifest
+            .i2c_devices
+            .iter()
+            .find(|d| d.device == "bmr491")
+            .ok_or_else(|| anyhow!("could not find 'bmr491' device"))?;
+        println!("{device:?}");
+        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
+        Ok(Self { hubris, device, core, context })
+    }
+    pub fn blackbox(&mut self, verbose: bool) -> Result<()> {
+        if verbose {
+            humility::msg!("hi");
+        }
+
+        let funcs = self.context.functions()?;
+        let write_func = funcs.get("I2cWrite", 8)?;
+        let read_func = funcs.get("I2cRead", 7)?;
+
+        let hargs = I2cArgs::from_device(self.device);
+
+        const EVENT_INDEX: u8 =
+            pmbus::commands::bmr491::CommandCode::MFR_EVENT_INDEX as u8;
+        const READ_EVENT: u8 =
+            pmbus::commands::bmr491::CommandCode::MFR_READ_EVENT as u8;
+
+        // We want to loop over the 48 slots (24 fault, 24 event)
+
+        let mut ops = vec![];
+        ops.push(Op::Push(hargs.controller));
+        ops.push(Op::Push(hargs.port.index));
+        if let Some(mux) = hargs.mux {
+            ops.push(Op::Push(mux.0));
+            ops.push(Op::Push(mux.1));
+        } else {
+            ops.push(Op::PushNone);
+            ops.push(Op::PushNone);
+        }
+        ops.push(Op::Push(hargs.address.unwrap()));
+
+        // Let's unroll the loop here to avoid having to think about it in HIF
+        for i in 0..48 {
+            ops.push(Op::Push(i)); // This is our actual index
+            ops.push(Op::Push(EVENT_INDEX));
+            ops.push(Op::Push(1)); // Number of words to write
+            ops.push(Op::Call(write_func.id));
+            ops.push(Op::DropN(3));
+
+            ops.push(Op::Push(READ_EVENT));
+            ops.push(Op::Push(1)); // Number of bytes to read
+            ops.push(Op::Call(read_func.id));
+            ops.push(Op::DropN(2));
+        }
+
+        ops.push(Op::DropN(5));
+        ops.push(Op::Done);
+
+        let results = self.context.run(self.core, ops.as_slice(), None)?;
+        println!("{results:?}");
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Raw data stored in the `READ_EVENT` PMBus block
+///
+/// Byte-encoded data is packed into native machine types, but is not decoded
+/// any further.
+///
+/// See page 19 of the BMR491 technical specification
+struct IbcEvent {
+    event_id: u16,
+    timestamp: u32,
+    status_word: u16,
+    status_vout: u8,
+    status_iout: u8,
+    status_input: u8,
+    status_temperature: u8,
+    status_cml: u8,
+    status_other: u8,
+    status_mfr: u8,
+    vin_value: u16,
+    vout_value: u16,
+    iout_value: u16,
+    temperature_value: u16,
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+fn ibc(context: &mut humility::ExecutionContext) -> Result<()> {
+    let core = &mut **context.core.as_mut().unwrap();
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+    let subargs = IbcArgs::try_parse_from(subargs)?;
+    let hubris = context.archive.as_ref().unwrap();
+    let mut worker = IbcHandler::new(hubris, core, subargs.timeout)?;
+
+    match subargs.cmd {
+        IbcSubcommand::BlackBox { verbose } => {
+            worker.blackbox(verbose)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn init() -> Command {
+    Command {
+        app: IbcArgs::command(),
+        name: "ibc",
+        run: ibc,
+        kind: CommandKind::Attached {
+            archive: Archive::Required,
+            attach: Attach::Any, // TODO
+            validate: Validate::Booted,
+        },
+    }
+}

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.27
+humility 0.9.28
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.27
+humility 0.9.28
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.27
+humility 0.9.28
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.27
+humility 0.9.28
 
 ```


### PR DESCRIPTION
This PR adds `humility ibc`, which reads and decodes the BMR491's blackbox log.

Right now, it's all done through raw I2C; we'll eventually want to shift it to Idol and then expose it to MGS.