### PR TITLE
Add abstraction and `net` support to `humility pmbus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,6 +1627,7 @@ dependencies = [
  "humility-core",
  "humility-hiffy",
  "humility-i2c",
+ "humility-idol",
  "indexmap",
  "parse_int",
  "pmbus",

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -18,3 +18,4 @@ humility-cmd.workspace = true
 humility-cli.workspace = true
 humility-hiffy.workspace = true
 humility-i2c.workspace = true
+humility-idol.workspace = true

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1720,6 +1720,7 @@ impl PmbusWorker for IdolWorker<'_> {
             .find(|(_i, dev)| {
                 &dev.port == harg.port
                     && dev.controller == harg.controller
+                    && Some(dev.address) == harg.address
                     && dev.mux.and_then(|mux| dev.segment.map(|s| (mux, s)))
                         == harg.mux
             })

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1887,7 +1887,7 @@ impl PmbusWorker for IdolWorker<'_> {
         // Inject synthetic rail selection results into the result array, since
         // that's expected by the caller.
         let mut out_with_rail = vec![];
-        assert_eq!(out.len(), self.command_is_block_read.len());
+        assert_eq!(out.len(), self.command_has_rail.len());
         for (out, b) in
             out.into_iter().zip(std::mem::take(&mut self.command_has_rail))
         {

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1599,6 +1599,14 @@ fn pmbus(context: &mut ExecutionContext) -> Result<()> {
         return Ok(());
     }
 
+    pmbus_main(&subargs, hubris, &mut worker)
+}
+
+fn pmbus_main(
+    subargs: &PmbusArgs,
+    hubris: &HubrisArchive,
+    worker: &dyn PmbusWorker,
+) -> Result<()> {
     let hargs = match (&subargs.rail, &subargs.device) {
         (Some(rails), None) => {
             if rails.len() > 1 {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -256,7 +256,7 @@ pub struct HubrisConfigSensorSensor {
     sensors: BTreeMap<String, usize>,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 pub struct HubrisI2cPort {
     pub name: String,
     pub index: u8,

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1132,8 +1132,7 @@ impl<'a> HiffyContext<'a> {
         }
 
         if core.is_net() {
-            let results = self.rpc_results.clone();
-            self.rpc_results = Vec::new();
+            let results = std::mem::take(&mut self.rpc_results);
             self.state = State::ResultsConsumed;
             return Ok(results);
         }


### PR DESCRIPTION
`humility pmbus` directly constructs I2C commands and executes them on-device.

Unfortunately, raw I2C commands can't be executed over the network.

The PR creates a trait for "a thing which does PMBus work", then implements that trait for both
- the existing raw I2C operations
- Idol operations (implemented in https://github.com/oxidecomputer/hubris/pull/1340)

All of the code in `humility pmbus` is refactored to use this trait, meaning it works transparently with both debugger and network connectivity.