### PR TITLE
Add support for persistent QSPI data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1668,6 +1668,7 @@ dependencies = [
  "clap",
  "hif",
  "humility-cmd",
+ "humility-cmd-hiffy",
  "humility-core",
  "indicatif",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.28"
+version = "0.9.29"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.28"
+version = "0.9.29"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ a specified target.  (In the above example, one could execute `humility
 
 - [humility apptable](#humility-apptable): print Hubris apptable
 - [humility auxflash](#humility-auxflash): manipulate auxiliary flash
+- [humility bankerase](#humility-bankerase): Erase a bank
 - [humility console-proxy](#humility-console-proxy): SP/host console uart proxy
 - [humility dashboard](#humility-dashboard): dashboard for Hubris sensor data
 - [humility debugmailbox](#humility-debugmailbox): interact with the debug mailbox on the LPC55
@@ -297,6 +298,19 @@ Tools to interact with the auxiliary flash, described in RFD 311.
 
 This subcommand should be rarely used; `humility flash` will automatically
 program auxiliary flash when needed.
+
+
+### `humility bankerase`
+
+Erase flash in "erase block" size chunks (32 KiB) on the RoT.
+
+Erase `len` is given in bytes and then rounded up to the nearest block
+size so that all pages containing the range are erased. Then the erased
+pages are overwritten with 0s, but only starting at the address given. In
+other words, if the address is given as 0x40001 and len as 512, flash will
+be erased from 0x40000 to 0x48000,  but address 0x40000 will have value
+`0xff`, and every other byte will have value `0`.
+
 
 
 ### `humility console-proxy`
@@ -871,7 +885,7 @@ stored in non-volatile memory, so it should be persistent through power
 loss.
 
 Here's an example:
-```rust
+```console
 matt@igor ~ (sn5) $ pfexec ./humility -tsn5 ibc black-box
 humility: attached to 0483:374e:001B00083156501320323443 via ST-Link V3
 FAULT EVENT
@@ -1583,6 +1597,10 @@ humility: attached via ST-Link V3
 120000..000080: 4d07112733efe240f990fad785726c52de4335d6c5c30a33e60096d4c2576742
 ```
 
+By default, Hubris reserved sector 0 (the lowest 64 KiB) of QSPI for its own
+internal bookkeeping.  To override this, use the `--write-sector0` flag;
+this is required for erases and writes that would otherwise modify sector 0,
+as well as bulk erase.
 
 
 ### `humility readmem`
@@ -1934,11 +1952,11 @@ humility: image CRC (0x841f35a5) matches OTP CRC
 
 `humility repl` is an interactive prompt that you can use with humility.
 
-This allows you to run several commands in succession without needing to type in some core settings
-over and over again.
+This allows you to run several commands in succession without needing to
+type in some core settings over and over again.
 
-`humility repl` takes the same top level arguments as any other subcommand, and will remember them
-inside of the prompt. For example:
+`humility repl` takes the same top level arguments as any other subcommand,
+and will remember them inside of the prompt. For example:
 
 ```console
 $ humility -a ../path/to/hubris/archive.zip repl
@@ -1977,10 +1995,12 @@ archive each time. In the output above, you can see the ping task faulting
 in the background; your code is still running in the background while you
 use the repl!
 
-Finally, as you can see, `quit` will quit the repl. There is also a `history`
-command, which will show you recent commands you've put into the prompt.
+Finally, as you can see, `quit` will quit the repl. There is also a
+`history` command, which will show you recent commands you've put into the
+prompt.
 
-The repl is still very early days! We'll be adding more features in the future.
+The repl is still very early days! We'll be adding more features in the
+future.
 
 
 ### `humility reset`

--- a/cmd/qspi/Cargo.toml
+++ b/cmd/qspi/Cargo.toml
@@ -7,6 +7,7 @@ description = "QSPI status, reading and writing"
 [dependencies]
 humility = { workspace = true }
 humility-cmd = { workspace = true }
+cmd-hiffy = { workspace = true }
 hif = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.28
+humility 0.9.29
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.28
+humility 0.9.29
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.28
+humility 0.9.29
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.28
+humility 0.9.29
 
 ```


### PR DESCRIPTION
This PR adds a `--write-sector0` flag to `humility qspi`, without which it will refuse to modify the contents of QSPI sector 0.  This is part of implementing https://github.com/oxidecomputer/hubris/issues/985, but should be backwards-compatible; Humility will fall back to older functions if the new ones aren't present.

I don't love the state of the code, but was trying not to get embroiled in a larger `humility qspi` refactor!