### PR TITLE
Reduce duplicate builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,8 @@
-on: [push, pull_request]
-
 name: Continuous integration
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 env:
   CARGO_INCREMENTAL: 0 # set here rather than on CI profile so that the tests get it too

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,5 +1,9 @@
 name: formatting
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
+
 jobs:
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We only want to build on PR *or* on pushes to the master branch, we don't want to build on every branch, since PRs are also branches, or else we build twice for no reason.