### PR TITLE
Print a warning but don't bail on unknown register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.9.31"
+version = "0.9.32"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -668,8 +668,10 @@ fn monorail_dump(
         };
         let addr = format!("{}", start_address as usize + i * 4);
         // XXX this is inefficient
-        let reg = parse_reg_or_addr(&addr)?;
-        println!("{}    {:#010x}", reg, value);
+        match parse_reg_or_addr(&addr) {
+            Ok(reg) => println!("{}    {:#010x}", reg, value),
+            Err(e) => humility::msg!("skipping unknown register at {}", addr),
+        }
     }
 
     Ok(())

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -670,7 +670,9 @@ fn monorail_dump(
         // XXX this is inefficient
         match parse_reg_or_addr(&addr) {
             Ok(reg) => println!("{}    {:#010x}", reg, value),
-            Err(e) => humility::msg!("skipping unknown register at {}", addr),
+            Err(e) => {
+                humility::msg!("skipping unknown register at {}: {}", addr, e)
+            }
         }
     }
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.9.31
+humility 0.9.32
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.9.31
+humility 0.9.32
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.9.31
+humility 0.9.32
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.9.31
+humility 0.9.32
 
 ```


### PR DESCRIPTION
Otherwise, dumping registers with undocumented spaces (e.g. `XGANA`) will fail partway.