### PR TITLE
Support array arguments as strings in Idol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.30"
+version = "0.9.31"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.30"
+version = "0.9.31"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -53,7 +53,7 @@ use humility::cli::Subcommand;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::warn;
-use humility_cmd::{hiffy::*, Archive, Attach, Command, Validate};
+use humility_cmd::{hiffy::*, Archive, Attach, Command, Dumper, Validate};
 use humility_cmd::{idol, CommandKind};
 use std::io::Read;
 
@@ -529,7 +529,7 @@ fn hiffy(context: &mut humility::ExecutionContext) -> Result<()> {
             } else if subargs.hex {
                 println!("Data: {:x?}", data);
             } else {
-                println!("Data: {:?}", data);
+                Dumper::new().dump(&data, 0x0);
             }
         }
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.30
+humility 0.9.31
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.30
+humility 0.9.31
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.30
+humility 0.9.31
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.30
+humility 0.9.31
 
 ```


### PR DESCRIPTION
This will let us eliminate stuff like
```
        "get_key_by_tag": (
            doc: "Scans the caboose for a key with the given tag",
            args: {
                "name": "[u8; 4]",
            },
            leases: {
                "data": (type: "[u8]", write: true),
            },
            reply: Result(
                ok: "u32",
                err: CLike("CabooseError"),
            ),
            idempotent: true,
        ),
        "get_key_by_u32": (
            doc: "Scans the caboose for a key with the given tag",
            args: {
                "tag": "u32",
            },
            leases: {
                "data": (type: "[u8]", write: true),
            },
            reply: Result(
                ok: "u32",
                err: CLike("CabooseError"),
            ),
            idempotent: true,
        ),
```
where the latter only exists because Idol couldn't take a `[u8; 4]` as an argument.

Also, this improves the pretty-printing of data returned by Idol operations that write to a lease.

Together, this means we can do stuff like this:
```
$ target/debug/humility hiffy -c Caboose.get_key_by_tag -aname=BORD -n32
humility: attached via ST-Link V3
Caboose.get_key_by_tag() => 0xb
             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
0x00000000 | 67 69 6d 6c 65 74 6c 65 74 2d 32 00 00 00 00 00 | gimletlet-2.....
0x00000010 | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 | ................
```