### PR TITLE
"humility dump" dies when no dump is present (+ potpourri)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty#448435605eaa076a57e0b7f78837602b5dd1deef"
+source = "git+https://github.com/oxidecomputer/humpty#b87a452e1c0a75e3e906616efc44945ac988748b"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1f025f441cdfb75831bec89b9d6a6ed02e5e763f78fc5e1ff30d4870fefaec"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "coolor"
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",
@@ -1521,6 +1521,7 @@ dependencies = [
  "clap",
  "humility-cmd",
  "humility-core",
+ "serde_json",
 ]
 
 [[package]]
@@ -2040,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty#70c646c4a9f31120fe4b39928580ce9f90358bfb"
+source = "git+https://github.com/oxidecomputer/humpty#448435605eaa076a57e0b7f78837602b5dd1deef"
 dependencies = [
  "hubpack",
  "lzss",
@@ -2695,14 +2696,14 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/pmbus#781cf33414b267277e168ed7f8699c3959090f76"
+source = "git+https://github.com/oxidecomputer/pmbus#03124d68e77a84a1e05513133c61990b14a2a75d"
 dependencies = [
  "anyhow",
  "convert_case",
  "libm",
  "num-derive",
  "num-traits",
- "ron 0.6.6",
+ "ron 0.8.0",
  "serde",
  "serde_with",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -94,7 +94,6 @@ use zerocopy::FromBytes;
     group = ArgGroup::new("simulation").multiple(false)
         .required(false).requires("force-dump-agent")
 )]
