### PR TITLE
Add support for remote dumping via `dump-agent`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#0ea3b81566e06ad90030f5a507529bbc8dd925ea"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#ffb6044785baa928349370636d42c7d0d08dc8e6"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,8 +2053,8 @@ dependencies = [
 
 [[package]]
 name = "humpty"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#47cda952e2052e1067e0d586bb125f3668864d27"
+version = "0.1.1"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#a2787d60e41b9f4e4c88b009fd92ee6c610f8d25"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#a2787d60e41b9f4e4c88b009fd92ee6c610f8d25"
+source = "git+https://github.com/oxidecomputer/humpty#b4052d8b0c1fe555e1686b281104852d7fba5230"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5972cd5ee06fafc4fbe88ffe5369e3d750e10ece"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#03e8bc34840841604fbf10eb45f352ef87552b98"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#03e8bc34840841604fbf10eb45f352ef87552b98"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#47cda952e2052e1067e0d586bb125f3668864d27"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "gimli"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,6 +1281,7 @@ dependencies = [
  "clap",
  "goblin",
  "hif",
+ "hubpack",
  "humility-cmd",
  "humility-core",
  "humpty",
@@ -1280,6 +1292,7 @@ dependencies = [
  "num-traits",
  "parse_int",
  "probe-rs",
+ "rand",
  "zerocopy",
  "zip",
 ]
@@ -2041,11 +2054,12 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty#b87a452e1c0a75e3e906616efc44945ac988748b"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#0ea3b81566e06ad90030f5a507529bbc8dd925ea"
 dependencies = [
  "hubpack",
  "lzss",
  "serde",
+ "serde-big-array",
  "static_assertions",
  "zerocopy",
 ]
@@ -2726,6 +2740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "probe-rs"
 version = "0.12.0"
 source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#75afc22df6bad7cae756b48728c5d788906aefe0"
@@ -2819,6 +2839,36 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "raw-cpuid"
@@ -3110,6 +3160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 [[package]]
 name = "humpty"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#ffb6044785baa928349370636d42c7d0d08dc8e6"
