### PR TITLE
Allow humility::msg to capture variables inline; do that more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,7 +1364,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "colored",
  "csv",
  "humility-cmd",
  "humility-core",
@@ -1468,7 +1467,6 @@ dependencies = [
  "anyhow",
  "atty",
  "clap",
- "colored",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -1980,7 +1978,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "colored",
  "humility-cmd",
  "humility-core",
  "humility-doppel",
@@ -2070,7 +2067,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "colored",
  "hif",
  "humility-cmd",
  "humility-core",
@@ -2161,6 +2157,7 @@ dependencies = [
  "humpty",
  "indexmap",
  "indicatif",
+ "log",
  "lzss",
  "num-traits",
  "rand",

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -282,9 +282,8 @@ impl<'a> AuxFlashHandler<'a> {
                 Ok(None) => break,
                 Err(e) => {
                     humility::msg!(
-                        "Failed to load data as TLV-C ({:?}); \
+                        "Failed to load data as TLV-C ({e:?}); \
                          skipping reflash check",
-                        e
                     );
                     break;
                 }
@@ -294,8 +293,7 @@ impl<'a> AuxFlashHandler<'a> {
             if let Ok(Some(chck_slot)) = self.slot_status(slot) {
                 if chck_data == chck_slot {
                     humility::msg!(
-                        "Slot {} is already programmed with our data",
-                        slot
+                        "Slot {slot} is already programmed with our data",
                     );
                     if force {
                         humility::msg!("Reprogramming it anyways!");
@@ -307,7 +305,7 @@ impl<'a> AuxFlashHandler<'a> {
             }
         }
 
-        humility::msg!("erasing slot {}", slot);
+        humility::msg!("erasing slot {slot}");
         self.slot_erase(slot)?;
 
         let slot_size = self.slot_size_bytes()?;
@@ -385,7 +383,7 @@ fn auxflash(context: &mut humility::ExecutionContext) -> Result<()> {
         }
         AuxFlashCommand::Erase { slot } => {
             worker.slot_erase(slot)?;
-            humility::msg!("done erasing slot {}", slot);
+            humility::msg!("done erasing slot {slot}");
         }
         AuxFlashCommand::Read { slot, output, count } => {
             let data = worker.auxflash_read(slot, count)?;

--- a/cmd/bankerase/src/lib.rs
+++ b/cmd/bankerase/src/lib.rs
@@ -62,7 +62,7 @@ fn bankerasecmd(context: &mut humility::ExecutionContext) -> Result<()> {
         None => bail!("no"),
     };
 
-    humility::msg!("attaching with chip set to {:x?}", chip);
+    humility::msg!("attaching with chip set to {chip:x?}");
     let mut c = humility::core::attach_for_flashing(probe, hubris, &chip)?;
     let core = c.as_mut();
 

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -410,9 +410,8 @@ fn dump_via_agent(
 
                 if let Some(overflow) = rval {
                     bail!(
-                        "compresion overflow at address {:#x} by {} bytes",
-                        addr,
-                        overflow,
+                        "compresion overflow at address {addr:#x} \
+                        by {overflow} bytes",
                     );
                 }
 
@@ -684,10 +683,10 @@ fn dump_all(
             };
 
             let dumpfile = (0..)
-                .map(|i| format!("hubris.core.{task_name}.{}", i))
+                .map(|i| format!("hubris.core.{task_name}.{i}"))
                 .find(|f| std::fs::File::open(f).is_err())
                 .unwrap();
-            humility::msg!("dumping {} (area {})", task_name, area);
+            humility::msg!("dumping {task_name} (area {area})");
 
             let mut out = DumpAgentCore::new(HubrisFlashMap::new(hubris)?);
             let started = Some(Instant::now());

--- a/cmd/etm/Cargo.toml
+++ b/cmd/etm/Cargo.toml
@@ -13,4 +13,3 @@ anyhow = { workspace = true }
 csv = { workspace = true }
 parse_int = { workspace = true }
 log = { workspace = true }
-colored = { workspace = true }

--- a/cmd/etm/src/lib.rs
+++ b/cmd/etm/src/lib.rs
@@ -105,7 +105,7 @@ fn etmcmd_probe(core: &mut dyn Core) -> Result<()> {
     }
 
     let etmccr = ETMCCR::read(core)?;
-    humility::msg!("{:#x?}", etmccr);
+    humility::msg!("{etmccr:#x?}");
 
     if !etmccr.has_etmidr() {
         warn!("ETMv1.3 and earlier not supported");
@@ -113,10 +113,10 @@ fn etmcmd_probe(core: &mut dyn Core) -> Result<()> {
     }
 
     let etmidr = ETMIDR::read(core)?;
-    humility::msg!("{:#x?}", etmidr);
+    humility::msg!("{etmidr:#x?}");
 
     let etmccer = ETMCCER::read(core)?;
-    humility::msg!("{:#x?}", etmccer);
+    humility::msg!("{etmccer:#x?}");
 
     Ok(())
 }

--- a/cmd/exec/src/lib.rs
+++ b/cmd/exec/src/lib.rs
@@ -122,16 +122,14 @@ fn exec(context: &mut ExecutionContext) -> Result<()> {
                 .unwrap_quotes(true)
                 .collect::<Vec<_>>();
 
-            humility::msg!("{} {}: executing: '{}' ...", target, cmd, cmdline);
+            humility::msg!("{target} {cmd}: executing: '{cmdline}' ...");
 
             let status = std::process::Command::new(args[0])
                 .args(&args[1..])
                 .status()?;
 
             humility::msg!(
-                "{} {}: done ({})",
-                target,
-                cmd,
+                "{target} {cmd}: done ({})",
                 match status.code() {
                     Some(code) => format!("status code {code}"),
                     None => "terminated by signal".to_string(),

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -116,7 +116,7 @@ fn force_openocd(
     };
 
     let dryrun = |cmd: &std::process::Command| {
-        humility::msg!("would execute: {:?}", cmd);
+        humility::msg!("would execute: {cmd:?}");
     };
 
     let payload = match &config.program {
@@ -141,7 +141,7 @@ fn force_openocd(
     let srec = tempfile::NamedTempFile::new()?;
 
     if let Some(serial) = serial {
-        humility::msg!("specifying serial {}", serial);
+        humility::msg!("specifying serial {serial}");
 
         //
         // In OpenOCD 0.11 dev, hla_serial has been deprecated, and
@@ -178,7 +178,7 @@ fn force_openocd(
 
     if subargs.retain || subargs.dryrun {
         humility::msg!("retaining OpenOCD config as {:?}", conf.path());
-        humility::msg!("retaining srec as {}", srec_path);
+        humility::msg!("retaining srec as {srec_path}");
         conf.keep()?;
         srec.keep()?;
     }
@@ -238,15 +238,13 @@ fn validate(
                         core.run()?;
                         bail!(
                             "image IDs match, but flash contents do not match \
-                            archive contents: {}",
-                            err
+                            archive contents: {err}",
                         );
                     }
 
                     humility::msg!(
                         "image IDs match, but flash contents do not match \
-                        archive contents: {}; reflashing",
-                        err
+                        archive contents: {err}; reflashing",
                     );
                 } else {
                     core.run()?;
@@ -317,7 +315,7 @@ fn flashcmd(context: &mut humility::ExecutionContext) -> Result<()> {
         }
     };
 
-    humility::msg!("attaching with chip set to {:x?}", chip);
+    humility::msg!("attaching with chip set to {chip:x?}");
     let mut c = humility::core::attach_for_flashing(probe, hubris, &chip)?;
     let core = c.as_mut();
 
@@ -380,9 +378,8 @@ fn try_program_auxflash(
                 Ok(())
             }
             Err(e) => bail!(
-                "failed to program auxflash: {:?}; \
+                "failed to program auxflash: {e:?}; \
                  your system may not be functional!",
-                e
             ),
         },
         None => Ok(()),
@@ -403,15 +400,14 @@ fn program_auxflash(
     match worker.active_slot() {
         Ok(Some(i)) => {
             humility::msg!(
-                "auxiliary flash data is already loaded in slot {}; \
+                "auxiliary flash data is already loaded in slot {i}; \
                  skipping programming",
-                i
             );
             return Ok(());
         }
         Ok(None) => (),
         Err(e) => {
-            humility::msg!("Got error while checking active slot: {:?}", e);
+            humility::msg!("Got error while checking active slot: {e:?}");
         }
     };
 

--- a/cmd/hiffy/Cargo.toml
+++ b/cmd/hiffy/Cargo.toml
@@ -12,7 +12,6 @@ parse_int.workspace = true
 indexmap.workspace = true
 idol.workspace = true
 atty.workspace = true
-colored.workspace = true
 
 humility.workspace = true
 humility-cmd.workspace = true

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -309,7 +309,7 @@ fn pretty_print_fields(
         } else {
             format!("{}", field.lo)
         };
-        println!("{:>5} | 0x{:<8x} | {}", range, bits, f);
+        println!("{range:>5} | 0x{bits:<8x} | {f}");
     }
 }
 
@@ -321,7 +321,7 @@ fn monorail_read(
 ) -> Result<()> {
     let reg = parse_reg_or_addr(&reg)?;
     let addr = reg.address();
-    humility::msg!("Reading {} from {:#x}", reg, addr);
+    humility::msg!("Reading {reg} from {addr:#x}");
 
     let op = hubris.get_idol_command("Monorail.read_vsc7448_reg")?;
     let value = humility_cmd_hiffy::hiffy_call(
@@ -337,9 +337,9 @@ fn monorail_read(
             let value = if let Value::Base(Base::U32(v)) = v {
                 v
             } else {
-                bail!("Got bad reflected value: expected U32, got {:?}", v);
+                bail!("Got bad reflected value: expected U32, got {v:?}");
             };
-            println!("{} => {:#x}", reg, value);
+            println!("{reg} => {value:#x}");
 
             // The VSC7448 is configured to return 0x88888888 if a register is
             // read too fast.  This should never happen, because the `monorail`
@@ -353,7 +353,7 @@ fn monorail_read(
             pretty_print_fields(value, reg.fields(), 0);
         }
         Err(e) => {
-            println!("Got error: {}", e);
+            println!("Got error: {e}");
         }
     }
     Ok(())
@@ -368,7 +368,7 @@ fn monorail_write(
 ) -> Result<()> {
     let reg = parse_reg_or_addr(&reg)?;
     let addr = reg.address();
-    humility::msg!("Writing {:#x} to {} at {:#x}", value, reg, addr);
+    humility::msg!("Writing {value:#x} to {reg} at {addr:#x}");
     pretty_print_fields(value, reg.fields(), 0);
 
     let op = hubris.get_idol_command("Monorail.write_vsc7448_reg")?;
@@ -386,11 +386,11 @@ fn monorail_write(
     match value {
         Ok(v) => {
             if !matches!(v, Value::Base(Base::U0)) {
-                bail!("Got unexpected value: expected (), got {:?}", v)
+                bail!("Got unexpected value: expected (), got {v:?}")
             }
         }
         Err(e) => {
-            println!("Got error: {}", e);
+            println!("Got error: {e}");
         }
     }
     Ok(())
@@ -419,7 +419,7 @@ fn parse_phy_register(reg: &str) -> Result<ParsedPhyRegister> {
         return Ok(ParsedPhyRegister {
             page: reg.page_addr().try_into().unwrap(),
             reg: reg.reg_addr(),
-            name: format!("{}", reg),
+            name: format!("{reg}"),
             fields: reg.fields().clone(),
         });
     }
@@ -518,11 +518,11 @@ fn monorail_phy_write(
     match value {
         Ok(v) => {
             if !matches!(v, Value::Base(Base::U0)) {
-                bail!("Got unexpected value: expected (), got {:?}", v)
+                bail!("Got unexpected value: expected (), got {v:?}")
             }
         }
         Err(e) => {
-            println!("Got error: {}", e);
+            println!("Got error: {e}");
         }
     }
     Ok(())
@@ -662,14 +662,14 @@ fn monorail_dump(
         let value = if let Ok(Value::Base(Base::U32(v))) = v {
             v
         } else {
-            bail!("Got bad reflected value: expected U32, got {:?}", v);
+            bail!("Got bad reflected value: expected U32, got {v:?}");
         };
         let addr = format!("{}", start_address as usize + i * 4);
         // XXX this is inefficient
         match parse_reg_or_addr(&addr) {
-            Ok(reg) => println!("{}    {:#010x}", reg, value),
+            Ok(reg) => println!("{reg}    {value:#010x}"),
             Err(e) => {
-                humility::msg!("skipping unknown register at {}: {}", addr, e)
+                humility::msg!("skipping unknown register at {addr}: {e}")
             }
         }
     }
@@ -795,9 +795,9 @@ fn monorail_status(
             "Up" => "up".to_owned().green(),
             "Down" => "down".to_owned().red(),
             "Error" => "err".to_owned().yellow(),
-            s => panic!("Unknown LinkStatus variant {:?}", s),
+            s => panic!("Unknown LinkStatus variant {s:?}"),
         },
-        b => panic!("Could not get bool or enum from {:?}", b),
+        b => panic!("Could not get bool or enum from {b:?}"),
     };
 
     println!("{}", "PORT | MODE    SPEED  DEV     SERDES  LINK |   PHY    MAC LINK  MEDIA LINK".bold());
@@ -849,7 +849,7 @@ fn monorail_status(
                         "--      --     --      --      --  ".dimmed()
                     );
                 } else {
-                    println!("Got unexpected error {}", e);
+                    println!("Got unexpected error {e}");
                 }
             }
         }
@@ -873,7 +873,7 @@ fn monorail_status(
                 if e == "UnconfiguredPort" || e == "NoPhy" {
                     println!("{}", "--       --         --".dimmed());
                 } else {
-                    println!("Got unexpected error {}", e);
+                    println!("Got unexpected error {e}");
                 }
             }
         }
@@ -909,11 +909,11 @@ fn monorail_mac_table(
             }
         }
         Err(e) => {
-            bail!("Got error: {}", e);
+            bail!("Got error: {e}");
         }
     };
 
-    println!("Reading {} MAC addresses...", mac_count);
+    println!("Reading {mac_count} MAC addresses...");
 
     let op = hubris.get_idol_command("Monorail.read_vsc7448_next_mac")?;
     let send = context.get_function("Send", 4)?;
@@ -1004,7 +1004,7 @@ fn monorail_reset_counters(
         &[("port", IdolArgument::Scalar(u64::from(port)))],
         None,
     )?;
-    value.map(|_| ()).map_err(|err| anyhow!("Got error {}", err))
+    value.map(|_| ()).map_err(|err| anyhow!("Got error {err}"))
 }
 
 fn monorail_counters(
@@ -1046,18 +1046,18 @@ fn monorail_counters(
             let s = v.as_struct()?;
             let (rx_mc, rx_uc, rx_bc) = decode_count(&s["rx"]);
             let (tx_mc, tx_uc, tx_bc) = decode_count(&s["tx"]);
-            println!("{} (port {})", "Packet counters:".bold(), port);
+            println!("{} (port {port})", "Packet counters:".bold());
             println!("  Receive:");
-            println!("    Unicast:   {}", rx_uc);
-            println!("    Multicast: {}", rx_mc);
-            println!("    Broadcast:  {}", rx_bc);
+            println!("    Unicast:   {rx_uc}");
+            println!("    Multicast: {rx_mc}");
+            println!("    Broadcast:  {rx_bc}");
             println!("  Transmit:");
-            println!("    Unicast:   {}", tx_uc);
-            println!("    Multicast: {}", tx_mc);
-            println!("    Broadcast:  {}", tx_bc);
+            println!("    Unicast:   {tx_uc}");
+            println!("    Multicast: {tx_mc}");
+            println!("    Broadcast:  {tx_bc}");
         }
         Err(e) => {
-            println!("Got error: {}", e);
+            println!("Got error: {e}");
         }
     }
     Ok(())
@@ -1091,13 +1091,13 @@ fn monorail(context: &mut ExecutionContext) -> Result<()> {
             let re = Regex::new(r"^([A-Z_0-9]+)(\[([0-9]+)\])?$").unwrap();
             let cap = re
                 .captures(&target)
-                .ok_or_else(|| anyhow!("Could not parse {}", target))?;
+                .ok_or_else(|| anyhow!("Could not parse {target}"))?;
             let name = &cap[1];
             let index: Option<u32> =
                 cap.get(3).map(|i| i.as_str().parse().unwrap());
             let tgt = vsc7448_info::MEMORY_MAP
                 .get(name)
-                .ok_or_else(|| anyhow!("Could not find target {}", name))?;
+                .ok_or_else(|| anyhow!("Could not find target {name}"))?;
             let tgt_name = &tgt.0;
             let start_addr: u32 = tgt
                 .1
@@ -1116,8 +1116,7 @@ fn monorail(context: &mut ExecutionContext) -> Result<()> {
             let end_addr = start_addr + tgt_size * 4;
 
             println!(
-                "Dumping target {} ({:#x} -> {:#x})",
-                target, start_addr, end_addr
+                "Dumping target {target} ({start_addr:#x} -> {end_addr:#x})",
             );
             monorail_dump(hubris, core, &mut context, start_addr, end_addr)?
         }
@@ -1154,7 +1153,7 @@ fn monorail_get_info(context: &mut ExecutionContext) -> Result<()> {
     match subargs.cmd {
         Command::Info { reg, value } => {
             let reg = parse_reg_or_addr(&reg)?;
-            println!("Register {}", reg);
+            println!("Register {reg}");
             println!("Register address: {:#x}", reg.address());
 
             if let Some(v) = value {
@@ -1168,13 +1167,13 @@ fn monorail_get_info(context: &mut ExecutionContext) -> Result<()> {
                     } else {
                         format!("{}", field.lo)
                     };
-                    println!(" {:>5} | {}", range, f);
+                    println!(" {range:>5} | {f}");
                 }
             }
         }
         Command::Phy { cmd: PhyCommand::Info { reg } } => {
             let reg: PhyRegister = reg.parse()?;
-            println!("PHY register: {}", reg);
+            println!("PHY register: {reg}");
         }
         _ => panic!("Called monorail_get_info without info subcommand"),
     }

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -95,7 +95,7 @@ fn net_ip(context: &mut humility::ExecutionContext) -> Result<()> {
     )?;
     let v = match value {
         Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {}", e),
+        Err(e) => bail!("Got Hiffy error: {e}"),
     };
     let v = v.as_tuple()?;
     assert_eq!(v.name(), "MacAddress");
@@ -108,7 +108,7 @@ fn net_ip(context: &mut humility::ExecutionContext) -> Result<()> {
         if i > 0 {
             print!(":");
         }
-        print!("{:02x}", byte);
+        print!("{byte:02x}");
     }
     println!();
 
@@ -160,11 +160,11 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
             if let Value::Base(Base::U32(v)) = v {
                 v
             } else {
-                bail!("Got bad reflected value: expected U32, got {:?}", v);
+                bail!("Got bad reflected value: expected U32, got {v:?}");
             }
         }
         Err(e) => {
-            bail!("Got error: {}", e);
+            bail!("Got error: {e}");
         }
     };
 
@@ -176,7 +176,7 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
         (mac_count as u8, false)
     };
 
-    humility::msg!("Reading {} MAC addresses...", mac_count);
+    humility::msg!("Reading {mac_count} MAC addresses...");
 
     let op = hubris.get_idol_command("Net.read_ksz8463_mac")?;
     let send = hiffy_context.get_function("Send", 4)?;
@@ -230,7 +230,7 @@ fn net_mac_table(context: &mut humility::ExecutionContext) -> Result<()> {
             }
         } else {
             // Log the error but keep going for other entries in the table
-            humility::msg!("Got error result: {:?}", r);
+            humility::msg!("Got error result: {r:?}");
         }
     }
     println!(" {} |        {}", "PORT".bold(), "MAC".bold());
@@ -279,7 +279,7 @@ fn net_status(context: &mut humility::ExecutionContext) -> Result<()> {
     )?;
     let v = match value {
         Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {}", e),
+        Err(e) => bail!("Got Hiffy error: {e}"),
     };
     let s = v.as_struct()?;
     assert_eq!(s.name(), "ManagementLinkStatus");
@@ -360,7 +360,7 @@ fn net_counters(context: &mut humility::ExecutionContext) -> Result<()> {
     )?;
     let v = match value {
         Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {}", e),
+        Err(e) => bail!("Got Hiffy error: {e}"),
     };
     let s = v.as_struct()?;
     assert_eq!(s.name(), "ManagementCounters");

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1119,21 +1119,16 @@ fn writes(
 
     let success = |harg, rail: &Option<u8>, cmd| {
         if let Some(rnum) = *rail {
-            humility::msg!(
-                "{}, rail {}: successfully wrote {}",
-                harg,
-                rnum,
-                cmd
-            );
+            humility::msg!("{harg}, rail {rnum}: successfully wrote {cmd}",);
         } else {
-            humility::msg!("{}: successfully wrote {}", harg, cmd);
+            humility::msg!("{harg}: successfully wrote {cmd}");
         }
     };
 
     for (harg, rail) in &hargs {
         if let Some(rnum) = rail {
             if let Err(code) = results[ndx] {
-                bail!("{}: failed to set rail {}: {}", harg, rnum, code);
+                bail!("{harg}: failed to set rail {rnum}: {code}");
             }
 
             ndx += 1;
@@ -1152,9 +1147,9 @@ fn writes(
                 WriteOp::Set | WriteOp::SetBlock(_) => match results[ndx] {
                     Err(code) => {
                         bail!(
-                                "{}: failed to set {}: {}",
-                                harg, cmd, write_func.strerror(code)
-                            )
+                            "{harg}: failed to set {cmd}: {}",
+                            write_func.strerror(code)
+                        )
                     }
                     Ok(_) => {
                         success(harg, rail, cmd);
@@ -1203,7 +1198,7 @@ fn writes(
 
         let mode = match results[ndx] {
             Err(code) => {
-                bail!("bad VOUT_MODE on {}: {}", harg, func.strerror(code));
+                bail!("bad VOUT_MODE on {harg}: {}", func.strerror(code));
             }
             Ok(ref val) => VOUT_MODE::CommandData::from_slice(val).unwrap(),
         };
@@ -1216,10 +1211,7 @@ fn writes(
             if let WriteOp::Modify(size, set) = op {
                 let payload = match results[ndx] {
                     Err(code) => {
-                        bail!(
-                            "failed to read {}: {}",
-                            cmd, func.strerror(code)
-                        );
+                        bail!("failed to read {cmd}: {}", func.strerror(code));
                     }
                     Ok(ref val) => val,
                 };
@@ -1228,8 +1220,8 @@ fn writes(
 
                 if payload.len() != *size {
                     bail!(
-                        "mismatch on {}: expected {}, found {}",
-                        cmd, size, payload.len()
+                        "mismatch on {cmd}: expected {size}, found {}",
+                        payload.len()
                     );
                 }
 
@@ -1270,7 +1262,7 @@ fn writes(
     for (harg, rail) in &hargs {
         if let Some(rnum) = rail {
             if let Err(code) = results[ndx] {
-                bail!("failed to set rail {} on {}: Err({})", rnum, harg, code);
+                bail!("failed to set rail {rnum} on {harg}: Err({code})");
             }
 
             ndx += 1;
@@ -1280,8 +1272,8 @@ fn writes(
             if let WriteOp::Modify(_, _) = op {
                 if let Err(code) = results[ndx] {
                     bail!(
-                        "{}: failed to write {}: {}",
-                        harg, cmd, write_func.strerror(code)
+                        "{harg}: failed to write {cmd}: {}",
+                        write_func.strerror(code)
                     );
                 } else {
                     success(harg, rail, cmd);

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -116,7 +116,7 @@ fn probecmd(context: &mut humility::ExecutionContext) -> Result<()> {
     let mut status = vec![];
 
     let print = |what, val| {
-        humility::msg!("{:>12} => {}", what, val);
+        humility::msg!("{what:>12} => {val}");
     };
 
     let mut statusif = |val, str: &str| {
@@ -412,7 +412,7 @@ fn probecmd(context: &mut humility::ExecutionContext) -> Result<()> {
             );
         }
         if let Some(ufsr) = cfsr.get_ufsr() {
-            humility::msg!("Usage Fault: {:#x?}", ufsr);
+            humility::msg!("Usage Fault: {ufsr:#x?}");
         }
         if let Some(mmfsr) = cfsr.get_mmfsr() {
             humility::msg!(

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -605,7 +605,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
 
             erase(&device, core, &mut context, &sectors)?;
         } else {
-            humility::msg!("will verify {} bytes...", filelen);
+            humility::msg!("will verify {filelen} bytes...");
         }
 
         //
@@ -704,8 +704,7 @@ fn qspi(context: &mut humility::ExecutionContext) -> Result<()> {
                         if r[0] != 0 {
                             let a = offset + (i as u32 * BLOCK_SIZE);
                             humility::msg!(
-                                "block at 0x{:x} failed to verify\n",
-                                a
+                                "block at 0x{a:x} failed to verify\n",
                             );
                         }
                     }

--- a/cmd/registers/src/lib.rs
+++ b/cmd/registers/src/lib.rs
@@ -258,7 +258,7 @@ fn registers(context: &mut humility::ExecutionContext) -> Result<()> {
             // indicate that regions can't be loadwed.)
             //
             if hubris.loaded() {
-                humility::msg!("failed to determine memory regions: {}", err);
+                humility::msg!("failed to determine memory regions: {err}");
             }
 
             BTreeMap::new()
@@ -324,8 +324,7 @@ fn registers(context: &mut humility::ExecutionContext) -> Result<()> {
                     region.tasks[0]
                 } else {
                     humility::msg!(
-                        "multiple tasks map 0x{:x}: {:?}",
-                        val,
+                        "multiple tasks map 0x{val:x}: {:?}",
                         region.tasks
                     );
                     continue;
@@ -347,14 +346,14 @@ fn registers(context: &mut humility::ExecutionContext) -> Result<()> {
                                 does the dump pre-date dumped kernel stacks?"
                             );
                         } else {
-                            humility::msg!("stack unwind failed: {:?} ", e);
+                            humility::msg!("stack unwind failed: {e:?}");
                         }
 
                         continue;
                     }
                 }
             } else {
-                humility::msg!("unknown region for SP 0x{:08x}", val);
+                humility::msg!("unknown region for SP 0x{val:08x}");
             }
         }
     }

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -387,11 +387,7 @@ fn rencm_attached(
                                     jobaddr(&job),
                                 );
                             } else {
-                                bail!(
-                                    "missing result at {}: {:?}",
-                                    rndx,
-                                    results
-                                );
+                                bail!("missing result at {rndx}: {results:?}");
                             }
                         }
 
@@ -401,7 +397,7 @@ fn rencm_attached(
                     let job = match calls[rndx] {
                         Some(ndx) => work[ndx],
                         None => {
-                            bail!("spurious result at {}: {:?}", rndx, results);
+                            bail!("spurious result at {rndx}: {results:?}");
                         }
                     };
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -934,7 +934,7 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         let results = context.run(core, ops.as_slice(), None)?;
 
         let crc = word_result(&results[1], "CRC")?;
-        humility::msg!("{} at {} has CRC 0x{:<08x}", d, &hargs, crc);
+        humility::msg!("{d} at {hargs} has CRC 0x{crc:<08x}");
 
         return Ok(());
     }
@@ -950,7 +950,7 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         let results = context.run(core, ops.as_slice(), None)?;
 
         let nslots = word_result(&results[1], "available slots")?;
-        humility::msg!("{} at {} has {} slots available", d, &hargs, nslots);
+        humility::msg!("{d} at {hargs} has {nslots} slots available");
 
         return Ok(());
     }
@@ -1023,7 +1023,7 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         }
 
         let nslots = word_result(&results[3], "available slots")?;
-        humility::msg!("{} NVM slots remain", nslots);
+        humility::msg!("{nslots} NVM slots remain");
 
         //
         // Check that the number of available slots seems sane -- and (for
@@ -1044,17 +1044,17 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         let crc = word_result(&results[5], "CRC")?;
 
         if crc == hex.crc {
-            let msg = format!("image CRC (0x{:08x}) matches OTP CRC", crc);
+            let msg = format!("image CRC (0x{crc:08x}) matches OTP CRC");
 
             if subargs.check {
-                humility::msg!("{}", msg);
+                humility::msg!("{msg}");
                 return Ok(());
             }
 
             if !subargs.force {
-                bail!("{}; use --force to force", msg);
+                bail!("{msg}; use --force to force");
             } else {
-                humility::msg!("{}; flashing anyway", msg);
+                humility::msg!("{msg}; flashing anyway");
             }
         } else if subargs.check {
             bail!(
@@ -1067,11 +1067,11 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         let nbytes = hex.data.iter().fold(0, |n, v| n + v.len());
 
         if subargs.dryrun {
-            humility::msg!("would flash {} bytes", nbytes);
+            humility::msg!("would flash {nbytes} bytes");
             return Ok(());
         }
 
-        humility::msg!("flashing {} bytes", nbytes);
+        humility::msg!("flashing {nbytes} bytes");
 
         let started = Instant::now();
         let bar = ProgressBar::new(nbytes as u64);
@@ -1189,7 +1189,7 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
                     Some(ref bank)
                         if *bank != RendmpBankStatus::BankUnaffected =>
                     {
-                        humility::msg!("bank {}: {}", ndx, bank);
+                        humility::msg!("bank {ndx}: {bank}");
                     }
                     _ => {}
                 }
@@ -1242,7 +1242,7 @@ fn rendmp(context: &mut humility::ExecutionContext) -> Result<()> {
         let mut file =
             OpenOptions::new().write(true).create_new(true).open(&filename)?;
 
-        humility::msg!("dumping device memory to {}", filename);
+        humility::msg!("dumping device memory to {filename}");
 
         bar.set_style(ProgressStyle::default_bar().template(
             "humility: dumping device memory \

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -56,7 +56,7 @@ fn reset(context: &mut humility::ExecutionContext) -> Result<()> {
             "There was an error when resetting. \
             The chip may be in an unknown state!"
         );
-        humility::msg!("Full error: {:x?}", r);
+        humility::msg!("Full error: {r:x?}");
     }
 
     Ok(())

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -216,9 +216,9 @@ fn ringbuf(context: &mut humility::ExecutionContext) -> Result<()> {
         if let Some(def) = def {
             if let Err(e) = ringbuf_dump(hubris, core, def, v.1) {
                 if subargs.verbose {
-                    humility::msg!("ringbuf dump failed: {:?}", e);
+                    humility::msg!("ringbuf dump failed: {e:?}");
                 } else {
-                    humility::msg!("ringbuf dump failed: {}", e);
+                    humility::msg!("ringbuf dump failed: {e}");
                 }
             }
         } else {

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -164,8 +164,7 @@ fn rpc_listen_one(
                 // If humility wasn't run as root, we can't listen on port 8;
                 // print a warning message instead of erroring out entirely.
                 humility::msg!(
-                    "Cannot listen on port {}; permission denied",
-                    port
+                    "Cannot listen on port {port}; permission denied",
                 );
                 return Ok(Default::default());
             } else {
@@ -299,9 +298,8 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
     let timeout = Duration::from_millis(rpc_args.timeout as u64);
     let ports = [8, 8888];
     humility::msg!(
-        "listening for {} seconds on ports {:?}...",
+        "listening for {} seconds on ports {ports:?}...",
         timeout.as_secs(),
-        ports
     );
 
     let threads = ports

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -99,9 +99,7 @@ fn dump_spd(
         let mut output = File::create(filename)?;
         output.write_all(buf)?;
         humility::msg!(
-            "wrote SPD data for address {} as binary to {}",
-            addr,
-            filename
+            "wrote SPD data for address {addr} as binary to {filename}"
         );
         return Ok(());
     }
@@ -153,7 +151,7 @@ fn dump_spd(
             let c = buf[offs + i] as char;
 
             if c.is_ascii() && !c.is_ascii_control() {
-                print!("{}", c);
+                print!("{c}");
             } else {
                 print!(".");
             }
@@ -204,9 +202,8 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
 
         if spd_data.size % SPD_SIZE != 0 {
             bail!(
-                "SPD_DATA is {} bytes; expected even multiple of {}",
+                "SPD_DATA is {} bytes; expected even multiple of {SPD_SIZE}",
                 spd_data.size,
-                SPD_SIZE
             );
         }
 
@@ -365,13 +362,13 @@ fn spd(context: &mut humility::ExecutionContext) -> Result<()> {
                         buf.extend_from_slice(val);
                     }
                     Err(_) => {
-                        bail!("failed to read SPD: {:?}", results);
+                        bail!("failed to read SPD: {results:?}");
                     }
                 }
             }
 
             if buf.len() != SPD_SIZE {
-                bail!("bad SPD length ({} bytes): {:?}", buf.len(), results);
+                bail!("bad SPD length ({} bytes): {results:?}", buf.len());
             }
 
             dump_spd(&subargs, addr, &buf, header)?;

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -108,7 +108,7 @@ pub fn spi_task(
     peripheral: Option<u8>,
 ) -> Result<HubrisTask> {
     let lookup = |peripheral| {
-        let spi = format!("spi{}", peripheral);
+        let spi = format!("spi{peripheral}");
         let tasks = hubris.lookup_feature(&spi)?;
         let tasks: Vec<HubrisTask> = tasks
             .into_iter()
@@ -126,7 +126,7 @@ pub fn spi_task(
             0 => Ok(None),
             1 => Ok(Some(tasks[0])),
             _ => {
-                bail!("more than one task has {}", spi);
+                bail!("more than one task has {spi}");
             }
         }
     };
@@ -135,7 +135,7 @@ pub fn spi_task(
         match lookup(peripheral)? {
             Some(task) => task,
             None => {
-                bail!("SPI peripheral {} not found", peripheral);
+                bail!("SPI peripheral {peripheral} not found");
             }
         }
     } else {
@@ -194,7 +194,7 @@ fn spi(context: &mut humility::ExecutionContext) -> Result<()> {
         if let Ok(device) = parse_int::parse::<u8>(&device) {
             ops.push(Op::Push(device));
         } else {
-            bail!("illegal device {}", device);
+            bail!("illegal device {device}");
         }
     } else {
         // Device 0
@@ -213,7 +213,7 @@ fn spi(context: &mut humility::ExecutionContext) -> Result<()> {
             if let Ok(val) = parse_int::parse::<u8>(byte) {
                 arr.push(val);
             } else {
-                bail!("invalid byte {}", byte)
+                bail!("invalid byte {byte}")
             }
         }
 

--- a/cmd/tasks/Cargo.toml
+++ b/cmd/tasks/Cargo.toml
@@ -9,7 +9,6 @@ clap.workspace = true
 anyhow.workspace = true
 num-traits.workspace = true
 log.workspace = true
-colored.workspace = true
 parse_int.workspace = true
 
 humility.workspace = true

--- a/cmd/update/src/lib.rs
+++ b/cmd/update/src/lib.rs
@@ -81,10 +81,7 @@ fn update(context: &mut humility::ExecutionContext) -> Result<()> {
         Err(e) => bail!("Hiffy error getting block size {}", e),
     };
 
-    humility::msg!(
-        "Starting update using an update block size of {}",
-        blk_size
-    );
+    humility::msg!("Starting update using an update block size of {blk_size}");
     humility::msg!("(Erase may take a moment)");
     let binary_contents = std::fs::read(&subargs.path)?;
 

--- a/cmd/vpd/Cargo.toml
+++ b/cmd/vpd/Cargo.toml
@@ -16,7 +16,6 @@ tlvc.workspace = true
 tlvc-text.workspace = true
 zerocopy.workspace = true
 indicatif.workspace = true
-colored.workspace = true
 
 humility-cmd.workspace = true
 humility-hiffy.workspace = true

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -327,7 +327,7 @@ fn vpd_write(
     if subargs.erase {
         humility::msg!("successfully erased VPD");
     } else {
-        humility::msg!("successfully wrote {} bytes of VPD", offset);
+        humility::msg!("successfully wrote {offset} bytes of VPD");
     }
 
     Ok(())

--- a/cmd/vsc7448/src/lib.rs
+++ b/cmd/vsc7448/src/lib.rs
@@ -207,7 +207,7 @@ impl<'a> Vsc7448<'a> {
             .as_ref()
             .map_err(|e| anyhow!("Got error code: {}", e))?;
         if r.len() != 8 {
-            bail!("wrong length read: {:x?}", r);
+            bail!("wrong length read: {r:x?}");
         }
         Ok(u32::from_be_bytes(r[4..].try_into().unwrap()))
     }
@@ -236,7 +236,7 @@ impl<'a> Vsc7448<'a> {
     // Configures GPIOs as MIIM alternate functions (see Table 270 in VSC7448
     // datasheet for details)
     fn set_miim_gpios(&mut self, miim: u8) -> Result<()> {
-        humility::msg!("Configuring MIIM{} alt gpios", miim);
+        humility::msg!("Configuring MIIM{miim} alt gpios");
         let gpio_reg = "GPIO_ALT1[0]".parse::<TargetRegister>()?.address();
         match miim {
             0 => Ok(()),
@@ -251,11 +251,11 @@ impl<'a> Vsc7448<'a> {
             bail!("Invalid phy address {} (must be < 32)", phy.phy);
         }
         if reg >= 32 {
-            bail!("Invalid register address {} (must be < 32)", reg);
+            bail!("Invalid register address {reg} (must be < 32)");
         }
         // Switch pages every time, since it's cheap and easier than restoring
         // the page when done _or_ whenever exiting early
-        humility::msg!("Switching to page {}", page);
+        humility::msg!("Switching to page {page}");
         self.miim_write_inner(
             phy, 0,  // STANDARD
             31, // PAGE
@@ -292,12 +292,12 @@ impl<'a> Vsc7448<'a> {
             bail!("Invalid phy address {} (must be < 32)", phy.phy);
         }
         if reg >= 32 {
-            bail!("Invalid register address {} (must be < 32)", reg);
+            bail!("Invalid register address {reg} (must be < 32)");
         }
         // Switch pages every time, since it's cheap and easier than restoring
         // the page when done _or_ whenever exiting early
         if switch_page {
-            humility::msg!("Switching to page {}", page);
+            humility::msg!("Switching to page {page}");
             self.miim_write_inner(
                 phy, 0,  // STANDARD
                 31, // PAGE
@@ -340,7 +340,7 @@ fn vsc7448(context: &mut humility::ExecutionContext) -> Result<()> {
         Command::Read { reg } => {
             let reg = parse_reg_or_addr(&reg)?;
             let addr = reg.address();
-            humility::msg!("Reading {} from 0x{:x}", reg, addr);
+            humility::msg!("Reading {reg} from 0x{addr:x}");
             let value = vsc.read(addr)?;
             println!("{} => 0x{:x}", reg, value);
             if value == 0x88888888 {
@@ -354,7 +354,7 @@ fn vsc7448(context: &mut humility::ExecutionContext) -> Result<()> {
         Command::Write { reg, value } => {
             let reg = parse_reg_or_addr(&reg)?;
             let addr = reg.address();
-            humility::msg!("Writing 0x{:x} to {} at 0x{:x}", value, reg, addr);
+            humility::msg!("Writing 0x{value:x} to {reg} at 0x{addr:x}");
             pretty_print_fields(value, reg.fields());
 
             vsc.write(addr, value)?;

--- a/humility-arch-cortex/src/tpiu.rs
+++ b/humility-arch-cortex/src/tpiu.rs
@@ -161,7 +161,7 @@ fn tpiu_next_state(state: TPIUState, byte: u8, offset: usize) -> TPIUState {
         }
 
         TPIUState::FramingSyncing(next) if byte != sync[next] => {
-            humility::msg!("TPIU framing derailed at offset {}", offset);
+            humility::msg!("TPIU framing derailed at offset {offset}");
             TPIUState::Searching
         }
 
@@ -556,7 +556,7 @@ pub fn tpiu_ingest(
         }
     }
 
-    humility::msg!("{} valid TPIU frames", nvalid);
+    humility::msg!("{nvalid} valid TPIU frames");
 
     Ok(())
 }

--- a/humility-cmd/src/test.rs
+++ b/humility-cmd/src/test.rs
@@ -263,7 +263,7 @@ impl<'a> TestRun<'a> {
 
             TestToken::Done => {
                 let result = TestRunResult::from(tokens[1]);
-                humility::msg!("tests completed: {}", result);
+                humility::msg!("tests completed: {result}");
                 self.result = Some(result);
                 TestToken::None
             }
@@ -359,7 +359,7 @@ impl<'a> TestRun<'a> {
         writeln!(out, "==== Test results")?;
         writeln!(out, "{:#?}", self.results)?;
 
-        humility::msg!("test output dumped to {}", filename);
+        humility::msg!("test output dumped to {filename}");
 
         Ok(())
     }

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -1462,7 +1462,7 @@ pub fn attach_to_probe(probe: &str) -> Result<Box<dyn Core>> {
                 let probe = probe_rs::Probe::open(selector)?;
                 let name = probe.get_name();
 
-                crate::msg!("Opened {} via {}", vidpid, name);
+                crate::msg!("Opened {vidpid} via {name}");
                 Ok(Box::new(UnattachedCore::new(probe, name, vid, pid, serial)))
             }
             Err(_) => Err(anyhow!("unrecognized probe: {}", probe)),
@@ -1512,7 +1512,7 @@ pub fn attach_to_chip(
                 None => (probe.attach("armv7m")?, false),
             };
 
-            crate::msg!("attached via {}", name);
+            crate::msg!("attached via {name}");
 
             Ok(Box::new(ProbeCore::new(
                 session,
@@ -1584,7 +1584,7 @@ pub fn attach_to_chip(
                     None => (probe.attach("armv7m")?, false),
                 };
 
-                crate::msg!("attached to {} via {}", vidpid, name);
+                crate::msg!("attached to {vidpid} via {name}");
 
                 Ok(Box::new(ProbeCore::new(
                     session,
@@ -1596,7 +1596,7 @@ pub fn attach_to_chip(
                     can_flash,
                 )))
             }
-            Err(_) => Err(anyhow!("unrecognized probe: {}", probe)),
+            Err(_) => Err(anyhow!("unrecognized probe: {probe}")),
         },
     }
 }

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4881,7 +4881,7 @@ impl HubrisArchive {
         let mut file =
             OpenOptions::new().write(true).create_new(true).open(&filename)?;
 
-        msg!("dumping to {}", filename);
+        msg!("dumping to {filename}");
 
         file.iowrite_with(header, ctx)?;
 

--- a/humility-core/src/lib.rs
+++ b/humility-core/src/lib.rs
@@ -34,25 +34,33 @@ extern crate num_derive;
 #[macro_export]
 macro_rules! msg {
     ($fmt:expr) => ({
-        eprintln!(concat!("humility: ", $fmt));
+        let s = format!($fmt);
+        eprintln!("humility: {s}");
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        eprintln!(concat!("humility: ", $fmt), $($arg)*);
+        let s = format!($fmt, $($arg)*);
+        eprintln!("humility: {}", s)
     });
 }
 
 #[macro_export]
 macro_rules! warn {
     ($fmt:expr) => ({
-        use colored::Colorize;
+        use $crate::__private::Colorize;
         eprint!("humility: {}: ", "WARNING".red());
         eprintln!($fmt);
     });
     ($fmt:expr, $($arg:tt)*) => ({
-        use colored::Colorize;
+        use $crate::__private::Colorize;
         eprint!("humility: {}: ", "WARNING".red());
         eprintln!($fmt, $($arg)*);
     });
+}
+
+// Not public API. Referenced by macro-generated code
+#[doc(hidden)]
+pub mod __private {
+    pub use colored::Colorize;
 }
 
 pub struct ExecutionContext {
@@ -111,7 +119,7 @@ impl ExecutionContext {
                 let env = match Environment::from_file(env, target) {
                     Ok(e) => e,
                     Err(err) => {
-                        msg!("failed to match environment: {:?}", err);
+                        msg!("failed to match environment: {err:?}");
                         std::process::exit(1);
                     }
                 };
@@ -144,7 +152,7 @@ impl ExecutionContext {
                     cli.archive = match env.archive(&cli.archive_name) {
                         Ok(a) => Some(a),
                         Err(e) => {
-                            msg!("Failed to get archive: {}", e);
+                            msg!("Failed to get archive: {e}");
                             std::process::exit(1);
                         }
                     }
@@ -158,7 +166,7 @@ impl ExecutionContext {
                     let targets = match Environment::targets(env) {
                         Ok(targets) => targets,
                         Err(err) => {
-                            msg!("failed to parse environment: {:?}", err);
+                            msg!("failed to parse environment: {err:?}");
                             std::process::exit(1);
                         }
                     };

--- a/humility-dump-agent/Cargo.toml
+++ b/humility-dump-agent/Cargo.toml
@@ -16,6 +16,7 @@ rand.workspace = true
 zerocopy.workspace = true
 lzss.workspace = true
 hif.workspace = true
+log.workspace = true
 
 humility.workspace = true
 humility-hiffy.workspace = true

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -353,6 +353,6 @@ pub fn attach_net(
     timeout: Duration,
 ) -> Result<Box<dyn Core>> {
     let core = NetCore::new(ip, hubris, timeout)?;
-    msg!("connecting to {}", ip);
+    msg!("connecting to {ip}");
     Ok(Box::new(core))
 }

--- a/tests/cmd/registers-s/registers-s.flash-ram-mismatch.0.stderr
+++ b/tests/cmd/registers-s/registers-s.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address. 
+humility: stack unwind failed: Do not have unwind info for the given address.

--- a/tests/cmd/registers-s/registers-s.in_bootloader.0.stderr
+++ b/tests/cmd/registers-s/registers-s.in_bootloader.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address. 
+humility: stack unwind failed: Do not have unwind info for the given address.

--- a/tests/cmd/registers-s/registers-s.spoopy.0.stderr
+++ b/tests/cmd/registers-s/registers-s.spoopy.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address. 
+humility: stack unwind failed: Do not have unwind info for the given address.


### PR DESCRIPTION
Previously, `humility::msg` could not capture variables because it used `concat!` to build the format string.

Also, secretly re-exports `colored`, so that downstream crates don't have to use it themselves.