### PR TITLE
panic at the probe-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2728,7 +2728,7 @@ checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 [[package]]
 name = "probe-rs"
 version = "0.12.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#d731eaa3e30d178a881af20bcbccb07abcf7394b"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#75afc22df6bad7cae756b48728c5d788906aefe0"
 dependencies = [
  "anyhow",
  "base64",
@@ -2759,7 +2759,7 @@ dependencies = [
 [[package]]
 name = "probe-rs-target"
 version = "0.12.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#d731eaa3e30d178a881af20bcbccb07abcf7394b"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#75afc22df6bad7cae756b48728c5d788906aefe0"
 dependencies = [
  "base64",
  "jep106",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.1"
+version = "0.10.2"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/README.md.in
+++ b/README.md.in
@@ -1,7 +1,6 @@
 # Humility
 
-Humility is the debugger for
-<a href="https://github.com/oxidecomputer/hubris">Hubris</a>.
+Humility is the debugger for Hubris.
 
 ## Guiding principles
 
@@ -16,29 +15,27 @@ the system.
 
 ### Hubris-specific
 
-Humility is Hubris-specific:  it is not trying to be a generic *in situ*
+Humility is Hubris-specific:  it is not trying to be a generic in situ
 debugger, but rather specifically focused on debugging Hubris-based systems.
 Humility is therefore willing to encode Hubris-specific concepts like
 archives and tasks.
 
 ### Microcontroller-specific
 
-Debuggers must cut through abstractions, which
-often requires knowledge of underlying
-implementation detail.  For Humility, this means being willing to take
-advantage of microcontroller-specific debug facilities where applicable.
-While Hubris may make decisions in the name of greater portability,
-Humility will generally make decisions to maximize debuggability, even
-where these facilities are highly specific to a particular MCU.
+Debuggers must cut through abstractions, which often requires knowledge of
+underlying implementation detail.  For Humility, this means being willing to
+take advantage of microcontroller-specific debug facilities where applicable.
+While Hubris may make decisions in the name of greater portability, Humility
+will generally make decisions to maximize debuggability, even where these
+facilities are highly specific to a particular MCU.
 
 ### Device-specific
 
 Humility is unafraid to offer device-specific functionality where that
 functionality is useful for system debuggability.  (For example,
-`humility i2c` functions as an I<sup>2</sup>C analyzer.)  That said, all device
+`humility i2c` functions as an I2C analyzer.)  That said, all device
 interaction uses Hubris as a proxy to actually communicate with the devices
-themselves (e.g., via [HIF](https://github.com/oxidecomputer/hif));
-Humility does not seek to create second I/O path.
+themselves (e.g., HIF); Humility does not seek to create second I/O path.
 
 ### Pragmatic
 
@@ -57,15 +54,14 @@ options that are specific to particular subcommands.
 Humility needs to have some way of extracting information and/or controlling
 the microcontroller running Hubris.  This is done through some variant of a
 debug *probe*, a separate microcontroller that speaks to debug-specific
-functionality on the target microcontroller.  (For details of the mechanics
-of these probes on ARM parts, see <a
-href="https://65.rfd.oxide.computer">RFD 65</a>.)
+functionality on the target microcontroller.
 
 For most evaluation boards, this debug probe is available on the board, and
 is connected to a host via USB, e.g. ST's STLink/V2 on the STM32F407
 Discovery or the LPC-Link2 present on the LPCXpresso55S69.
 (On the Gemini board, there are two SWD headers, one for the LPC55S28
 and the other for the STM32H753.)
+
 While Humility allows for direct attachment to an on-chip debugger, doing so
 precludes other connections (from, for example, OpenOCD), making it too
 disruptive to development workflows. To allow for easier development
@@ -77,19 +73,6 @@ which can have the following values:
 
 - `auto` (default): Automatically determine how to attach to the
   microcontroller.
-
-- `ocd`: Attach via OpenOCD, which is presumed to have the TCL interface
-  available on localhost on port 6666 (its default).
-
-- `jlink`: Attach via Segger JLink, which is presumed to have the GDB
-  interface available on localhost on port 2331 (its default).  Note that
-  when semihosting is being used by Hubris, the Segger JLink GDB server
-  will become confused when Humility attaches to it -- and subsequent
-  calls to semihosting will cause a halt.  A subsequent Humility invocation
-  will resume the target (directing semihosting output correctly to the
-  running GDB instance), but subsequent semihosting output will again cause
-  a halt. To recover from this condition, send an explicit ^C to the
-  running GDB and continue from the resulting stop.
 
 - `usb`: Attach directly via USB to a debug probe.  When multiple probes
   are plugged in via USB, a probe index must be specified as a suffix
@@ -106,6 +89,19 @@ which can have the following values:
   of the probe (as reported via `humility probe` or found in the 
   `iSerialNumber` field of the USB device descriptor) can be postpended,
   also delimited by a colon, e.g. `0483:374e:004000343137510939383538`.
+
+- `ocd`: Attach via OpenOCD, which is presumed to have the TCL interface
+  available on localhost on port 6666 (its default).
+
+- `jlink`: Attach via Segger JLink, which is presumed to have the GDB
+  interface available on localhost on port 2331 (its default).  Note that
+  when semihosting is being used by Hubris, the Segger JLink GDB server
+  will become confused when Humility attaches to it -- and subsequent
+  calls to semihosting will cause a halt.  A subsequent Humility invocation
+  will resume the target (directing semihosting output correctly to the
+  running GDB instance), but subsequent semihosting output will again cause
+  a halt. To recover from this condition, send an explicit ^C to the
+  running GDB and continue from the resulting stop.
 
 ### Archive
 

--- a/cmd/doc/build.rs
+++ b/cmd/doc/build.rs
@@ -120,6 +120,7 @@ fn docs() -> &'static str {{
     )?;
 
     let root = metadata.workspace_root;
+    println!("cargo:rerun-if-changed={}", root.join("README.md.in").display());
     let input = std::fs::read(root.join("README.md.in"))?;
 
     output.write_all(&input)?;

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -333,7 +333,7 @@ fn flashcmd(context: &mut humility::ExecutionContext) -> Result<()> {
 
     //
     // Load the flash image.  If that fails, we're in a world of hurt:  we
-    // really don't want to run the core for fear of masking of initial
+    // really don't want to run the core for fear of masking the initial
     // error.  (It will hopefully be pretty clear to the user that a
     // half-flashed part is going to be in an ill-defined state!)
     //

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -332,12 +332,12 @@ fn flashcmd(context: &mut humility::ExecutionContext) -> Result<()> {
     let ihex_path = ihex.path();
 
     //
-    // Load the flash image, and reset the part if that works.
+    // Load the flash image.  If that fails, we're in a world of hurt:  we
+    // really don't want to run the core for fear of masking of initial
+    // error.  (It will hopefully be pretty clear to the user that a
+    // half-flashed part is going to be in an ill-defined state!)
     //
-    if let Err(err) = core.load(ihex_path) {
-        core.run()?;
-        return Err(err);
-    }
+    core.load(ihex_path)?;
 
     //
     // On Gimlet Rev B, the BOOT0 pin is unstrapped -- and during a flash,

--- a/humility-core/src/cli.rs
+++ b/humility-core/src/cli.rs
@@ -30,38 +30,48 @@ pub struct Cli {
     #[clap(long, short = 'V')]
     pub version: bool,
 
-    /// probe to use
-    #[clap(long, short, env = "HUMILITY_PROBE", group = "hubris")]
+    /// If a system has multiple debug probes attached, the specific probe
+    /// to use.  If specifying a USB probe, its index can be used (e.g.,
+    /// "usb-0"); if specifying an exact probe, this is of the form
+    /// "vid:pid[:serial]". This may also be set via the HUMILITY_PROBE
+    /// environment variable. Run "humility doc" for more information on
+    /// probes.
+    #[clap(long, short, group = "hubris")]
     pub probe: Option<String>,
 
-    /// Hubris archive
-    #[clap(long, short, env = "HUMILITY_ARCHIVE")]
+    /// File that contains the Hubris archive. This may also be set via
+    /// the HUMILITY_ARCHIVE environment variable. Run "humility doc" for
+    /// more information on Hubris archives.
+    #[clap(long, short, env = "HUMILITY_ARCHIVE", hide_env = true)]
     pub archive: Option<String>,
 
-    /// Hubris dump
-    #[clap(long, short, env = "HUMILITY_DUMP", group = "hubris")]
+    /// Hubris dump. This may also be set via the HUMILITY_DUMP environment
+    /// variable. Run "humility doc" for more information on debugging
+    /// from a hubris dump.
+    #[clap(long, short, group = "hubris")]
     pub dump: Option<String>,
 
-    /// IP address of remote Hubris instance
-    #[clap(long, short, env = "HUMILITY_IP", group = "hubris")]
+    /// IP address of remote Hubris instance. This may also be set via the
+    /// HUMILITY_IP environment variable. Run "humility doc" for more
+    /// information on running Humility over a network.
+    #[clap(long, short, group = "hubris")]
     pub ip: Option<String>,
 
-    /// Hubris environment file
-    #[clap(long, short, env = "HUMILITY_ENVIRONMENT")]
+    /// Hubris environment file. Thie may also be set via the
+    /// HUMILITY_ENVIRONMENT environment variable. Run "humility doc" for
+    /// more information on Humility environments.
+    #[clap(long, short, env = "HUMILITY_ENVIRONMENT", hide_env = true)]
     pub environment: Option<String>,
 
-    /// target to use from specified environment
-    #[clap(
-        long,
-        short,
-        env = "HUMILITY_TARGET",
-        requires = "environment",
-        group = "hubris"
-    )]
+    /// Target to use from a specified environment. This may also be set via
+    /// the HUMILITY_TARGET environment variable. Run "humility doc" for
+    /// for information on specifying targets within an environment.
+    #[clap(long, short, requires = "environment", group = "hubris")]
     pub target: Option<String>,
 
     /// If multiple archives are specified in an environment, name of
-    /// the archive to use
+    /// the archive to use.  Run "humility doc" for more information on
+    /// Humility environments and their relationship to archives.
     #[clap(long, requires = "environment")]
     pub archive_name: Option<String>,
 
@@ -80,7 +90,8 @@ pub struct Cli {
     #[clap(long, short, env = "HUMILITY_CHIP", hide = true)]
     pub chip: Option<String>,
 
-    /// list targets within an environment
+    /// List targets within an environment. Run "humility doc" for more
+    /// information on Humility environments.
     #[clap(
         long = "list-targets",
         requires = "environment",

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.1
+humility 0.10.2
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.1
+humility 0.10.2
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.1
+humility 0.10.2
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.1
+humility 0.10.2
 
 ```


### PR DESCRIPTION
- Fixes #347
- Fixes #262
- Adds an option to "humility spd" to emit SPD data to a binary file
- Cleans up the help message for Humility to both better assist and to point to "humility doc"