+source = "git+https://github.com/oxidecomputer/humpty?branch=udp-types#5972cd5ee06fafc4fbe88ffe5369e3d750e10ece"
 dependencies = [
  "hubpack",
  "lzss",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ members = [
 [workspace.dependencies]
 # `git`-based deps
 hif = { git = "https://github.com/oxidecomputer/hif" }
-humpty = { git = "https://github.com/oxidecomputer/humpty", branch = "udp-types", version = "0.1.1" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.1" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "a07e8d39caf27dd83c314e121755d481a3f52263" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ members = [
 [workspace.dependencies]
 # `git`-based deps
 hif = { git = "https://github.com/oxidecomputer/hif" }
-humpty = { git = "https://github.com/oxidecomputer/humpty" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", branch = "udp-types" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "a07e8d39caf27dd83c314e121755d481a3f52263" }
@@ -204,13 +204,14 @@ lzss = "0.8"
 multimap = "0.8.1"
 num-derive = "0.3"
 num-traits = "0.2"
-parse_int = "0.4.0"
 parse-size = { version = "1.0", features = ["std"]}
+parse_int = "0.4.0"
 paste = "0.1"
 path-slash = "0.1.4"
 postcard = "0.7.0"
 proc-macro2 = "1.0"
 quote = "1.0"
+rand = "0.8"
 raw-cpuid = "10.6.0"
 reedline = "0.11.0"
 regex = "1.5.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ members = [
 [workspace.dependencies]
 # `git`-based deps
 hif = { git = "https://github.com/oxidecomputer/hif" }
-humpty = { git = "https://github.com/oxidecomputer/humpty", branch = "udp-types" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", branch = "udp-types", version = "0.1.1" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
 lpc55_areas = { git = "https://github.com/oxidecomputer/lpc55_support", rev = "a07e8d39caf27dd83c314e121755d481a3f52263" }

--- a/cmd/dump/Cargo.toml
+++ b/cmd/dump/Cargo.toml
@@ -5,19 +5,21 @@ edition = "2021"
 description = "generate Hubris dump"
 
 [dependencies]
-humility = { workspace = true }
-humility-cmd = { workspace = true }
-humpty = { workspace = true }
-indicatif = { workspace = true }
-clap = { workspace = true }
-anyhow = { workspace = true }
-log = { workspace = true }
-zip = { workspace = true }
-goblin = { workspace = true }
-hif = { workspace = true }
-lzss = { workspace = true }
-parse_int = { workspace = true }
-zerocopy = { workspace = true }
-num-traits = { workspace = true }
-probe-rs = { workspace = true }
-indexmap = { workspace = true }
+anyhow.workspace = true
+clap.workspace = true
+goblin.workspace = true
+hif.workspace = true
+hubpack.workspace = true
+humility-cmd.workspace = true
+humility.workspace = true
+humpty.workspace = true
+indexmap.workspace = true
+indicatif.workspace = true
+log.workspace = true
+lzss.workspace = true
+num-traits.workspace = true
+parse_int.workspace = true
+probe-rs.workspace = true
+rand.workspace = true
+zerocopy.workspace = true
+zip.workspace = true

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -1585,7 +1585,7 @@ fn dump_agent_status(
 ) -> Result<()> {
     let mut agent = get_dump_agent(hubris, core, subargs)?;
     let headers = agent.read_dump_headers(true)?;
-    humility::msg!("{:#x?}", headers);
+    println!("{:#x?}", headers);
 
     Ok(())
 }

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -112,6 +112,10 @@ struct DumpArgs {
     #[clap(long)]
     force_dump_agent: bool,
 
+    /// force use of hiffy, even if the UDP dump agent is available
+    #[clap(long)]
+    force_hiffy_agent: bool,
+
     /// force manual initiation, leaving target halted
     #[clap(long, requires = "force-dump-agent")]
     force_manual_initiation: bool,
@@ -1175,6 +1179,7 @@ fn get_dump_agent<'a>(
     subargs: &DumpArgs,
 ) -> Result<Box<dyn DumpAgent + 'a>> {
     if core.is_net()
+        && !subargs.force_hiffy_agent
         && hubris
             .manifest
             .task_features

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -377,9 +377,9 @@ trait DumpAgent {
     fn read_dump_header_at(&mut self, i: u8) -> Result<DumpAreaHeader> {
         let val = self
             .read_generic(&mut std::iter::once((i, 0)), &mut |_, _, _| {
-                Ok(false)
+                Ok(true)
             })?;
-        assert_eq!(val.len(), 0);
+        assert_eq!(val.len(), 1);
         let (header, _task) = parse_dump_header(i as usize, &val[0])?;
         Ok(header)
     }
@@ -392,7 +392,7 @@ trait DumpAgent {
         // Read the header of this dump area
         let val = &self.read_generic(
             &mut std::iter::once((index, 0)),
-            &mut |_, _, _| Ok(false),
+            &mut |_, _, _| Ok(true),
         )?[0];
 
         let header = DumpAreaHeader::read_from_prefix(val.as_slice())
@@ -1470,9 +1470,9 @@ fn dump_list(
     core: &mut dyn Core,
     subargs: &DumpArgs,
 ) -> Result<()> {
-    println!("{:4} {:21} {:10} SIZE", "AREA", "TASK", "TIME");
-
     let mut agent = get_dump_agent(hubris, core, subargs)?;
+
+    println!("{:4} {:21} {:10} SIZE", "AREA", "TASK", "TIME");
     let headers = agent.read_dump_headers(false)?;
 
     if headers.is_empty() || headers[0].0.dumper == humpty::DUMPER_NONE {

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -444,7 +444,7 @@ trait DumpAgentExt {
         assert_eq!(chunk_size, 256);
 
         let mut chunks = vec![];
-        let mut offset = chunk_size;
+        let mut offset = chunk_size.min(header.written as usize);
         while offset < header.written as usize {
             let len = chunk_size.min(header.written as usize - offset);
             chunks.push(offset.try_into().unwrap());

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -1275,10 +1275,10 @@ fn get_dump_agent<'a>(
             .map(|f| f.contains(&"net".to_string()))
             .unwrap_or(false)
     {
-        humility::msg!("making UDP dump agent");
+        humility::msg!("using UDP dump agent");
         Ok(Box::new(UdpDumpAgent { core }))
     } else {
-        humility::msg!("making hiffy dump agent");
+        humility::msg!("using hiffy dump agent");
         Ok(Box::new(HiffyDumpAgent::new(hubris, core, subargs.timeout)?))
     }
 }

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -844,7 +844,8 @@ impl<'a> UdpDumpAgent<'a> {
     ) -> Result<Result<udp::Response, udp::Error>> {
         use udp::{Header, Request, Response};
         let mut rng = rand::thread_rng();
-        let header = Header { version: udp::VERSION, message_id: rng.gen() };
+        let header =
+            Header { version: udp::version::CURRENT, message_id: rng.gen() };
         let mut buf = vec![
             0u8;
             std::cmp::max(

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -393,10 +393,12 @@ trait DumpAgentExt {
     ////////////////////////////////////////////////////////////////////////
     // Everything beyond this point is implemented in terms of `read_generic`
 
+    /// Reads the root header
     fn read_dump_header(&mut self) -> Result<DumpAreaHeader> {
         self.read_dump_header_at(0)
     }
 
+    /// Reads the header from the given dump area
     fn read_dump_header_at(&mut self, i: u8) -> Result<DumpAreaHeader> {
         let val = self.read_dump_area_start(i)?;
         let (header, _task) = parse_dump_header(i as usize, &val)?;
@@ -505,6 +507,7 @@ trait DumpAgentExt {
         out: &mut AgentCore,
     ) -> Result<Option<DumpTask>> {
         let (base, headers, task) = {
+            // Read dump headers until the first empty header (DUMPER_NONE)
             let all = self.read_dump_headers(false)?;
 
             let area = match area {

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -372,6 +372,7 @@ trait DumpAgent {
     /// The `cont` callback can also be used as a progress tracker.  Each time
     /// it is called, it takes an incremental number of bytes that have been
     /// read in the most recent operation.
+    #[allow(clippy::type_complexity)]
     fn read_generic(
         &mut self,
         areas: &mut dyn Iterator<Item = (u8, u32)>,

--- a/humility-cmd/src/hiffy.rs
+++ b/humility-cmd/src/hiffy.rs
@@ -5,7 +5,7 @@
 use crate::{doppel::RpcHeader, doppel::StaticCell, idol};
 use anyhow::{anyhow, bail, Context, Result};
 use hif::*;
-use humility::core::Core;
+use humility::core::{Core, NetAgent};
 use humility::hubris::*;
 use humility::reflect::{self, Load, Value};
 use postcard::{take_from_bytes, to_slice};
@@ -549,13 +549,13 @@ impl<'a> HiffyContext<'a> {
                 packet.extend(&payload[0..nbytes as usize]);
 
                 // Send the packet out
-                if let Err(e) = core.send(&packet) {
+                if let Err(e) = core.send(&packet, NetAgent::UdpRpc) {
                     workspace.errors.push(e);
                     return Err(Failure::FunctionError(0));
                 }
 
                 // Try to receive a reply
-                match core.recv(buf.as_mut_slice()) {
+                match core.recv(buf.as_mut_slice(), NetAgent::UdpRpc) {
                     Ok(n) => {
                         workspace.results.push(buf[0..n].to_vec());
                         Ok(())

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -1393,7 +1393,7 @@ impl NetCore {
 
         let scopeid = decode_iface(iface)?;
 
-        // Hard-coded socket address, based on Hubris configuration
+        // See oxidecomputer/oana for standard Hubris UDP ports
         let target = format!("[{}%{}]:998", ip, scopeid);
 
         let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
@@ -1411,7 +1411,7 @@ impl NetCore {
             .lookup_module(*rpc_task)?
             .lookup_enum_byname(hubris, "RpcReply")?;
 
-        // Hard-coded socket address, based on Hubris configuration
+        // See oxidecomputer/oana for standard Hubris UDP ports
         let target = format!("[{}%{}]:11113", ip, scopeid);
         let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
         let dump_agent_socket = UdpSocket::bind("[::]:0")?;

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4706,6 +4706,7 @@ impl HubrisArchive {
         })
     }
 
+    /// Returns a set of `(start, size)` dump segments
     pub fn dump_segments(
         &self,
         core: &mut dyn crate::core::Core,


### PR DESCRIPTION
This is the third PR in the https://github.com/oxidecomputer/hubris/issues/1217 saga.

Previous PRs are
- https://github.com/oxidecomputer/humpty/pull/4
- https://github.com/oxidecomputer/hubris/pull/1278

This PR brings it home and updates Humility to support the new `dump-agent` UDP protocol, meaning we can read dumps even if `udprpc` (and therefore `hiffy`) are unavailable.

A bunch of this work was discovering the One Abstraction To Rule Them All, which is
```rust
    fn read_generic<I, F>(
        &mut self,
        mut areas: I,
        mut cont: F,
    ) -> Result<Vec<Vec<u8>>>
    where
        I: Iterator<Item = (u8, u32)>,
        F: FnMut(u8, u32, &[u8]) -> Result<bool>;
```

(wait, no, don't run away)

The reason this matters is because we read dump areas in a bunch of _different_ ways:

- Reading headers is unbounded, we keep going until we hit `InvalidArea`
- Reading a single dump area has a known size (fixed by its header)
- Any reading through HIF calls wants to execute multiple calls to `DumpAgent.read_dump` in a single HIF program, to amortize HIF overhead
- Some dump reading wants to provide periodic updates to a progress bar

This function does it all:

- When reading headers, we can provide an infinite iterator as the first argument
- Reading a single dump area takes a bounded iterator
- This function is in a trait, so the implementer can choose to read multiple areas from the iterator and batch them into a single HIF call
- The "keep going" function `cont` also takes a "number of bytes" parameter for progress reporting

I created a new trait named `DumpAgent`, which contains this core function (and a few others).  Then, I implemented the trait for both `HiffyDumpAgent` (i.e. our previous behavior) and `UdpDumpAgent` (our new UDP endpoint).

Finally, `get_dump_agent` selects one or the other, returning a `Box<dyn DumpAgent>` for other functions to use.

Up in the `struct NetCore`, I added a second socket, since `dump-agent` listens on a different port than `udprpc`.  This required adding a new argument to `send` and `recv` specifying _to whom_ you are sending or receiving.