### PR TITLE
Enable debug assertions in `profile.ci`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,6 +243,7 @@ debug = true
 [profile.ci]
 inherits = "release"
 debug = false
+debug-assertions = true
 
 [build-dependencies]
 cargo_metadata = { workspace = true }

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -148,7 +148,7 @@ struct VpdArgs {
 
     /// specify binary file to act as a loopback device
     #[clap(
-        long, short, value_name = "file",
+        long, value_name = "file",
         conflicts_with_all = &["device", "id"]
     )]
     loopback: Option<String>,


### PR DESCRIPTION
The `validate_clap` test is currently broken, but CI passed; this PR enables `debug-assertions` in CI builds (which run in release mode) to make sure `validate_clap` fails in CI.

I'm pushing an initial PR/commit that only adds `debug-assertions`; we should see it fail, and I'll push a followup commit that fixes the actual issue `validate_clap` is complaining about.