### PR TITLE
Bump to 1.68, fix Clippy warnings, change build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ on: [push, pull_request]
 name: Continuous integration
 
 env:
-  MSRV: 1.65.0
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too
 
 jobs:
@@ -24,11 +23,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.MSRV }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-readme
         uses: baptiste0928/cargo-install@v1
@@ -86,11 +80,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.MSRV }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-readme
         uses: baptiste0928/cargo-install@v1
@@ -109,12 +98,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ env.MSRV }}
-          override: true
-          components: clippy
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-readme
         uses: baptiste0928/cargo-install@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ version = "0.9.30"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"
+rust-version = "1.68"
 
 [workspace]
 members = [

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -391,11 +391,11 @@ fn auxflash(context: &mut humility::ExecutionContext) -> Result<()> {
         }
         AuxFlashCommand::Read { slot, output, count } => {
             let data = worker.auxflash_read(slot, count)?;
-            std::fs::write(&output, &data)?;
+            std::fs::write(output, data)?;
         }
         AuxFlashCommand::Write { slot, input, force } => match input {
             Some(input) => {
-                let data = std::fs::read(&input)?;
+                let data = std::fs::read(input)?;
                 worker.auxflash_write(slot, &data, force)?;
             }
             None => {

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -284,7 +284,7 @@ impl Graph {
                 continue;
             }
 
-            let offs = (self.time - (self.width - i)) as usize;
+            let offs = self.time - (self.width - i);
 
             for (_ndx, s) in &mut self.series.iter_mut().enumerate() {
                 if let Some(datum) = s.raw[offs] {

--- a/cmd/isp/src/lib.rs
+++ b/cmd/isp/src/lib.rs
@@ -254,7 +254,7 @@ fn ispcmd(context: &mut humility::ExecutionContext) -> Result<()> {
             println!("If you didn't already erase the flash this operation will fail!");
             println!("This operation may take a while");
             let mut infile =
-                std::fs::OpenOptions::new().read(true).open(&file)?;
+                std::fs::OpenOptions::new().read(true).open(file)?;
 
             let mut bytes = Vec::new();
 

--- a/cmd/lpc55-pfr/src/lib.rs
+++ b/cmd/lpc55-pfr/src/lib.rs
@@ -235,7 +235,7 @@ fn lpc55_pfr(context: &mut humility::ExecutionContext) -> Result<()> {
         PfrCmd::WriteCFPA { file } => {
             let mut file_bytes = Vec::new();
             let mut infile =
-                std::fs::OpenOptions::new().read(true).open(&file)?;
+                std::fs::OpenOptions::new().read(true).open(file)?;
 
             infile.read_to_end(&mut file_bytes)?;
 
@@ -289,7 +289,7 @@ fn lpc55_pfr(context: &mut humility::ExecutionContext) -> Result<()> {
         PfrCmd::WriteCMPA { file } => {
             let mut file_bytes = Vec::new();
             let mut infile =
-                std::fs::OpenOptions::new().read(true).open(&file)?;
+                std::fs::OpenOptions::new().read(true).open(file)?;
 
             infile.read_to_end(&mut file_bytes)?;
 

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -709,7 +709,7 @@ fn monorail_status(
             ops.push(Op::Push32(op.task.task())); // Task id
             ops.push(Op::Push16(op.code)); // opcode
             ops.push(Op::Push(0)); // port (payload)
-            ops.push(Op::Push(NUM_PORTS as u8)); // comparison target (dummy)
+            ops.push(Op::Push(NUM_PORTS)); // comparison target (dummy)
             ops.push(Op::Label(label));
             {
                 ops.push(Op::Drop); // Drop comparison target
@@ -719,7 +719,7 @@ fn monorail_status(
                 ops.push(Op::DropN(2)); // Drop payload and return size
                 ops.push(Op::Push(1)); // Increment by one
                 ops.push(Op::Add); // port = port + 1
-                ops.push(Op::Push(NUM_PORTS as u8)); // Comparison target
+                ops.push(Op::Push(NUM_PORTS)); // Comparison target
                 ops.push(Op::BranchGreaterThan(label)); // Jump to loop start
             }
             ops.push(Op::DropN(4)); // Cleanup

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -726,8 +726,8 @@ fn summarize(
                 // For each of the commands that we need to run, add a call
                 // for it
                 //
-                for (code, _) in &commands {
-                    driver.command(*code, |cmd| {
+                for &(code, _) in &commands {
+                    driver.command(code, |cmd| {
                         let op = match cmd.read_op() {
                             pmbus::Operation::ReadByte => Op::Push(1),
                             pmbus::Operation::ReadWord => Op::Push(2),
@@ -738,11 +738,11 @@ fn summarize(
                             }
                         };
 
-                        ops.push(Op::Push(*code));
+                        ops.push(Op::Push(code));
                         ops.push(op);
                         ops.push(Op::Call(func.id));
                         ops.push(Op::DropN(2));
-                        calls.push(*code as u8);
+                        calls.push(code);
                     });
                 }
 

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -337,7 +337,7 @@ impl<'a> RpcClient<'a> {
         let header = RpcHeader {
             image_id: U64::from_bytes(our_image_id.try_into().unwrap()),
             task: U16::new(op.task.task().try_into().unwrap()),
-            op: U16::new(op.code as u16),
+            op: U16::new(op.code),
             nreply: U16::new(nreply as u16),
             nbytes: U16::new(payload.len().try_into().unwrap()),
         };

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -108,7 +108,7 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
                     bail!("invalid byte {}", byte)
                 }
             }
-            ops.push(Op::Push32(addr as u32));
+            ops.push(Op::Push32(addr));
             ops.push(Op::Push32(arr.len() as u32));
 
             let sp_write = funcs.get("WriteToSp", 2)?;
@@ -120,7 +120,7 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
             println!("{:x?}", results);
         }
         SpCtrlCmd::Read { addr, nbytes } => {
-            ops.push(Op::Push32(addr as u32));
+            ops.push(Op::Push32(addr));
             ops.push(Op::Push32(nbytes as u32));
             let sp_read = funcs.get("ReadFromSp", 2)?;
             ops.push(Op::Call(sp_read.id));

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -226,11 +226,11 @@ fn spi(context: &mut humility::ExecutionContext) -> Result<()> {
             }
 
             addr = match size {
-                1 => arr[l - size] as u32,
-                2 => u16::from_le_bytes(arr[l - size..l].try_into().unwrap())
-                    as u32,
-                4 => u32::from_le_bytes(arr[l - size..l].try_into().unwrap())
-                    as u32,
+                1 => u32::from(arr[l - size]),
+                2 => u32::from(u16::from_le_bytes(
+                    arr[l - size..l].try_into().unwrap(),
+                )),
+                4 => u32::from_le_bytes(arr[l - size..l].try_into().unwrap()),
                 _ => {
                     bail!("invalid address size");
                 }
@@ -245,11 +245,11 @@ fn spi(context: &mut humility::ExecutionContext) -> Result<()> {
             }
 
             addr = match size {
-                1 => arr[l - size] as u32,
-                2 => u16::from_be_bytes(arr[l - size..l].try_into().unwrap())
-                    as u32,
-                4 => u32::from_be_bytes(arr[l - size..l].try_into().unwrap())
-                    as u32,
+                1 => u32::from(arr[l - size]),
+                2 => u32::from(u16::from_be_bytes(
+                    arr[l - size..l].try_into().unwrap(),
+                )),
+                4 => u32::from_be_bytes(arr[l - size..l].try_into().unwrap()),
                 _ => {
                     bail!("invalid address size");
                 }

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -159,10 +159,10 @@ fn eeprom(context: &mut humility::ExecutionContext) -> Result<()> {
     match subargs.cmd {
         EepromCommand::Read { output, count } => {
             let data = worker.eeprom_read(count)?;
-            std::fs::write(&output, &data)?;
+            std::fs::write(output, data)?;
         }
         EepromCommand::Write { input } => {
-            let data = std::fs::read(&input)?;
+            let data = std::fs::read(input)?;
             worker.eeprom_write(&data)?;
         }
     }

--- a/humility-arch-cortex/src/etm.rs
+++ b/humility-arch-cortex/src/etm.rs
@@ -572,7 +572,7 @@ fn etm_payload_decode(
         }
     };
 
-    let reason = |ibyte| match ((ibyte >> 5) as u8) & 0b11 {
+    let reason = |ibyte: u8| match (ibyte >> 5) & 0b11 {
         0b00 => ETM3SyncReason::Periodic,
         0b01 => ETM3SyncReason::TracingEnabled,
         0b10 => ETM3SyncReason::TracingRestarted,

--- a/humility-arch-cortex/src/scs.rs
+++ b/humility-arch-cortex/src/scs.rs
@@ -350,7 +350,7 @@ pub fn read_rom(
             // This is a ROM table, so we want to read its entries, and
             // descend.
             //
-            for offset in (0..max).step_by(size_of::<u32>() as usize) {
+            for offset in (0..max).step_by(size_of::<u32>()) {
                 let val = core.read_word_32(base + offset as u32)?;
 
                 if val == 0 {

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -743,7 +743,7 @@ impl<'a> HiffyContext<'a> {
             } else if val <= u16::MAX as u32 {
                 Op::Push16(val as u16)
             } else {
-                Op::Push32(val as u32)
+                Op::Push32(val)
             }
         };
 

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -213,11 +213,11 @@ impl Dumper {
                 print!(
                     "{:0width$x} ",
                     match size {
-                        1 => line[i - offs] as u32,
-                        2 =>
-                            u16::from_le_bytes(slice.try_into().unwrap()) as u32,
-                        4 =>
-                            u32::from_le_bytes(slice.try_into().unwrap()) as u32,
+                        1 => u32::from(line[i - offs]),
+                        2 => u32::from(u16::from_le_bytes(
+                            slice.try_into().unwrap()
+                        )),
+                        4 => u32::from_le_bytes(slice.try_into().unwrap()),
                         _ => {
                             panic!("invalid size");
                         }

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -987,9 +987,9 @@ impl GDBCore {
         log::trace!("command {} returned {}", cmd, rstr);
 
         match rstr.len() {
-            2 => Ok(u8::from_le_bytes(buf[..].try_into().unwrap()) as u32),
-            4 => Ok(u16::from_le_bytes(buf[..].try_into().unwrap()) as u32),
-            8 => Ok(u32::from_le_bytes(buf[..].try_into().unwrap()) as u32),
+            2 => Ok(u32::from(u8::from_le_bytes(buf[..].try_into().unwrap()))),
+            4 => Ok(u32::from(u16::from_le_bytes(buf[..].try_into().unwrap()))),
+            8 => Ok(u32::from_le_bytes(buf[..].try_into().unwrap())),
             16 => {
                 //
                 // Amazingly, for some 32-bit register values under certain

--- a/humility-core/src/env.rs
+++ b/humility-core/src/env.rs
@@ -45,7 +45,7 @@ impl Environment {
 
     fn read(filename: &str) -> Result<IndexMap<String, Environment>> {
         let path = PathBuf::from(filename);
-        let input = fs::read_to_string(&path)?;
+        let input = fs::read_to_string(path)?;
         Ok(serde_json::from_str(&input)?)
     }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -633,7 +633,7 @@ impl HubrisArchive {
         // that our search is over when the address plus the length
         // is less than our base.
         //
-        for ((addr, _depth), (len, goff, origin)) in
+        for (&(addr, _depth), (len, goff, origin)) in
             self.inlined.range(..=(pc, std::isize::MAX)).rev()
         {
             if addr + len < base {
@@ -646,7 +646,7 @@ impl HubrisArchive {
 
             if let Some(func) = self.subprograms.get(origin) {
                 inlined.push(HubrisInlined {
-                    addr: *addr as u32,
+                    addr,
                     name: func,
                     id: *goff,
                     origin: *origin,
@@ -963,9 +963,9 @@ impl HubrisArchive {
         Err(anyhow!("missing address range for {}", goff))
     }
 
-    fn dwarf_subprogram<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_subprogram<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1036,9 +1036,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_basetype<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_basetype<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1100,9 +1100,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_ptrtype<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_ptrtype<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1167,9 +1167,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_variable<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_variable<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1397,9 +1397,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_struct<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_struct<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1444,9 +1444,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_const_enum<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_const_enum<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1499,9 +1499,9 @@ impl HubrisArchive {
         }
     }
 
-    fn dwarf_enum_variant<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_enum_variant<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1629,9 +1629,9 @@ impl HubrisArchive {
         }
     }
 
-    fn dwarf_union<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_union<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -1673,9 +1673,9 @@ impl HubrisArchive {
         Ok(())
     }
 
-    fn dwarf_member<'a, R: gimli::Reader<Offset = usize>>(
+    fn dwarf_member<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<
             gimli::EndianSlice<gimli::LittleEndian>,
@@ -2138,7 +2138,7 @@ impl HubrisArchive {
             .collect::<HashSet<_>>();
 
         let offset = textsec.sh_offset as u32;
-        let size = textsec.sh_size as u32;
+        let textsize = textsec.sh_size as u32;
         let current = self.current;
 
         log::trace!("loading {} as object {}", object, self.current);
@@ -2323,7 +2323,7 @@ impl HubrisArchive {
                 name: String::from(object),
                 object: current,
                 textbase: (textsec.sh_addr as u32),
-                textsize: size as u32,
+                textsize,
                 memsize: memsz as u32,
                 heapbss,
                 task,
@@ -4038,7 +4038,7 @@ impl HubrisArchive {
         };
 
         let readreg = |rname| -> Result<u32> {
-            let o = state.lookup_member(rname)?.offset as usize;
+            let o = state.lookup_member(rname)?.offset;
             Ok(u32::from_le_bytes(regs[o..o + 4].try_into().unwrap()))
         };
 
@@ -4047,7 +4047,7 @@ impl HubrisArchive {
         //
         for r in 4..=11 {
             let rname = format!("r{}", r);
-            let o = state.lookup_member(&rname)?.offset as usize;
+            let o = state.lookup_member(&rname)?.offset;
             let val = u32::from_le_bytes(regs[o..o + 4].try_into().unwrap());
 
             rval.insert(ARMRegister::from_usize(r).unwrap(), val);
@@ -5250,10 +5250,10 @@ impl HubrisEnum {
     ) -> Result<&HubrisEnumVariant> {
         let readval = |b: &[u8], o, sz| -> Result<u64> {
             Ok(match sz {
-                1 => b[o] as u64,
-                2 => u16::from_le_bytes(b[o..o + 2].try_into()?) as u64,
-                4 => u32::from_le_bytes(b[o..o + 4].try_into()?) as u64,
-                8 => u64::from_le_bytes(b[o..o + 8].try_into()?) as u64,
+                1 => u64::from(b[o]),
+                2 => u64::from(u16::from_le_bytes(b[o..o + 2].try_into()?)),
+                4 => u64::from(u32::from_le_bytes(b[o..o + 4].try_into()?)),
+                8 => u64::from_le_bytes(b[o..o + 8].try_into()?),
                 _ => {
                     bail!("bad variant size!");
                 }

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -900,7 +900,7 @@ pub fn load_base(buf: &[u8], ty: &HubrisBasetype, addr: usize) -> Result<Base> {
         }
 
         (Unsigned, 0) => Base::U0,
-        (Unsigned, 1) => Base::U8(buf[0] as u8),
+        (Unsigned, 1) => Base::U8(buf[0]),
         (Unsigned, 2) => Base::U16(u16::from_le_bytes(buf.try_into().unwrap())),
         (Unsigned, 4) => Base::U32(u32::from_le_bytes(buf.try_into().unwrap())),
         (Unsigned, 8) => Base::U64(u64::from_le_bytes(buf.try_into().unwrap())),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.68.0"
+components = ["clippy"]


### PR DESCRIPTION
Ultimate goal: bumping toolchain rev to 1.68.

The continuous build was using a separate notion of MSRV (which happened to equal the pinned toolchain but needed to be updated separately), so the original bump didn't pass. I have rearranged that build after talking with @steveklabnik -- the original intent was to build on both pinned and latest-stable, and it now does that without needing a separate MSRV variable.

I have, however, added an MRSV to Cargo.toml to give better feedback to people who try and build Humility with a too-old toolchain.

Once I got past that hurdle, I hit the build that requires Humility to be clippy clean with the pinned toolchain -- and evidently it wasn't. The things it reported were absolutely lints in previous versions of clippy -- I guess they got missed because of some bugs in clippy that got fixed? Anyway, I have gone through and fixed them all, generally in the most minimal way possible, but making a related nearby cleanup in a few cases to simplify the code.

This seems to work now.

Note that the 1.68 toolchain is now warning us about some deps containing deprecated code, which we should probably fix.