-
 struct DumpArgs {
     /// sets timeout
     #[clap(
@@ -969,6 +968,10 @@ fn read_dump(
 
     let (base, headers, task) = {
         let all = read_dump_headers(hubris, core, context, funcs, false)?;
+
+        if all.is_empty() {
+            bail!("no dump is present?");
+        }
 
         let area = match area {
             None => None,

--- a/cmd/manifest/Cargo.toml
+++ b/cmd/manifest/Cargo.toml
@@ -9,3 +9,4 @@ humility = { workspace = true }
 humility-cmd = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
+serde_json = { workspace = true }

--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -44,17 +44,30 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
+use humility::cli::Subcommand;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashSet;
 
 #[derive(Parser, Debug)]
 #[clap(name = "manifest", about = env!("CARGO_PKG_DESCRIPTION"))]
-struct ManifestArgs {}
+struct ManifestArgs {
+    /// generate JSON output
+    #[clap(short, long)]
+    json: bool,
+}
 
 #[allow(clippy::print_literal)]
 fn manifestcmd(context: &mut humility::ExecutionContext) -> Result<()> {
     let hubris = context.archive.as_ref().unwrap();
     let manifest = &hubris.manifest;
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+
+    let subargs = ManifestArgs::try_parse_from(subargs)?;
+
+    if subargs.json {
+        println!("{}", serde_json::to_string(manifest)?);
+        return Ok(());
+    }
 
     let print = |what, val| {
         println!("{:>12} => {}", what, val);

--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -43,8 +43,8 @@
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
-use humility::hubris::*;
 use humility::cli::Subcommand;
+use humility::hubris::*;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashSet;
 

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -402,25 +402,25 @@ fn probecmd(context: &mut humility::ExecutionContext) -> Result<()> {
         humility::msg!("Fault detected! Raw CFSR: 0x{:x}", cfsr.0);
         if let Some(bfsr) = cfsr.get_bfsr() {
             humility::msg!(
-                "Bus Fault accessing address {} : {:x?}",
+                "Bus Fault accessing address {}: {:x?}",
                 if bfsr.bfarvalid() {
-                    format!("{:x}", BFAR::read(core)?.address())
+                    format!("{:#x}", BFAR::read(core)?.address())
                 } else {
-                    "unknown".to_string()
+                    "<unknown>".to_string()
                 },
                 bfsr,
             );
         }
         if let Some(ufsr) = cfsr.get_ufsr() {
-            humility::msg!("Usage Fault : {:x?}", ufsr);
+            humility::msg!("Usage Fault: {:#x?}", ufsr);
         }
         if let Some(mmfsr) = cfsr.get_mmfsr() {
             humility::msg!(
-                "MM Fault accessing address {} : {:x?}",
+                "MM Fault accessing address {}: {:x?}",
                 if mmfsr.mmfarvalid() {
-                    format!("{:x}", MMFAR::read(core)?.address())
+                    format!("{:#x}", MMFAR::read(core)?.address())
                 } else {
-                    "unknown".to_string()
+                    "<unknown>".to_string()
                 },
                 mmfsr
             );
@@ -430,11 +430,11 @@ fn probecmd(context: &mut humility::ExecutionContext) -> Result<()> {
         let sfsr = SFSR::read(core)?;
         if sfsr.has_fault() {
             humility::msg!(
-                "Secure Fault accessing address {} : (raw SFSR 0x{:x}) {:x?}",
+                "Secure Fault accessing address {}: (raw SFSR 0x{:x}) {:x?}",
                 if sfsr.sfarvalid() {
-                    format!("{:x}", SFAR::read(core)?.address())
+                    format!("{:#x}", SFAR::read(core)?.address())
                 } else {
-                    "unknown".to_string()
+                    "<unknown>".to_string()
                 },
                 sfsr.0,
                 sfsr

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -5,7 +5,7 @@
 use probe_rs::MemoryInterface;
 use probe_rs::{flashing, Probe};
 
-use anyhow::{anyhow, bail, ensure, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 
 use crate::arch::ARMRegister;
 use crate::hubris::*;
@@ -296,12 +296,22 @@ impl Core for ProbeCore {
         if let Some(range) = self.unhalted_read.range(..=addr).next_back() {
             if addr + 4 < range.0 + range.1 {
                 let mut core = self.session.core(0)?;
-                return Ok(core.read_word_32(addr)?);
+                return Ok(core.read_word_32(addr).with_context(|| {
+                    format!(
+                        "failed to perform unhalted word read at address \
+                        {addr:#x}",
+                    )
+                })?);
             }
         }
 
         self.halt_and_read(|core| {
-            rval = core.read_word_32(addr)?;
+            rval = core.read_word_32(addr).with_context(|| {
+                format!(
+                    "failed to perform halted word read at address {addr:#x}"
+                )
+            })?;
+
             Ok(())
         })?;
 
@@ -317,11 +327,25 @@ impl Core for ProbeCore {
         if let Some(range) = self.unhalted_read.range(..=addr).next_back() {
             if addr + (data.len() as u32) < range.0 + range.1 {
                 let mut core = self.session.core(0)?;
-                return Ok(core.read_8(addr, data)?);
+                return Ok(core.read_8(addr, data).with_context(|| {
+                    format!(
+                        "failed to perform unhalted read at address \
+                        {addr:#x} for length {}",
+                        data.len()
+                    )
+                })?);
             }
         }
 
-        self.halt_and_read(|core| Ok(core.read_8(addr, data)?))
+        self.halt_and_read(|core| {
+            Ok(core.read_8(addr, data).with_context(|| {
+                format!(
+                    "failed to perform halted read at address \
+                    {addr:#x} for length {}",
+                    data.len()
+                )
+            })?)
+        })
     }
 
     fn read_reg(&mut self, reg: ARMRegister) -> Result<u32> {

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -296,12 +296,12 @@ impl Core for ProbeCore {
         if let Some(range) = self.unhalted_read.range(..=addr).next_back() {
             if addr + 4 < range.0 + range.1 {
                 let mut core = self.session.core(0)?;
-                return Ok(core.read_word_32(addr).with_context(|| {
+                return core.read_word_32(addr).with_context(|| {
                     format!(
                         "failed to perform unhalted word read at address \
                         {addr:#x}",
                     )
-                })?);
+                });
             }
         }
 
@@ -327,24 +327,24 @@ impl Core for ProbeCore {
         if let Some(range) = self.unhalted_read.range(..=addr).next_back() {
             if addr + (data.len() as u32) < range.0 + range.1 {
                 let mut core = self.session.core(0)?;
-                return Ok(core.read_8(addr, data).with_context(|| {
+                return core.read_8(addr, data).with_context(|| {
                     format!(
                         "failed to perform unhalted read at address \
                         {addr:#x} for length {}",
                         data.len()
                     )
-                })?);
+                });
             }
         }
 
         self.halt_and_read(|core| {
-            Ok(core.read_8(addr, data).with_context(|| {
+            core.read_8(addr, data).with_context(|| {
                 format!(
                     "failed to perform halted read at address \
                     {addr:#x} for length {}",
                     data.len()
                 )
-            })?)
+            })
         })
     }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -5,7 +5,7 @@
 use crate::arch::{presyscall_pushes, ARMRegister};
 use capstone::prelude::*;
 use indexmap::IndexMap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::io::prelude::*;
 
 use std::borrow::Cow;
@@ -41,7 +41,7 @@ const OXIDE_NT_HUBRIS_TASK: u32 = OXIDE_NT_BASE + 3;
 
 const MAX_HUBRIS_VERSION: u32 = 8;
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Serialize)]
 pub struct HubrisManifest {
     pub version: Option<String>,
     pub gitrev: Option<String>,
@@ -127,12 +127,12 @@ struct HubrisConfigI2cController {
     target: Option<bool>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct HubrisConfigI2cPmbus {
     rails: Option<Vec<String>>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct HubrisConfigI2cPower {
     rails: Option<Vec<String>>,
     #[serde(default = "HubrisConfigI2cPower::default_pmbus")]
@@ -153,7 +153,7 @@ impl HubrisConfigI2cPower {
     }
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct HubrisConfigI2cSensors {
     #[serde(default)]
@@ -180,7 +180,7 @@ struct HubrisConfigI2cSensors {
     names: Option<Vec<String>>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 struct HubrisConfigI2cDevice {
     device: String,
     name: Option<String>,
@@ -203,7 +203,7 @@ struct HubrisConfigI2c {
     devices: Option<Vec<HubrisConfigI2cDevice>>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct HubrisConfigAuxflash {
     pub memory_size: usize,
@@ -238,13 +238,13 @@ pub struct HubrisConfigSensorSensor {
     sensors: BTreeMap<String, usize>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HubrisI2cPort {
     pub name: String,
     pub index: u8,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HubrisI2cBus {
     pub controller: u8,
     pub port: HubrisI2cPort,
@@ -253,14 +253,14 @@ pub struct HubrisI2cBus {
     pub target: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub enum HubrisI2cDeviceClass {
     Pmbus { rails: Vec<String> },
     Unspecified,
     Unknown,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HubrisI2cDevice {
     pub device: String,
     pub name: Option<String>,
@@ -274,7 +274,7 @@ pub struct HubrisI2cDevice {
     pub removable: bool,
 }
 
-#[derive(Copy, Clone, Deserialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Deserialize, Debug, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum HubrisSensorKind {
     Temperature,
@@ -286,13 +286,13 @@ pub enum HubrisSensorKind {
     Speed,
 }
 
-#[derive(Clone, Debug, PartialOrd, Ord, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialOrd, Ord, Eq, PartialEq, Serialize)]
 pub enum HubrisSensorDevice {
     I2c(usize),
     Other(String, usize),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HubrisSensor {
     pub name: String,
     pub kind: HubrisSensorKind,

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3550,11 +3550,19 @@ impl HubrisArchive {
         let task_t = self.lookup_struct_byname("Task")?;
         let size = task_t.size;
 
+        if cur < base || cur >= base + (task_count * size as u32) {
+            bail!(
+                "CURRENT_TASK_PTR ({cur:#x}) does not appear to point into \
+                the task table ({base:#x}, {task_count} tasks, {size} \
+                bytes per task)"
+            );
+        }
+
         if (cur - base) % size as u32 != 0 {
             bail!(
                 "CURRENT_TASK_PTR ({cur:#x}) - base ({base:#x}) \
                 is not an even multiple of task size ({size})"
-            )
+            );
         }
 
         let ndx = (cur - base) / task_t.size as u32;

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.0
+humility 0.10.1
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.0
+humility 0.10.1
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.0
+humility 0.10.1
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.0
+humility 0.10.1
 
 ```


### PR DESCRIPTION
Draft commit comment:

```
- Fixes #338
- Makes Humility fail cleanly if no dump is found
- Adds optional JSON output to "humility manifest"
- Updates humpty for oxidecomputer/hubris#1248.
- Improves error messages when we fail to read over a probe
- Cleans up "humility probe" to always have base prefix on hex output
```
