### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -454,9 +454,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"
@@ -2390,9 +2390,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libm"
@@ -2448,9 +2448,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -3129,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3140,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "ron"
@@ -3189,9 +3189,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc_version"
@@ -3204,9 +3204,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags 1.3.2",
  "errno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +178,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -311,6 +329,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -328,9 +349,18 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -421,6 +451,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "content_inspector"
@@ -768,6 +804,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1050,6 +1087,15 @@ dependencies = [
  "pkg-version",
  "postcard",
  "serde",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -2374,6 +2420,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2774,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "os_pipe"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,6 +2887,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2921,18 @@ name = "path-slash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "pest"
@@ -3406,6 +3490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3591,6 +3686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+
+[[package]]
 name = "svg"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,6 +3826,22 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "tlvc"
@@ -4241,14 +4358,50 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
 dependencies = [
+ "aes",
  "byteorder",
  "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror",
- "time",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time 0.3.20",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,7 @@ trycmd = "0.13.2"
 tui = { version = "0.16", default-features = false }
 winapi = "0.3.9"
 zerocopy = "0.6.1"
-zip = "0.5"
+zip = "0.6.4"
 
 [profile.release]
 debug = true

--- a/tests/cmd/extract-list/extract-list.kiowa.3.fails.stderr
+++ b/tests/cmd/extract-list/extract-list.kiowa.3.fails.stderr
@@ -1,1 +1,1 @@
-humility extract failed: invalid Zip archive
+humility extract failed: invalid Zip archive: Invalid zip header

--- a/tests/cmd/extract-list/extract-list.ouray.34.fails.stderr
+++ b/tests/cmd/extract-list/extract-list.ouray.34.fails.stderr
@@ -1,1 +1,1 @@
-humility extract failed: invalid Zip archive
+humility extract failed: invalid Zip archive: Invalid zip header

--- a/tests/cmd/extract/extract.kiowa.3.fails.stderr
+++ b/tests/cmd/extract/extract.kiowa.3.fails.stderr
@@ -1,1 +1,1 @@
-humility extract failed: invalid Zip archive
+humility extract failed: invalid Zip archive: Invalid zip header

--- a/tests/cmd/extract/extract.ouray.34.fails.stderr
+++ b/tests/cmd/extract/extract.ouray.34.fails.stderr
@@ -1,1 +1,1 @@
-humility extract failed: invalid Zip archive
+humility extract failed: invalid Zip archive: Invalid zip header

--- a/tests/cmd/hiffy-list/hiffy-list.kiowa.3.fails.stderr
+++ b/tests/cmd/hiffy-list/hiffy-list.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility hiffy failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/manifest/manifest.kiowa.3.fails.stderr
+++ b/tests/cmd/manifest/manifest.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility manifest failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/map/map.kiowa.3.fails.stderr
+++ b/tests/cmd/map/map.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility map failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/readvar-list/readvar-list.kiowa.3.fails.stderr
+++ b/tests/cmd/readvar-list/readvar-list.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility readvar failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/readvar-ticks/readvar-ticks.kiowa.3.fails.stderr
+++ b/tests/cmd/readvar-ticks/readvar-ticks.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility readvar failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/registers-s/registers-s.kiowa.3.fails.stderr
+++ b/tests/cmd/registers-s/registers-s.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility registers failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/registers/registers.kiowa.3.fails.stderr
+++ b/tests/cmd/registers/registers.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility registers failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/ringbuf-arg/ringbuf-arg.kiowa.3.fails.stderr
+++ b/tests/cmd/ringbuf-arg/ringbuf-arg.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility ringbuf failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/ringbuf/ringbuf.kiowa.3.fails.stderr
+++ b/tests/cmd/ringbuf/ringbuf.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility ringbuf failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/spd/spd.kiowa.3.fails.stderr
+++ b/tests/cmd/spd/spd.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility spd failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/stackmargin/stackmargin.kiowa.3.fails.stderr
+++ b/tests/cmd/stackmargin/stackmargin.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility stackmargin failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.3.fails.stderr
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility tasks failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header

--- a/tests/cmd/tasks/tasks.kiowa.3.fails.stderr
+++ b/tests/cmd/tasks/tasks.kiowa.3.fails.stderr
@@ -1,4 +1,4 @@
 humility tasks failed: failed to load dump "hubris.core.kiowa.3.fails"
 
 Caused by:
-    invalid Zip archive
+    invalid Zip archive: Invalid zip header


### PR DESCRIPTION
Some of these have been yanked, some of these have active dependabot alerts. None seem to be an active problem for us, but it's easy to update them, so let's get clean.