### PR TITLE
`isp` command cleanup

### DIFF
--- a/cmd/isp/src/cmd.rs
+++ b/cmd/isp/src/cmd.rs
@@ -9,9 +9,9 @@ fn do_command(
     port: &mut dyn serialport::SerialPort,
     tag: CommandTag,
     command_resp: ResponseCode,
-    args: Vec<u32>,
+    args: &[u32],
 ) -> Result<Vec<u32>> {
-    send_command(port, tag, &args)?;
+    send_command(port, tag, args)?;
 
     read_response(port, command_resp)
 }
@@ -37,7 +37,7 @@ fn recv_data(
 }
 
 pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let args = vec![
+    let args = [
         // Arg 0 =  WriteNonVolatile
         KeyProvisionCmds::WriteNonVolatile as u32,
         // Arg 1 = Memory ID (0 = internal flash)
@@ -48,14 +48,14 @@ pub fn do_save_keystore(port: &mut dyn serialport::SerialPort) -> Result<()> {
         port,
         CommandTag::KeyProvision,
         ResponseCode::Generic,
-        args,
+        &args,
     )?;
 
     Ok(())
 }
 
 pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let args = vec![
+    let args = [
         // Arg =  Enroll
         KeyProvisionCmds::Enroll as u32,
     ];
@@ -64,14 +64,14 @@ pub fn do_enroll(port: &mut dyn serialport::SerialPort) -> Result<()> {
         port,
         CommandTag::KeyProvision,
         ResponseCode::Generic,
-        args,
+        &args,
     )?;
 
     Ok(())
 }
 
 pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
-    let args = vec![
+    let args = [
         // Arg 0 =  SetIntrinsicKey
         KeyProvisionCmds::SetIntrinsicKey as u32,
         // Arg 1 = UDS
@@ -84,7 +84,7 @@ pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
         port,
         CommandTag::KeyProvision,
         ResponseCode::Generic,
-        args,
+        &args,
     )?;
 
     Ok(())
@@ -92,18 +92,18 @@ pub fn do_generate_uds(port: &mut dyn serialport::SerialPort) -> Result<()> {
 
 pub fn do_isp_write_keystore(
     port: &mut dyn serialport::SerialPort,
-    data: Vec<u8>,
+    data: &[u8],
 ) -> Result<()> {
-    let args = vec![KeyProvisionCmds::WriteKeyStore as u32];
+    let args = [KeyProvisionCmds::WriteKeyStore as u32];
 
     let _ = do_command(
         port,
         CommandTag::KeyProvision,
         ResponseCode::KeyProvision,
-        args,
+        &args,
     )?;
 
-    send_data(port, &data, ResponseCode::Generic)
+    send_data(port, data, ResponseCode::Generic)
 }
 
 pub fn do_isp_read_memory(
@@ -111,7 +111,7 @@ pub fn do_isp_read_memory(
     address: u32,
     cnt: u32,
 ) -> Result<Vec<u8>> {
-    let args = vec![
+    let args = [
         // Arg0 = address
         address, // Arg1 = length
         cnt,     // Arg2 = memory type
@@ -122,7 +122,7 @@ pub fn do_isp_read_memory(
         port,
         CommandTag::ReadMemory,
         ResponseCode::ReadMemory,
-        args,
+        &args,
     )?;
 
     recv_data(port, cnt, ResponseCode::Generic)
@@ -131,9 +131,9 @@ pub fn do_isp_read_memory(
 pub fn do_isp_write_memory(
     port: &mut dyn serialport::SerialPort,
     address: u32,
-    data: Vec<u8>,
+    data: &[u8],
 ) -> Result<()> {
-    let args = vec![
+    let args = [
         // arg 0 = address
         address,
         // arg 1 = len
@@ -142,16 +142,20 @@ pub fn do_isp_write_memory(
         0x0_u32,
     ];
 
-    let _ =
-        do_command(port, CommandTag::WriteMemory, ResponseCode::Generic, args)?;
+    let _ = do_command(
+        port,
+        CommandTag::WriteMemory,
+        ResponseCode::Generic,
+        &args,
+    )?;
 
-    send_data(port, &data, ResponseCode::Generic)
+    send_data(port, data, ResponseCode::Generic)
 }
 
 pub fn do_isp_flash_erase_all(
     port: &mut dyn serialport::SerialPort,
 ) -> Result<()> {
-    let args = vec![
+    let args = [
         // Erase internal flash
         0x0_u32,
     ];
@@ -160,7 +164,7 @@ pub fn do_isp_flash_erase_all(
         port,
         CommandTag::FlashEraseAll,
         ResponseCode::Generic,
-        args,
+        &args,
     )?;
 
     Ok(())
@@ -170,25 +174,25 @@ pub fn do_isp_get_property(
     port: &mut dyn serialport::SerialPort,
     prop: BootloaderProperty,
 ) -> Result<Vec<u32>> {
-    let args = vec![
+    let args = [
         // Arg 0 = property
         prop as u32,
     ];
 
-    do_command(port, CommandTag::GetProperty, ResponseCode::GetProperty, args)
+    do_command(port, CommandTag::GetProperty, ResponseCode::GetProperty, &args)
 }
 
 pub fn do_isp_last_error(
     port: &mut dyn serialport::SerialPort,
 ) -> Result<Vec<u32>> {
-    let args = vec![
+    let args = [
         // Arg 0 = LastCRC
         BootloaderProperty::CRCStatus as u32,
         // Arg 1 = Last error
         1_u32,
     ];
 
-    do_command(port, CommandTag::GetProperty, ResponseCode::GetProperty, args)
+    do_command(port, CommandTag::GetProperty, ResponseCode::GetProperty, &args)
 }
 
 pub fn do_ping(port: &mut dyn serialport::SerialPort) -> Result<()> {

--- a/cmd/isp/src/cmd.rs
+++ b/cmd/isp/src/cmd.rs
@@ -128,6 +128,19 @@ pub fn do_isp_read_memory(
     recv_data(port, cnt, ResponseCode::Generic)
 }
 
+/// Variant of `do_isp_read_memory` that reads a compile-time byte count, which
+/// means it can return a precisely sized allocation that can be treated as a
+/// fixed length array without further work.
+pub fn do_isp_read_memory_array<const N: usize>(
+    port: &mut dyn serialport::SerialPort,
+    address: u32,
+) -> Result<Box<[u8; N]>> {
+    let cnt = u32::try_from(N).unwrap();
+    let bytes = do_isp_read_memory(port, address, cnt)?;
+    Ok(crate::fixed_vec(bytes)
+        .expect("do_isp_read_memory returned wrong vec length!"))
+}
+
 pub fn do_isp_write_memory(
     port: &mut dyn serialport::SerialPort,
     address: u32,

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -282,38 +282,23 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
                 },
             };
 
-            let mut cmpa_bytes = [0u8; 512];
-            cmpa_bytes.clone_from_slice(&bytes);
-            let cmpa = CMPAPage::from_bytes(&cmpa_bytes)?;
+            let cmpa_bytes: &[u8; 512] =
+                as_array(&bytes).context("reading archive CMPA")?;
 
-            let m1 = crate::cmd::do_isp_read_memory(
-                &mut *port,
-                CFPA_PING_ADDR,
-                512,
-            )?;
-            let m2 = crate::cmd::do_isp_read_memory(
-                &mut *port,
-                CFPA_PONG_ADDR,
-                512,
-            )?;
-            let mut ping_bytes = [0u8; 512];
-            let mut pong_bytes = [0u8; 512];
+            let cmpa = CMPAPage::from_bytes(cmpa_bytes)?;
 
-            ping_bytes.clone_from_slice(&m1);
-            pong_bytes.clone_from_slice(&m2);
-            let ping = CFPAPage::from_bytes(&ping_bytes)?;
-            let pong = CFPAPage::from_bytes(&pong_bytes)?;
+            let cfpa = read_current_cfpa(&mut *port)?;
 
-            let (pin, dflt) = if ping.version > pong.version {
-                (ping.dcfg_cc_socu_ns_pin, ping.dcfg_cc_socu_ns_dflt)
-            } else {
-                (pong.dcfg_cc_socu_ns_pin, pong.dcfg_cc_socu_ns_dflt)
-            };
+            let (pin, dflt) =
+                (cfpa.dcfg_cc_socu_ns_pin, cfpa.dcfg_cc_socu_ns_dflt);
 
             if (pin != 0 || dflt != 0)
                 && (cmpa.cc_socu_pin == 0 || cmpa.cc_socu_dflt == 0)
             {
-                anyhow::bail!("CFPA has non-zero debug settings but CMPA has zero settings! This would brick the chip!");
+                anyhow::bail!(
+                    "CFPA has non-zero debug settings but CMPA \
+                    has zero settings! This would brick the chip!"
+                );
             }
 
             crate::cmd::do_isp_write_memory(&mut *port, CMPA_ADDR, &bytes)?;
@@ -332,19 +317,12 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
 
             // The code below will become very upset if the CFPA file isn't 512
             // bytes in length. Rather than panicking, let's present an error:
-            let bytes = as_array(&bytes).context("loading archive CFPA")?;
-            let cfpa = CFPAPage::from_bytes(bytes)?;
+            let bytes = fixed_vec(bytes).context("loading archive CFPA")?;
+            let cfpa = CFPAPage::from_bytes(&bytes)?;
 
             // Read a copy of the CMPA from the device so we can check for some
             // potential bricking cases.
-            let cmpa = {
-                let cmpa_bytes =
-                    crate::cmd::do_isp_read_memory(&mut *port, CMPA_ADDR, 512)?;
-                CMPAPage::from_bytes(
-                    as_array(&cmpa_bytes)
-                        .expect("constant above should be 512"),
-                )?
-            };
+            let cmpa = read_cmpa(&mut *port)?;
 
             if (cfpa.dcfg_cc_socu_ns_pin != 0 || cfpa.dcfg_cc_socu_ns_dflt != 0)
                 && (cmpa.cc_socu_pin == 0 || cmpa.cc_socu_dflt == 0)
@@ -358,77 +336,55 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             crate::cmd::do_isp_write_memory(
                 &mut *port,
                 CFPA_SCRATCH_ADDR,
-                bytes,
+                &*bytes,
             )?;
             println!("Write to CFPA done!");
         }
         IspCmd::ReadCFPA => {
-            let m = crate::cmd::do_isp_read_memory(
+            let m = crate::cmd::do_isp_read_memory_array::<512>(
                 &mut *port,
                 CFPA_SCRATCH_ADDR,
-                512,
             )?;
 
             let mut dumper = Dumper::new();
             dumper.size = 4;
             println!("=====Scratch Page=====");
-            dumper.dump(&m, CFPA_SCRATCH_ADDR);
+            dumper.dump(&*m, CFPA_SCRATCH_ADDR);
 
-            let m = crate::cmd::do_isp_read_memory(
+            let m = crate::cmd::do_isp_read_memory_array::<512>(
                 &mut *port,
                 CFPA_PING_ADDR,
-                512,
             )?;
 
             println!("=====Ping Page=====");
-            dumper.dump(&m, CFPA_PING_ADDR);
+            dumper.dump(&*m, CFPA_PING_ADDR);
 
-            let m = crate::cmd::do_isp_read_memory(
+            let m = crate::cmd::do_isp_read_memory_array::<512>(
                 &mut *port,
                 CFPA_PONG_ADDR,
-                512,
             )?;
             println!("=====Pong Page=====");
-            dumper.dump(&m, CFPA_PONG_ADDR);
+            dumper.dump(&*m, CFPA_PONG_ADDR);
         }
         IspCmd::EraseCMPA { full } => {
             let b = if full {
-                let m1 = crate::cmd::do_isp_read_memory(
-                    &mut *port,
-                    CFPA_PING_ADDR,
-                    512,
-                )?;
-                let m2 = crate::cmd::do_isp_read_memory(
-                    &mut *port,
-                    CFPA_PONG_ADDR,
-                    512,
-                )?;
-                let mut ping_bytes = [0u8; 512];
-                let mut pong_bytes = [0u8; 512];
+                // We're reading the CFPA to erase the CMPA -- this is not a
+                // typo! Before allowing the erase we check fields in the CFPA
+                // to try to prevent bricking the chip.
+                let cfpa = read_current_cfpa(&mut *port)?;
 
-                ping_bytes.clone_from_slice(&m1);
-                pong_bytes.clone_from_slice(&m2);
-                let ping = CFPAPage::from_bytes(&ping_bytes)?;
-                let pong = CFPAPage::from_bytes(&pong_bytes)?;
-
-                let (pin, dflt) = if ping.version > pong.version {
-                    (ping.dcfg_cc_socu_ns_pin, ping.dcfg_cc_socu_ns_dflt)
-                } else {
-                    (pong.dcfg_cc_socu_ns_pin, pong.dcfg_cc_socu_ns_dflt)
-                };
+                let (pin, dflt) =
+                    (cfpa.dcfg_cc_socu_ns_pin, cfpa.dcfg_cc_socu_ns_dflt);
                 if pin != 0 || dflt != 0 {
-                    anyhow::bail!("The CFPA has non-zero settings! Erasing the CMPA would brick the chip!");
+                    anyhow::bail!(
+                        "The CFPA has non-zero settings! Erasing \
+                        the CMPA would brick the chip!"
+                    );
                 }
 
                 vec![0; 512]
             } else {
-                let m =
-                    crate::cmd::do_isp_read_memory(&mut *port, CMPA_ADDR, 512)?;
-                let mut bytes = [0u8; 512];
-                bytes.clone_from_slice(&m);
-
-                let mut cmpa = CMPAPage::from_bytes(&bytes)?;
-
+                let mut cmpa = read_cmpa(&mut *port)?;
                 cmpa.secure_boot_cfg = 0;
                 cmpa.to_vec()?
             };
@@ -437,11 +393,13 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             println!("You can now boot unsigned images");
         }
         IspCmd::ReadCMPA => {
-            let m = crate::cmd::do_isp_read_memory(&mut *port, CMPA_ADDR, 512)?;
+            let m = crate::cmd::do_isp_read_memory_array::<512>(
+                &mut *port, CMPA_ADDR,
+            )?;
 
             let mut dumper = Dumper::new();
             dumper.size = 4;
-            dumper.dump(&m, CMPA_ADDR);
+            dumper.dump(&*m, CMPA_ADDR);
         }
         IspCmd::Restore => {
             println!("Erasing flash");
@@ -541,8 +499,51 @@ pub fn init() -> Command {
     }
 }
 
+/// Attempts to cast `slice` into an array reference, succeeding only if the
+/// length equals `N`. This is a wrapper for the `TryFrom` impl from the
+/// standard library that adds slightly improved error reporting.
 fn as_array<const N: usize>(slice: &[u8]) -> Result<&[u8; N]> {
     slice
         .try_into()
         .map_err(|_| anyhow!("data should be {N}B, but is: {}", slice.len()))
+}
+
+/// Attempts to cast `vec` into a `Box<[T; N]>`, succeeding only if the length
+/// is right.
+fn fixed_vec<T, const N: usize>(vec: Vec<T>) -> Result<Box<[T; N]>> {
+    vec.try_into().map_err(|vec: Vec<T>| {
+        anyhow!("len should be {N}, but is: {}", vec.len())
+    })
+}
+
+/// Reads the CMPA page over the ISP connection and parses the result.
+pub fn read_cmpa(port: &mut dyn serialport::SerialPort) -> Result<CMPAPage> {
+    let m = crate::cmd::do_isp_read_memory_array::<512>(port, CMPA_ADDR)
+        .context("reading CMPA")?;
+    CMPAPage::from_bytes(&m).context("parsing CMPA using packed_struct")
+}
+
+/// The CFPA is held in two copies, and whichever has the higher version field
+/// is the current one. This reads both copies and compares version fields to
+/// determine which is most current, and returns that.
+///
+/// Note: NXP doesn't specify the behavior when the version field is equal, nor
+/// what happens if it wraps around; this function will arbitrarily return one
+/// page if the versions are equal, and wraparound is not supported.
+pub fn read_current_cfpa(
+    port: &mut dyn serialport::SerialPort,
+) -> Result<CFPAPage> {
+    let ping_bytes =
+        crate::cmd::do_isp_read_memory_array::<512>(port, CFPA_PING_ADDR)
+            .context("reading CPFA ping page")?;
+    let pong_bytes =
+        crate::cmd::do_isp_read_memory_array::<512>(&mut *port, CFPA_PONG_ADDR)
+            .context("reading CFPA pong page")?;
+
+    let ping = CFPAPage::from_bytes(&ping_bytes)
+        .context("parsing CFPA ping page with packed_struct")?;
+    let pong = CFPAPage::from_bytes(&pong_bytes)
+        .context("parsing CFPA pong page with packed_struct")?;
+
+    Ok(if ping.version > pong.version { ping } else { pong })
 }

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -341,30 +341,23 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             println!("Write to CFPA done!");
         }
         IspCmd::ReadCFPA => {
-            let m = crate::cmd::do_isp_read_memory_array::<512>(
-                &mut *port,
-                CFPA_SCRATCH_ADDR,
-            )?;
+            // We're going to dump all three versions of the CFPA, in hex,
+            // without decoding.
+            let pages = [
+                (CFPA_SCRATCH_ADDR, "Scratch"),
+                (CFPA_PING_ADDR, "Ping"),
+                (CFPA_PONG_ADDR, "Pong"),
+            ];
+            for (addr, name) in pages {
+                let m = crate::cmd::do_isp_read_memory_array::<512>(
+                    &mut *port, addr,
+                )?;
 
-            let mut dumper = Dumper::new();
-            dumper.size = 4;
-            println!("=====Scratch Page=====");
-            dumper.dump(&*m, CFPA_SCRATCH_ADDR);
-
-            let m = crate::cmd::do_isp_read_memory_array::<512>(
-                &mut *port,
-                CFPA_PING_ADDR,
-            )?;
-
-            println!("=====Ping Page=====");
-            dumper.dump(&*m, CFPA_PING_ADDR);
-
-            let m = crate::cmd::do_isp_read_memory_array::<512>(
-                &mut *port,
-                CFPA_PONG_ADDR,
-            )?;
-            println!("=====Pong Page=====");
-            dumper.dump(&*m, CFPA_PONG_ADDR);
+                let mut dumper = Dumper::new();
+                dumper.size = 4;
+                println!("====={name} Page=====");
+                dumper.dump(&*m, addr);
+            }
         }
         IspCmd::EraseCMPA { full } => {
             let b = if full {

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -260,7 +260,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
 
             infile.read_to_end(&mut bytes)?;
 
-            crate::cmd::do_isp_write_memory(&mut *port, address, bytes)?;
+            crate::cmd::do_isp_write_memory(&mut *port, address, &bytes)?;
             println!("Write complete!");
         }
         IspCmd::FlashEraseAll => {
@@ -303,7 +303,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
                 anyhow::bail!("CFPA has non-zero debug settings but CMPA has zero settings! This would brick the chip!");
             }
 
-            crate::cmd::do_isp_write_memory(&mut *port, 0x9e400, bytes)?;
+            crate::cmd::do_isp_write_memory(&mut *port, 0x9e400, &bytes)?;
             println!("Write to CMPA done!");
         }
         IspCmd::WriteCFPA => {
@@ -332,7 +332,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
                 anyhow::bail!("It looks like the CMPA debug settings aren't set but the CFPA settings are! This will brick the chip!");
             }
 
-            crate::cmd::do_isp_write_memory(&mut *port, 0x9de00, bytes)?;
+            crate::cmd::do_isp_write_memory(&mut *port, 0x9de00, &bytes)?;
             println!("Write to CFPA done!");
         }
         IspCmd::ReadCFPA => {
@@ -387,7 +387,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
                 cmpa.secure_boot_cfg = 0;
                 cmpa.to_vec()?
             };
-            crate::cmd::do_isp_write_memory(&mut *port, 0x9e400, b)?;
+            crate::cmd::do_isp_write_memory(&mut *port, 0x9e400, &b)?;
             println!("CMPA region erased!");
             println!("You can now boot unsigned images");
         }
@@ -429,7 +429,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             );
 
             println!("Writing bytes");
-            crate::cmd::do_isp_write_memory(&mut *port, 0x0, bytes.to_vec())?;
+            crate::cmd::do_isp_write_memory(&mut *port, 0x0, &bytes)?;
 
             println!("Restore done! SWD should work now.");
         }
@@ -457,7 +457,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             // Write 3 * 512 bytes of 0
             let bytes = vec![0; 512 * 3];
 
-            crate::cmd::do_isp_write_keystore(&mut *port, bytes)?;
+            crate::cmd::do_isp_write_keystore(&mut *port, &bytes)?;
             crate::cmd::do_save_keystore(&mut *port)?;
             println!("done.")
         }

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -55,9 +55,9 @@ enum IspCmd {
     },
     /// Erases all non-secure flash. This MUST be done before writing!
     FlashEraseAll,
-    /// Write a file to the CMPA region
+    /// Write the CMPA image from the current archive to the CMPA region
     WriteCMPA,
-    /// Write a file to the CFPA region
+    /// Write the CMPA image from the current archive to the CFPA region
     WriteCFPA,
     /// Read the CMPA region
     ReadCMPA,


### PR DESCRIPTION
This is a first pass over the `isp` command code. My general goals here were

1. To add finer-grained error reporting to distinguish cases like "file missing from ZIP file" from "file found but wrong length", using `anyhow::Context` liberally.
2. To reduce the use of magic numbers for things like the CFPA page addresses, which seemed really easy to get wrong by accident (and which I kept having to look up in the datasheet).
3. To reduce boilerplate sequences for things like reading pages and parsing structs.
4. Secondarily, to reduce allocation. Humility allocates a lot, but the extra allocations done here were adding a lot of lines of code (all the `clone_from_slice` stuff) that were (IMO) distracting from the task being performed, so I've removed them and replaced them with a couple of utility functions that are, with any luck, less distracting.

Note: I have _not_ renamed the `isp` command in this PR because I think that's going to require coordination with manufacturing. I still intend to rename it.