### PR TITLE
Fix check for features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "bitfield 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -5086,8 +5086,8 @@ impl HubrisArchive {
             .manifest
             .task_features
             .get(name)
-            .ok_or_else(|| anyhow!("invalid task {task:?}"))?
-            .contains(&feature.to_string()))
+            .map(|f| f.contains(&feature.to_string()))
+            .unwrap_or(false))
     }
 
     pub fn lookup_peripheral(&self, name: &str) -> Result<u32> {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.6
+humility 0.10.7
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.6
+humility 0.10.7
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.6
+humility 0.10.7
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.6
+humility 0.10.7
 
 ```


### PR DESCRIPTION
This fixes `humility --ip ...` with older images, where `dump_agent` isn't in the feature list because it has no features.