### PR TITLE
Store functions in HiffyContext instead of on-demand

### DIFF
--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -155,13 +155,12 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
     let hubris = context.archive.as_ref().unwrap();
     let subargs = GpioArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
 
-    let gpio_toggle = funcs.get("GpioToggle", 2)?;
-    let gpio_set = funcs.get("GpioSet", 2)?;
-    let gpio_reset = funcs.get("GpioReset", 2)?;
-    let gpio_input = funcs.get("GpioInput", 1)?;
-    let gpio_configure = funcs.get("GpioConfigure", 7)?;
+    let gpio_toggle = context.get_function("GpioToggle", 2)?;
+    let gpio_set = context.get_function("GpioSet", 2)?;
+    let gpio_reset = context.get_function("GpioReset", 2)?;
+    let gpio_input = context.get_function("GpioInput", 1)?;
+    let gpio_configure = context.get_function("GpioConfigure", 7)?;
     let mut configure_args = vec![];
 
     let target = if subargs.toggle {

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -280,25 +280,22 @@ pub fn hiffy_call(
 ) -> Result<std::result::Result<humility::reflect::Value, String>> {
     check_lease(op, lease.as_ref())?;
 
-    let funcs = context.functions()?;
     let mut ops = vec![];
 
     let payload = op.payload(args)?;
     match lease.as_ref() {
-        None => context.idol_call_ops(&funcs, op, &payload, &mut ops)?,
+        None => context.idol_call_ops(op, &payload, &mut ops)?,
         // Read/Write is flipped when passing through the Idol operation;
         // HiffyLease::Read/Write is from the perspective of the host, but
         // idol_call_ops_read/write is from the perspective of the called
         // function.
         Some(HiffyLease::Read(n)) => context.idol_call_ops_write(
-            &funcs,
             op,
             &payload,
             &mut ops,
             n.len().try_into().unwrap(),
         )?,
         Some(HiffyLease::Write(d)) => context.idol_call_ops_read(
-            &funcs,
             op,
             &payload,
             &mut ops,
@@ -552,7 +549,7 @@ fn hiffy(context: &mut humility::ExecutionContext) -> Result<()> {
         bail!("expected one of -l, -L, or -c");
     }
 
-    let funcs = context.functions()?;
+    let funcs = context.functions();
     let mut byid: Vec<Option<(&String, &HiffyFunction)>> = vec![];
 
     byid.resize(funcs.len(), None);

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -471,8 +471,7 @@ fn i2c(context: &mut humility::ExecutionContext) -> Result<()> {
         }
     };
 
-    let funcs = context.functions()?;
-    let func = funcs.get(fname, args)?;
+    let func = context.get_function(fname, args)?;
 
     let hargs = humility_cmd::i2c::I2cArgs::parse(
         hubris,
@@ -556,7 +555,7 @@ fn i2c(context: &mut humility::ExecutionContext) -> Result<()> {
         let mut file = File::open(filename)?;
         let mut last = false;
 
-        let sleep = funcs.get("Sleep", 1)?;
+        let sleep = context.get_function("Sleep", 1)?;
 
         let started = Instant::now();
         let bar = ProgressBar::new(filelen as u64);
@@ -753,7 +752,7 @@ fn i2c(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let results = context.run(core, ops.as_slice(), None)?;
 
-    i2c_done(&subargs, &hargs, &results, func)?;
+    i2c_done(&subargs, &hargs, &results, &func)?;
 
     Ok(())
 }

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -134,7 +134,6 @@ impl<'a> IbcHandler<'a> {
         let read_log =
             self.hubris.get_idol_command("Power.bmr491_event_log_read")?;
 
-        let funcs = self.context.functions()?;
         let mut ops = vec![];
 
         // We must read VOUT_MODE to interpret later data
@@ -143,16 +142,14 @@ impl<'a> IbcHandler<'a> {
             ("rail", idol::IdolArgument::Scalar(0)),
             ("index", idol::IdolArgument::Scalar(0)),
         ])?;
-        self.context.idol_call_ops(&funcs, &read_mode, &payload, &mut ops)?;
+        self.context.idol_call_ops(&read_mode, &payload, &mut ops)?;
 
         self.context.idol_call_ops(
-            &funcs,
             &bmr491_max_fault_event_index,
             &[],
             &mut ops,
         )?;
         self.context.idol_call_ops(
-            &funcs,
             &bmr491_max_lifecycle_event_index,
             &[],
             &mut ops,
@@ -160,8 +157,7 @@ impl<'a> IbcHandler<'a> {
         for i in 0..48 {
             let payload = read_log
                 .payload(&[("index", idol::IdolArgument::Scalar(i))])?;
-            self.context
-                .idol_call_ops(&funcs, &read_log, &payload, &mut ops)?;
+            self.context.idol_call_ops(&read_log, &payload, &mut ops)?;
         }
         ops.push(Op::Done);
         let results = self.context.run(self.core, &ops, None)?;

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -70,14 +70,13 @@ fn gpio(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let subargs = GpioArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
 
-    let gpio_toggle = funcs.get("GpioToggle", 1)?;
-    let gpio_set = funcs.get("GpioSet", 1)?;
-    let gpio_reset = funcs.get("GpioReset", 1)?;
-    let gpio_input = funcs.get("GpioInput", 1)?;
-    let gpio_configure = funcs.get("GpioConfigure", 7)?;
-    let gpio_direction = funcs.get("GpioDirection", 2)?;
+    let gpio_toggle = context.get_function("GpioToggle", 1)?;
+    let gpio_set = context.get_function("GpioSet", 1)?;
+    let gpio_reset = context.get_function("GpioReset", 1)?;
+    let gpio_input = context.get_function("GpioInput", 1)?;
+    let gpio_configure = context.get_function("GpioConfigure", 7)?;
+    let gpio_direction = context.get_function("GpioDirection", 2)?;
     let mut configure_args = vec![];
     let mut direction_args = vec![];
 

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -538,8 +538,7 @@ fn monorail_phy_dump(
     use hif::*;
     let op = hubris.get_idol_command("Monorail.read_phy_reg")?;
 
-    let funcs = context.functions()?;
-    let send = funcs.get("Send", 4)?;
+    let send = context.get_function("Send", 4)?;
     let ret_size = hubris.typesize(op.ok)? as u32;
     assert_eq!(ret_size, 2);
 
@@ -625,8 +624,7 @@ fn monorail_dump(
         use hif::*;
         let op_read = hubris.get_idol_command("Monorail.read_vsc7448_reg")?;
 
-        let funcs = context.functions()?;
-        let send = funcs.get("Send", 4)?;
+        let send = context.get_function("Send", 4)?;
         let mut ops = vec![];
 
         let label = Target(0);
@@ -693,8 +691,7 @@ fn monorail_status(
         let op_port = hubris.get_idol_command("Monorail.get_port_status")?;
         let op_phy = hubris.get_idol_command("Monorail.get_phy_status")?;
         use hif::*;
-        let funcs = context.functions()?;
-        let send = funcs.get("Send", 4)?;
+        let send = context.get_function("Send", 4)?;
         let mut ops = vec![];
 
         let label = Target(0);
@@ -919,8 +916,7 @@ fn monorail_mac_table(
     println!("Reading {} MAC addresses...", mac_count);
 
     let op = hubris.get_idol_command("Monorail.read_vsc7448_next_mac")?;
-    let funcs = context.functions()?;
-    let send = funcs.get("Send", 4)?;
+    let send = context.get_function("Send", 4)?;
 
     use hif::*;
     let label = Target(0);

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -181,8 +181,7 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
     humility::msg!("Reading {} MAC addresses...", mac_count);
 
     let op = hubris.get_idol_command("Net.read_ksz8463_mac")?;
-    let funcs = hiffy_context.functions()?;
-    let send = funcs.get("Send", 4)?;
+    let send = hiffy_context.get_function("Send", 4)?;
 
     use hif::*;
     let label = Target(0);

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1337,17 +1337,16 @@ fn pmbus(context: &mut humility::ExecutionContext) -> Result<()> {
     }
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
-    let func = funcs.get("I2cRead", 7)?;
-    let write_func = funcs.get("I2cWrite", 8)?;
+    let func = context.get_function("I2cRead", 7)?;
+    let write_func = context.get_function("I2cWrite", 8)?;
 
     if subargs.summarize {
-        summarize(&subargs, hubris, core, &mut context, func, write_func)?;
+        summarize(&subargs, hubris, core, &mut context, &func, &write_func)?;
         return Ok(());
     }
 
     if subargs.writes.is_some() {
-        writes(&subargs, hubris, core, &mut context, func, write_func)?;
+        writes(&subargs, hubris, core, &mut context, &func, &write_func)?;
         return Ok(());
     }
 

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -47,7 +47,6 @@ fn power(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let mut ops = vec![];
-    let funcs = context.functions()?;
     let op = hubris.get_idol_command("Sensor.get")?;
 
     let ok = hubris.lookup_basetype(op.ok)?;
@@ -118,7 +117,7 @@ fn power(context: &mut humility::ExecutionContext) -> Result<()> {
 
             let payload =
                 op.payload(&[("id", idol::IdolArgument::Scalar(i as u64))])?;
-            context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+            context.idol_call_ops(&op, &payload, &mut ops)?;
             ndx += 1;
         }
     }

--- a/cmd/powershelf/src/lib.rs
+++ b/cmd/powershelf/src/lib.rs
@@ -149,7 +149,6 @@ fn powershelf_run(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let mut ops = vec![];
-    let funcs = context.functions()?;
 
     let idol_cmd = hubris
         .get_idol_command("Power.pmbus_read")
@@ -167,7 +166,7 @@ fn powershelf_run(context: &mut humility::ExecutionContext) -> Result<()> {
     for variant in &operation.variants {
         args[0].1 = idol::IdolArgument::String(&variant.name);
         let payload = idol_cmd.payload(&args)?;
-        context.idol_call_ops(&funcs, &idol_cmd, &payload, &mut ops)?;
+        context.idol_call_ops(&idol_cmd, &payload, &mut ops)?;
     }
 
     ops.push(Op::Done);

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -101,9 +101,8 @@ fn rencm_attached(
     modules: &[Module],
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
-    let read_func = funcs.get("I2cRead", 7)?;
-    let write_func = funcs.get("I2cWrite", 8)?;
+    let read_func = context.get_function("I2cRead", 7)?;
+    let write_func = context.get_function("I2cWrite", 8)?;
 
     let hargs = I2cArgs::parse(
         hubris,

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -784,9 +784,8 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
     }
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
-    let i2c_read = funcs.get("I2cRead", 7)?;
-    let i2c_write = funcs.get("I2cWrite", 8)?;
+    let i2c_read = context.get_function("I2cRead", 7)?;
+    let i2c_write = context.get_function("I2cWrite", 8)?;
 
     let hargs = match (&subargs.rail, &subargs.device) {
         (Some(rail), None) => {

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -153,7 +153,6 @@ fn call_cpuid(
     ecx: u32,
 ) -> Result<CpuIdResult> {
     let op = hubris.get_idol_command("Sbrmi.cpuid")?;
-    let funcs = context.functions()?;
     let mut ops = vec![];
 
     let payload = op.payload(&[
@@ -162,7 +161,7 @@ fn call_cpuid(
         ("ecx", idol::IdolArgument::Scalar(ecx as u64)),
     ])?;
 
-    context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+    context.idol_call_ops(&op, &payload, &mut ops)?;
     ops.push(Op::Done);
 
     let results = context.run(core, ops.as_slice(), None)?;
@@ -429,7 +428,6 @@ fn mca(
     let nbanks = (mcg_cap & 0xff) as u8;
     let op = hubris.get_idol_command("Sbrmi.rdmsr64")?;
     let mut ops = vec![];
-    let funcs = context.functions()?;
     let thread_name = format!("thread 0x{thread:x} ({thread})");
 
     for bank in 0..nbanks {
@@ -438,7 +436,7 @@ fn mca(
             ("msr", idol::IdolArgument::Scalar(Msr::MCA_STATUS(bank).into())),
         ])?;
 
-        context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+        context.idol_call_ops(&op, &payload, &mut ops)?;
     }
 
     for bank in 0..nbanks {
@@ -447,7 +445,7 @@ fn mca(
             ("msr", idol::IdolArgument::Scalar(Msr::MCA_IPID(bank).into())),
         ])?;
 
-        context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+        context.idol_call_ops(&op, &payload, &mut ops)?;
     }
 
     ops.push(Op::Done);
@@ -504,7 +502,7 @@ fn mca(
                 ("msr", idol::IdolArgument::Scalar(r.into())),
             ])?;
 
-            context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+            context.idol_call_ops(&op, &payload, &mut ops)?;
         }
 
         ops.push(Op::Done);
@@ -585,16 +583,15 @@ fn sbrmi(context: &mut humility::ExecutionContext) -> Result<()> {
     }
 
     let mut ops = vec![];
-    let funcs = context.functions()?;
 
     let nthreads = hubris.get_idol_command("Sbrmi.nthreads")?;
-    context.idol_call_ops(&funcs, &nthreads, &[], &mut ops)?;
+    context.idol_call_ops(&nthreads, &[], &mut ops)?;
 
     let enabled = hubris.get_idol_command("Sbrmi.enabled")?;
-    context.idol_call_ops(&funcs, &enabled, &[], &mut ops)?;
+    context.idol_call_ops(&enabled, &[], &mut ops)?;
 
     let alert = hubris.get_idol_command("Sbrmi.alert")?;
-    context.idol_call_ops(&funcs, &alert, &[], &mut ops)?;
+    context.idol_call_ops(&alert, &[], &mut ops)?;
 
     let mcg_cap = hubris.get_idol_command("Sbrmi.rdmsr64")?;
 
@@ -603,7 +600,7 @@ fn sbrmi(context: &mut humility::ExecutionContext) -> Result<()> {
         ("msr", idol::IdolArgument::Scalar(Msr::MCG_CAP.into())),
     ])?;
 
-    context.idol_call_ops(&funcs, &mcg_cap, &payload, &mut ops)?;
+    context.idol_call_ops(&mcg_cap, &payload, &mut ops)?;
 
     ops.push(Op::Done);
 

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -165,7 +165,6 @@ fn print(
 ) -> Result<()> {
     let mut all_ops = vec![];
     let mut err_ops = vec![];
-    let funcs = context.functions()?;
     let nerrbits = 32;
     let op = hubris.get_idol_command("Sensor.get")?;
 
@@ -217,7 +216,7 @@ fn print(
         for (i, _) in s {
             let payload =
                 op.payload(&[("id", idol::IdolArgument::Scalar(*i as u64))])?;
-            context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+            context.idol_call_ops(&op, &payload, &mut ops)?;
         }
 
         ops.push(Op::Done);
@@ -243,7 +242,7 @@ fn print(
                     "id",
                     idol::IdolArgument::Scalar(*i as u64),
                 )])?;
-                context.idol_call_ops(&funcs, &errop, &payload, &mut ops)?;
+                context.idol_call_ops(&errop, &payload, &mut ops)?;
             }
 
             ops.push(Op::Done);

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -94,7 +94,6 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
     let subargs = SpCtrlArgs::try_parse_from(subargs)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
     let mut ops = vec![];
 
     match subargs.cmd {
@@ -111,7 +110,7 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
             ops.push(Op::Push32(addr));
             ops.push(Op::Push32(arr.len() as u32));
 
-            let sp_write = funcs.get("WriteToSp", 2)?;
+            let sp_write = context.get_function("WriteToSp", 2)?;
             ops.push(Op::Call(sp_write.id));
             ops.push(Op::Done);
 
@@ -122,7 +121,7 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
         SpCtrlCmd::Read { addr, nbytes } => {
             ops.push(Op::Push32(addr));
             ops.push(Op::Push32(nbytes as u32));
-            let sp_read = funcs.get("ReadFromSp", 2)?;
+            let sp_read = context.get_function("ReadFromSp", 2)?;
             ops.push(Op::Call(sp_read.id));
             ops.push(Op::Done);
 
@@ -139,7 +138,7 @@ fn spctrl(context: &mut humility::ExecutionContext) -> Result<()> {
             }
         }
         SpCtrlCmd::Init => {
-            let init = funcs.get("SpCtrlInit", 0)?;
+            let init = context.get_function("SpCtrlInit", 0)?;
             ops.push(Op::Call(init.id));
             ops.push(Op::Done);
 

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -245,10 +245,9 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
     }
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
 
-    let i2c_read = funcs.get("I2cRead", 7)?;
-    let i2c_write = funcs.get("I2cWrite", 8)?;
+    let i2c_read = context.get_function("I2cRead", 7)?;
+    let i2c_write = context.get_function("I2cWrite", 8)?;
 
     let hargs = I2cArgs::parse(
         hubris,
@@ -277,7 +276,7 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
     // First, we want to have all SPDs on the specified bus flip to
     // their 0 page
     //
-    set_page(&mut ops, i2c_write, 0);
+    set_page(&mut ops, &i2c_write, 0);
 
     //
     // Now issue single byte register reads to determine where our devices are.
@@ -326,7 +325,7 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
             // Switch to the 1 page
             //
             ops.push(Op::DropN(3));
-            set_page(&mut ops, i2c_write, 1);
+            set_page(&mut ops, &i2c_write, 1);
 
             //
             // Issue an identical read for the bottom 128 bytes...
@@ -348,7 +347,7 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
             //
             // Finally, set ourselves back to the 0 page
             //
-            set_page(&mut ops, i2c_write, 0);
+            set_page(&mut ops, &i2c_write, 0);
 
             ops.push(Op::Done);
 

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -177,10 +177,9 @@ fn spi(context: &mut humility::ExecutionContext) -> Result<()> {
 
     let subargs = SpiArgs::try_parse_from(subargs)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
 
-    let spi_read = funcs.get("SpiRead", 4)?;
-    let spi_write = funcs.get("SpiWrite", 3)?;
+    let spi_read = context.get_function("SpiRead", 4)?;
+    let spi_write = context.get_function("SpiWrite", 3)?;
 
     let task = spi_task(hubris, subargs.peripheral)?;
     let mut ops = vec![];

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -156,7 +156,6 @@ fn validate(context: &mut humility::ExecutionContext) -> Result<()> {
     }
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
     let op = hubris.get_idol_command("Validate.validate_i2c")?;
     let mut ops = vec![];
 
@@ -183,7 +182,7 @@ fn validate(context: &mut humility::ExecutionContext) -> Result<()> {
 
         let payload =
             op.payload(&[("index", idol::IdolArgument::Scalar(ndx as u64))])?;
-        context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+        context.idol_call_ops(&op, &payload, &mut ops)?;
     }
 
     ops.push(Op::Done);

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -248,7 +248,6 @@ fn vpd_write(
     subargs: &VpdArgs,
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
     let op = hubris.get_idol_command("Vpd.write")?;
     let target = target(hubris, subargs)?;
 
@@ -282,7 +281,7 @@ fn vpd_write(
             ("contents", idol::IdolArgument::Scalar(*b as u64)),
         ])?;
 
-        context.idol_call_ops(&funcs, &op, &payload, &mut ops)?;
+        context.idol_call_ops(&op, &payload, &mut ops)?;
         all_ops.push(ops);
     }
 
@@ -337,7 +336,6 @@ fn vpd_write(
 fn vpd_read_at(
     core: &mut dyn Core,
     context: &mut HiffyContext,
-    funcs: &HiffyFunctions,
     op: &idol::IdolOperation,
     target: &mut VpdTarget,
     offset: usize,
@@ -359,7 +357,7 @@ fn vpd_read_at(
 
     let mut ops = vec![];
 
-    context.idol_call_ops(funcs, op, &payload, &mut ops)?;
+    context.idol_call_ops(op, &payload, &mut ops)?;
     ops.push(Op::Done);
 
     let results = context.run(core, ops.as_slice(), None)?;
@@ -385,14 +383,13 @@ fn vpd_read(
     subargs: &VpdArgs,
 ) -> Result<()> {
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
-    let funcs = context.functions()?;
     let op = hubris.get_idol_command("Vpd.read")?;
     let mut target = target(hubris, subargs)?;
 
     //
     // First, read in enough to read just the header.
     //
-    let mut vpd = vpd_read_at(core, &mut context, &funcs, &op, &mut target, 0)?;
+    let mut vpd = vpd_read_at(core, &mut context, &op, &mut target, 0)?;
 
     let reader = match tlvc::TlvcReader::begin(&vpd[..]) {
         Ok(reader) => reader,
@@ -424,7 +421,6 @@ fn vpd_read(
         vpd.extend(vpd_read_at(
             core,
             &mut context,
-            &funcs,
             &op,
             &mut target,
             vpd.len(),

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -132,7 +132,6 @@ struct Vsc7448<'a> {
     context: HiffyContext<'a>,
 
     task: HubrisTask,
-    funcs: HiffyFunctions,
 }
 
 impl<'a> Vsc7448<'a> {
@@ -142,15 +141,14 @@ impl<'a> Vsc7448<'a> {
         args: &Vsc7448Args,
     ) -> Result<Self> {
         let mut context = HiffyContext::new(hubris, core, args.timeout)?;
-        let funcs = context.functions()?;
 
         let task = spi_task(hubris, args.peripheral)?;
-        Ok(Self { core, context, task, funcs })
+        Ok(Self { core, context, task })
     }
 
     /// Writes a single 32-bit register
     fn write(&mut self, addr: u32, data: u32) -> Result<()> {
-        let spi_write = self.funcs.get("SpiWrite", 3)?;
+        let spi_write = self.context.get_function("SpiWrite", 3)?;
 
         // Write 7 bytes from the data array over SPI
         let ops = [
@@ -182,7 +180,7 @@ impl<'a> Vsc7448<'a> {
 
     /// Reads a single 32-bit register
     fn read(&mut self, addr: u32) -> Result<u32> {
-        let spi_read = self.funcs.get("SpiRead", 4)?;
+        let spi_read = self.context.get_function("SpiRead", 4)?;
 
         // Write 3 bytes of address, and read 8 bytes back in total
         // (3 address bytes, 1 padding byte, 4 bytes of result)

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -35,18 +35,17 @@ pub struct HiffyContext<'a> {
     requests: &'a HubrisVariable,
     errors: &'a HubrisVariable,
     failure: &'a HubrisVariable,
-    funcs: HubrisGoff,
     scratch_size: usize,
     cached: Option<(u32, u32)>,
     kicked: Option<Instant>,
     timeout: u32,
     state: State,
-    functions: HashMap<String, TargetFunction>,
+    functions: HiffyFunctions,
     rpc_results: Vec<Result<Vec<u8>, u32>>,
     rpc_reply_type: Option<&'a HubrisEnum>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HiffyFunction {
     pub id: TargetFunction,
     pub name: String,
@@ -117,11 +116,11 @@ impl HiffyFunction {
 }
 
 /// Simple wrapper `struct` that exposes a checked `get(name, nargs)`
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HiffyFunctions(pub HashMap<String, HiffyFunction>);
 
 impl HiffyFunctions {
-    pub fn get(&self, name: &str, nargs: usize) -> Result<&HiffyFunction> {
+    pub fn get(&self, name: &str, nargs: usize) -> Result<HiffyFunction> {
         let f = self
             .0
             .get(name)
@@ -136,7 +135,7 @@ impl HiffyFunctions {
                 nargs
             );
         }
-        Ok(f)
+        Ok(f.clone())
     }
     pub fn len(&self) -> usize {
         self.0.len()
@@ -253,6 +252,80 @@ impl<'a> HiffyContext<'a> {
             }
         };
 
+        let mut function_map = HashMap::new();
+        let funcs = Self::definition(hubris, "HIFFY_FUNCTIONS")?;
+        let goff = hubris
+            .lookup_enum(funcs)?
+            .lookup_variant_byname("Some")?
+            .goff
+            .ok_or_else(|| anyhow!("malconstructed functions"))?;
+
+        let ptr = hubris.lookup_struct(goff)?.lookup_member("__0")?.goff;
+        let goff = hubris.lookup_ptrtype(ptr)?;
+        let functions = hubris.lookup_enum(goff)?;
+
+        //
+        // Iterate over our functions.  Note that we very much expect these to
+        // be encoded in the DWARF in program order!
+        //
+        for (id, f) in functions.variants.iter().enumerate() {
+            let goff = f.goff.ok_or_else(|| {
+                anyhow!("function {} in {}: missing a type", f.name, goff)
+            })?;
+
+            let mut func = HiffyFunction {
+                id: TargetFunction(u8::try_from(id)?),
+                name: f.name.to_string(),
+                args: Vec::new(),
+                errmap: HashMap::new(),
+            };
+
+            //
+            // We expect a 2-tuple that is our arguments and our error type
+            //
+            let sig = hubris.lookup_struct(goff)?;
+            let args = sig.lookup_member("__0")?.goff;
+
+            if let Ok(args) = hubris.lookup_struct(args) {
+                for arg in &args.members {
+                    func.args.push(arg.goff);
+                }
+            } else {
+                //
+                // This isn't a structure argument; if it's not an empty
+                // tuple (denoting no argument), push our single argument.
+                //
+                match hubris.lookup_basetype(args) {
+                    Ok(basetype) if basetype.size == 0 => {}
+                    _ => {
+                        func.args.push(args);
+                    }
+                }
+            }
+
+            let err = sig.lookup_member("__1")?.goff;
+
+            //
+            // We expect our error type to be 4-byte base type or an enum.
+            //
+            if let Ok(err) = hubris.lookup_enum(err) {
+                for e in &err.variants {
+                    let tag = e.tag.ok_or_else(|| {
+                        anyhow!(
+                            "function {}: malformed error type {}",
+                            f.name,
+                            err.goff,
+                        )
+                    })?;
+
+                    let val = u32::try_from(tag)?;
+                    func.errmap.insert(val, e.name.to_string());
+                }
+            }
+
+            function_map.insert(func.name.clone(), func);
+        }
+
         Ok(Self {
             hubris,
             ready: Self::variable(hubris, "HIFFY_READY", true)?,
@@ -263,13 +336,12 @@ impl<'a> HiffyContext<'a> {
             requests: Self::variable(hubris, "HIFFY_REQUESTS", true)?,
             errors: Self::variable(hubris, "HIFFY_ERRORS", true)?,
             failure: Self::variable(hubris, "HIFFY_FAILURE", false)?,
-            funcs: Self::definition(hubris, "HIFFY_FUNCTIONS")?,
             scratch_size,
             cached: None,
             kicked: None,
             timeout,
             state: State::Initialized,
-            functions: HashMap::new(),
+            functions: HiffyFunctions(function_map),
             rpc_reply_type: if core.is_net() {
                 //
                 // This should have been checked when we initially attached.
@@ -331,95 +403,25 @@ impl<'a> HiffyContext<'a> {
         Ok(total)
     }
 
-    pub fn functions(&mut self) -> Result<HiffyFunctions> {
-        let hubris = self.hubris;
+    pub fn get_function(
+        &self,
+        name: &str,
+        nargs: usize,
+    ) -> Result<HiffyFunction> {
+        self.functions.get(name, nargs)
+    }
 
-        let goff = hubris
-            .lookup_enum(self.funcs)?
-            .lookup_variant_byname("Some")?
-            .goff
-            .ok_or_else(|| anyhow!("malconstructed functions"))?;
-
-        let ptr = hubris.lookup_struct(goff)?.lookup_member("__0")?.goff;
-        let goff = hubris.lookup_ptrtype(ptr)?;
-        let functions = hubris.lookup_enum(goff)?;
-        let mut rval = HashMap::new();
-
-        //
-        // Iterate over our functions.  Note that we very much expect these to
-        // be encoded in the DWARF in program order!
-        //
-        for (id, f) in functions.variants.iter().enumerate() {
-            let goff = f.goff.ok_or_else(|| {
-                anyhow!("function {} in {}: missing a type", f.name, goff)
-            })?;
-
-            let mut func = HiffyFunction {
-                id: TargetFunction(u8::try_from(id)?),
-                name: f.name.to_string(),
-                args: Vec::new(),
-                errmap: HashMap::new(),
-            };
-
-            self.functions.insert(func.name.clone(), func.id);
-
-            //
-            // We expect a 2-tuple that is our arguments and our error type
-            //
-            let sig = hubris.lookup_struct(goff)?;
-            let args = sig.lookup_member("__0")?.goff;
-
-            if let Ok(args) = hubris.lookup_struct(args) {
-                for arg in &args.members {
-                    func.args.push(arg.goff);
-                }
-            } else {
-                //
-                // This isn't a structure argument; if it's not an empty
-                // tuple (denoting no argument), push our single argument.
-                //
-                match hubris.lookup_basetype(args) {
-                    Ok(basetype) if basetype.size == 0 => {}
-                    _ => {
-                        func.args.push(args);
-                    }
-                }
-            }
-
-            let err = sig.lookup_member("__1")?.goff;
-
-            //
-            // We expect our error type to be 4-byte base type or an enum.
-            //
-            if let Ok(err) = hubris.lookup_enum(err) {
-                for e in &err.variants {
-                    let tag = e.tag.ok_or_else(|| {
-                        anyhow!(
-                            "function {}: malformed error type {}",
-                            f.name,
-                            err.goff,
-                        )
-                    })?;
-
-                    let val = u32::try_from(tag)?;
-                    func.errmap.insert(val, e.name.to_string());
-                }
-            }
-
-            rval.insert(func.name.clone(), func);
-        }
-
-        Ok(HiffyFunctions(rval))
+    pub fn functions(&self) -> HiffyFunctions {
+        self.functions.clone()
     }
 
     fn perform_rpc(&mut self, core: &mut dyn Core, ops: &[Op]) -> Result<()> {
-        let send = self
-            .functions
-            .get("Send")
-            .ok_or_else(|| anyhow!("illegal network operations: {:?}", ops))?;
+        let send = self.functions.get("Send", 4).with_context(|| {
+            format!("illegal network operations: {:?}", ops)
+        })?;
 
         // Bail out immediately if the program makes a call other than Send
-        if ops.iter().any(|op| matches!(*op, Op::Call(id) if id != *send)) {
+        if ops.iter().any(|op| matches!(*op, Op::Call(id) if id != send.id)) {
             bail!("can't make non-Idol calls over RPC");
         }
 
@@ -590,7 +592,8 @@ impl<'a> HiffyContext<'a> {
         // contains our local `hiffy_send_fn`, repeated just times so that the
         // call operation works; i.e. at index `send.0`, it will find a function
         // pointer to `hiffy_send_fn`.
-        let functions: Vec<Function> = vec![hiffy_send_fn; send.0 as usize + 1];
+        let functions: Vec<Function> =
+            vec![hiffy_send_fn; send.id.0 as usize + 1];
 
         // Okay, this is a _little_ cursed: HIF functions use a C calling
         // convention without any place to stash a context pointer, so we're
@@ -728,7 +731,6 @@ impl<'a> HiffyContext<'a> {
     /// generic across `Send/SendLeaseRead/SendLeaseWrite`
     fn idol_call_ops_inner(
         &self,
-        funcs: &HiffyFunctions,
         op: &idol::IdolOperation,
         payload: &[u8],
         ops: &mut Vec<Op>,
@@ -736,7 +738,7 @@ impl<'a> HiffyContext<'a> {
         func_name: &str,
     ) -> Result<()> {
         let arg_count = if lease_size.is_some() { 5 } else { 4 };
-        let send = funcs.get(func_name, arg_count)?;
+        let send = self.functions.get(func_name, arg_count)?;
 
         let push = |val: u32| {
             if val <= u8::MAX as u32 {
@@ -786,26 +788,23 @@ impl<'a> HiffyContext<'a> {
     /// Convenience routine to translate an Idol call into HIF operations
     pub fn idol_call_ops(
         &self,
-        funcs: &HiffyFunctions,
         op: &idol::IdolOperation,
         payload: &[u8],
         ops: &mut Vec<Op>,
     ) -> Result<()> {
-        self.idol_call_ops_inner(funcs, op, payload, ops, None, "Send")
+        self.idol_call_ops_inner(op, payload, ops, None, "Send")
     }
 
     /// Convenience routine to translate an Idol call (which reads data from the
     /// device back to the host) into HIF operations
     pub fn idol_call_ops_read(
         &self,
-        funcs: &HiffyFunctions,
         op: &idol::IdolOperation,
         payload: &[u8],
         ops: &mut Vec<Op>,
         lease_size: u32,
     ) -> Result<()> {
         self.idol_call_ops_inner(
-            funcs,
             op,
             payload,
             ops,
@@ -818,14 +817,12 @@ impl<'a> HiffyContext<'a> {
     /// the host to the device) into HIF operations
     pub fn idol_call_ops_write(
         &self,
-        funcs: &HiffyFunctions,
         op: &idol::IdolOperation,
         payload: &[u8],
         ops: &mut Vec<Op>,
         lease_size: u32,
     ) -> Result<()> {
         self.idol_call_ops_inner(
-            funcs,
             op,
             payload,
             ops,


### PR DESCRIPTION
Right now, we have an odd pattern that occurs in many places:

- Get a map of functions (`HiffyFunctions`) out of a `HiffyContext` with `functions()`
- Pass that list of functions _back into_ calls on that `HiffyContext`, e.g. `context.idol_call_ops_inner(funcs, op, payload, ...)`

(likely due to the history of the `HiffyContext` and how it has grown functionality over time)

This PR changes the behavior to be a little simpler:

- `HiffyFunctions` are calculated _once_ and stored within the `HiffyContext` at construction
- The `funcs` map is no longer passed into `HiffyContext` calls
- A new `get_function` method is added to avoid the two-step dance of getting the `HiffyFunctions` object, then getting a function out of it; this function is used _almost_ everywhere (except in `humility hiffy`, where we care about the full length of the array)

