### PR TITLE
More remote dumping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.10"
+version = "0.10.11"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.11"
+version = "0.10.12"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -57,6 +57,11 @@ fn stackmargin(context: &mut ExecutionContext) -> Result<()> {
         let offs = i as usize * task.size;
         let addr = base + offs as u32;
         core.read_8(addr, &mut taskblock[offs..offs + task.size])?;
+    } else if core.is_net() {
+        humility::msg!(
+            "skipping supervisor because we are reading over the network"
+        );
+        core.read_8(base + task.size as u32, &mut taskblock[task.size..])?;
     } else {
         core.read_8(base, &mut taskblock)?;
     }
@@ -87,11 +92,20 @@ fn stackmargin(context: &mut ExecutionContext) -> Result<()> {
             }
         }
 
+        let module = hubris.lookup_module(HubrisTask::Task(i))?;
+
+        if core.is_net() && i == 0 {
+            println!(
+                "{:2} {:18} [cannot read supervisor memory remotely]",
+                i, module.name
+            );
+            continue;
+        }
+
         let offs = i as usize * task.size;
         let daddr = taskblock32(offs + descriptor as usize);
         let initial = core.read_word_32(daddr + initial_stack)?;
 
-        let module = hubris.lookup_module(HubrisTask::Task(i))?;
         let region = find(initial)?;
 
         if region.tasks.len() != 1 || region.tasks[0] != module.task {

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -96,7 +96,7 @@ fn stackmargin(context: &mut ExecutionContext) -> Result<()> {
 
         if core.is_net() && i == 0 {
             println!(
-                "{:2} {:18} [cannot read supervisor memory remotely]",
+                "{:2} {:18} unknown (cannot read supervisor memory remotely)",
                 i, module.name
             );
             continue;

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -281,7 +281,7 @@ fn tasks(context: &mut ExecutionContext) -> Result<()> {
             "system time = {}",
             ticks
                 .map(|t| t.to_string())
-                .unwrap_or_else(|| "unknown".to_owned())
+                .unwrap_or_else(|| "unavailable-via-net".to_owned())
         );
         println!("{:2} {:21} {:>8} {:3} {:9}",
             "ID", "TASK", "GEN", "PRI", "STATE");

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -636,7 +636,7 @@ fn explain_recv(
         // bit.
         let irqnums = if let Some(irqs) = irqs {
             irqs.iter()
-                .filter(|&&(m, _)| m == i)
+                .filter(|&&(m, _)| m == bitmask)
                 .map(|&(_, n)| n)
                 .collect::<Vec<_>>()
         } else {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3594,9 +3594,10 @@ impl HubrisArchive {
     ) -> Result<Option<HubrisTask>> {
         //
         // If this is a dump and it only contains a single task, there is
-        // no current task.
+        // no current task.  If this is an online task, then we can't read
+        // kernel memory remotely, so we can't tell.
         //
-        if self.task_dump.is_some() {
+        if self.task_dump.is_some() || core.is_net() {
             return Ok(None);
         }
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2831,7 +2831,7 @@ impl HubrisArchive {
                             .iter()
                             .position(|n| n == name)
                         {
-                            Some(i) => i.try_into().unwrap(),
+                            Some(i) => 1 << i,
                             None => bail!(
                                 "could not find notification '{name}' \
                                  (options are {:?})",

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -152,6 +152,7 @@ impl NetCore {
                         execute: false,
                         device: false,
                         dma: false,
+                        external: false,
                     },
                     size: task_t.size as u32,
                     mapsize: task_t.size as u32,

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.10
+humility 0.10.11
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.10
+humility 0.10.11
 
 ```
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.11
+humility 0.10.12
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.11
+humility 0.10.12
 
 ```
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
@@ -84,7 +84,7 @@ ID TASK                       GEN PRI STATE
                     descriptor: 0x8004434 (&kern::descs::TaskDesc)
                 }
 
- 2 usart_driver                 0   2 recv, notif: usart-irq
+ 2 usart_driver                 0   2 recv, notif: usart-irq(irq27)
    |
    +--->  0x20000ab8 0x0800633e userlib::sys_recv_stub
    |                 @ /hubris/sys/userlib/src/lib.rs:333

--- a/tests/cmd/tasks/tasks.v6.stdout
+++ b/tests/cmd/tasks/tasks.v6.stdout
@@ -2,5 +2,5 @@ system time = 42126
 ID TASK                       GEN PRI STATE    
  0 jefe                         0   0 recv, notif: timer(T+74) fault
  1 sys                          0   1 recv
- 2 usart_driver                 0   2 recv, notif: usart-irq
+ 2 usart_driver                 0   2 recv, notif: usart-irq(irq27)
  3 idle                         0   5 RUNNING

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.10
+humility 0.10.11
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.10
+humility 0.10.11
 
 ```

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.11
+humility 0.10.12
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.11
+humility 0.10.12
 
 ```


### PR DESCRIPTION
This PR updates `humility tasks` and `humility stackmargin` to (mostly) work over the network:
```console
% humility tasks
humility: connecting to fe80::c1d:ddff:fef8:fb69%en0
humility: reading tasks remotely; state may not be consistent
system time = unknown
ID TASK                       GEN PRI STATE
 0 jefe                         ?   0 [cannot read supervisor memory]
 1 sys                          0   1 recv
 2 i2c_driver                   0   2 recv
 3 packrat                      0   3 recv
 4 user_leds                    0   5 recv
 5 dump_agent                   0   6 wait: reply from jefe/gen0
 6 gimlet_seq                   0   2 recv
 7 pong                         0   8 recv, notif: timer(T=4746000)
 8 uartecho                     0   3 notif: usart-irq(irq38)
 9 host_sp_comms                0   8 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
10 hiffy                        0   7 notif: bit31(T=4745909)
11 hf                           0   6 notif: bit31(T=4745755)
12 hash_driver                  0   2 recv
13 net                          0   3 recv, notif: eth-irq(irq61) wake-timer(T=4750030)
14 udprpc                       0   6 notif: socket
15 udpecho                      0   4 notif: socket
16 udpbroadcast                 0   6 notif: bit31(T=4746004)
17 control_plane_agent          0   7 recv, notif: usart-irq(irq37) socket timer
18 sensor                       0   5 recv, notif: timer(T=4746001)
19 sprot                        0   5 recv
20 validate                     0   3 recv
21 caboose_reader               0   2 recv
22 idle                         0   9 ready
23 rng_driver                   0   6 recv
24 update_server                0   3 recv

% humility stackmargin
humility: connecting to fe80::c1d:ddff:fef8:fb69%en0
humility: skipping supervisor because we are reading over the network
ID TASK                STACKBASE  STACKSIZE   MAXDEPTH     MARGIN
 0 jefe               unknown (cannot read supervisor memory remotely)
 1 sys                0x24040800        896        192        704
 2 i2c_driver         0x2403e800        896        456        440
 3 packrat            0x2403f000        896        304        592
 4 user_leds          0x24040c00        896        272        624
 5 dump_agent         0x24002000       2400       1544        856
 6 gimlet_seq         0x24041000        896        296        600
 7 pong               0x24041400        896        216        680
 8 uartecho           0x2403a000       2048        224       1824
 9 host_sp_comms      0x24008000       2048        864       1184
10 hiffy              0x24020000       2048        608       1440
11 hf                 0x2403f800       1920        768       1152
12 hash_driver        0x2403b000       2048        912       1136
13 net                0x24010000       6040       4488       1552
14 udprpc             0x24004000       4096       2416       1680
15 udpecho            0x24006000       4096        408       3688
16 udpbroadcast       0x24038000       4096        440       3656
17 control_plane_agent 0x24028000       4096       1840       2256
18 sensor             0x24040000       1024        192        832
19 sprot              0x24030000      16384        968      15416
20 validate           0x2403c000       1024        176        848
21 caboose_reader     0x24041800        896        280        616
22 idle               0x24041e00        256        256          0
23 rng_driver         0x24041c00        256        192         64
24 update_server      0x2403d000       2048       1296        752
```

Because supervisor memory can't be read remotely, the supervisor is special-cased in both of these subcommands.

In addition, the PR fixes a long-standing bug with how we matched up Hubris notifications to hardware IRQs.  I noticed a suspicious line when reading the output of `humility tasks`:
```
1 9 host_sp_comms                0   8 recv, notif: jefe-state-change(irq82) usart-irq multitimer control-plane-agent
```
`jefe` does not have a hardware interrupt; `irq82` should be associated with `usart-irq`!

It turns out that we were handling named notifications wrong (storing `i` instead of `1 << i`); this fix affects a small number of dumps from the test suite.