### PR TITLE
Renesas per-phase check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,7 @@ dependencies = [
  "humility-hiffy",
  "humility-i2c",
  "humility-idol",
+ "humility-pmbus",
  "indexmap",
  "parse_int",
  "pmbus",
@@ -1775,6 +1776,7 @@ dependencies = [
  "humility-hiffy",
  "humility-i2c",
  "humility-idol",
+ "humility-pmbus",
  "indicatif",
  "num-derive",
  "num-traits",
@@ -2183,6 +2185,14 @@ dependencies = [
  "humility-core",
  "humility-dump-agent",
  "humpty",
+]
+
+[[package]]
+name = "humility-pmbus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "humility-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.18"
+version = "0.10.19"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "humility-jefe",
     "humility-log",
     "humility-net-core",
+    "humility-pmbus",
     "humility-stack",
     "cmd/apptable",
     "cmd/auxflash",
@@ -135,6 +136,7 @@ humility-jefe = { path = "./humility-jefe" }
 humility_load_derive = { path = "./load_derive" }
 humility-log = { path = "./humility-log" }
 humility-net-core = { path = "./humility-net-core" }
+humility-pmbus = { path = "./humility-pmbus" }
 humility-stack = { path = "./humility-stack" }
 cmd-apptable = { path = "./cmd/apptable", package = "humility-cmd-apptable" }
 cmd-auxflash = { path = "./cmd/auxflash", package = "humility-cmd-auxflash" }

--- a/README.md
+++ b/README.md
@@ -2175,6 +2175,20 @@ controller read temperature: 0°C
 ```
 (In the example above, there have been no faults so the blackbox is empty)
 
+To check individual phases for errors, use the `--phase-check` subcommand:
+```console
+$ humility rendmp --phase-check --device=0x5c
+humility: attached to 0483:3754:000D00344741500820383733 via ST-Link V3
+Phase check for ISL68221 at 0x5c
+PHASE |   VOUT   |   IOUT   |   TEMP   | RAIL
+------|----------|----------|----------|----------
+ 0    |   0.451V | -55.600A | 26.000°C | VPP_ABCD
+ 1    |   0.447V | -55.200A | 24.000°C | VPP_EFGH
+ 2    |   0.441V |   1.100A |  0.000°C | V1P8_SP3
+```
+
+This must be run with the system in the A2 power state.
+
 
 ### `humility repl`
 

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -14,8 +14,9 @@ indexmap.workspace = true
 parse_int.workspace = true
 
 humility.workspace = true
-humility-cmd.workspace = true
 humility-cli.workspace = true
+humility-cmd.workspace = true
 humility-hiffy.workspace = true
 humility-i2c.workspace = true
 humility-idol.workspace = true
+humility-pmbus.workspace = true

--- a/cmd/rendmp/Cargo.toml
+++ b/cmd/rendmp/Cargo.toml
@@ -16,9 +16,10 @@ parse_int.workspace = true
 pmbus.workspace = true
 zerocopy.workspace = true
 
-humility-cmd.workspace = true
 humility-cli.workspace = true
+humility-cmd.workspace = true
 humility-hiffy.workspace = true
-humility-idol.workspace = true
 humility-i2c.workspace = true
+humility-idol.workspace = true
+humility-pmbus.workspace = true
 humility.workspace = true

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -906,7 +906,7 @@ impl std::fmt::Display for SupportedDevice {
             SupportedDevice::ISL68224 => "ISL68224",
             SupportedDevice::RAA229618 => "RAA229618",
         };
-        write!(f, "{s}",)
+        write!(f, "{s}")
     }
 }
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1778,7 +1778,7 @@ fn rendmp_phase_check<'a>(
     // - Wait a little while
     // - Measure current + voltage
     // - Disable rail
-    println!("Phase check for {} at {addr:#x}", dev.bold());
+    println!("Phase check for {} at {addr:#x}", format!("{dev}").bold());
     println!(
         "{} |   {}   |   {}   | {}",
         "PHASE".bold(),

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1192,8 +1192,13 @@ struct HifWorker<'a, 'b> {
 
     rail_indexes: Vec<u32>,
 
-    /// Mapping from a phase (in the chip sense) to a rail (as an index in
-    /// `self.rail_indexes`).
+    /// Mapping from a phase (in the chip sense) to a tuple of `(rail, name)`.
+    ///
+    /// - `rail` is an index into `self.rail_indexes`
+    /// - `name` is the name of that rail
+    ///
+    /// This means that names are duplicated (since each rail has multiple
+    /// phases), but that's not a huge amount of memory overhead.
     phase_to_rail: BTreeMap<u8, (usize, String)>,
 }
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1264,12 +1264,13 @@ impl<'a, 'b> HifWorker<'a, 'b> {
                     .get(&(sensor_id as u32))
                     .ok_or_else(|| {
                         anyhow!(
-                    "could not find sensor {sensor_id} in CONTROLLER_CONFIG"
-                )
+                            "could not find sensor {sensor_id} in CONTROLLER_CONFIG"
+                        )
                     })
                     .map(|i| *i as u32)
             })
             .collect::<Result<Vec<_>>>()?;
+        println!("got rail_indexes: {rail_indexes:?}");
 
         Ok(Self {
             hubris,
@@ -1804,7 +1805,7 @@ fn rendmp_phase_check<'a>(
             .get(&phase_name.parse().unwrap())
             .ok_or_else(|| anyhow!("could not get rail for {phase_name}"))?;
         let ctrl_addr = (0xEA0D + 0x80 * rail) as u16;
-        let index = worker.rail_indexes[rail as usize];
+        let index = rail_indexes[rail as usize];
         // Not totally sure if these operations need to be separate, but we
         // were seeing processor errors under certain circumstances.
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1766,6 +1766,9 @@ fn rendmp_phase_check<'a>(
         // Enable all rails (since only our target phase will be on)
         for (j, c) in ctrl.iter().enumerate() {
             let ctrl_addr = (0xEA0D + 0x80 * j) as u16;
+            // Not totally sure if these need to be separate, but better safe
+            // than sorry when it comes to these parts!
+            worker.write_dma(addr, ctrl_addr, (c & !(1 << 2)))?;
             worker.write_dma(addr, ctrl_addr, (c & !(1 << 2)) | 1)?;
         }
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -123,6 +123,20 @@
 //!  19    | 0°C         | 0.0 A
 //! ```
 //! (In the example above, there have been no faults so the blackbox is empty)
+//!
+//! To check individual phases for errors, use the `--phase-check` subcommand:
+//! ```console
+//! $ humility rendmp --phase-check --device=0x5c
+//! humility: attached to 0483:3754:000D00344741500820383733 via ST-Link V3
+//! Phase check for ISL68221 at 0x5c
+//! PHASE |   VOUT   |   IOUT   |   TEMP   | RAIL
+//! ------|----------|----------|----------|----------
+//!  0    |   0.451V | -55.600A | 26.000°C | VPP_ABCD
+//!  1    |   0.447V | -55.200A | 24.000°C | VPP_EFGH
+//!  2    |   0.441V |   1.100A |  0.000°C | V1P8_SP3
+//! ```
+//!
+//! This must be run with the system in the A2 power state.
 
 use humility::hubris::*;
 use humility::reflect::{Base, Value};

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1778,7 +1778,7 @@ fn rendmp_phase_check<'a>(
     // - Wait a little while
     // - Measure current + voltage
     // - Disable rail
-    println!("Phase check for {dev} at {addr:#x}");
+    println!("Phase check for {} at {addr:#x}", dev.bold());
     println!(
         "{} |   {}   |   {}   | {}",
         "PHASE".bold(),

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1747,12 +1747,15 @@ fn rendmp_phase_check<'a>(
                 bail!("failed to modify PEAK_OCUC_COUNT for rail {rail}: {e}")
             }
         }
-        if dev == SupportedDevice::RAA229618 {
-            match next()? {
+        match dev {
+            SupportedDevice::RAA229618 => match next()? {
                 Ok(v) => v.expect_write_dma()?,
                 Err(e) => {
                     bail!("failed to modify EA5B for rail {rail}: {e}")
                 }
+            },
+            SupportedDevice::ISL68224 => {
+                // no changes were made specifically for the ISL68224
             }
         }
         match next()? {

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1489,7 +1489,7 @@ fn rendmp_phase_check<'a>(
     let (addr, dev) = check_addr(subargs, hubris)?;
 
     // Read pin states so that we don't try to enable a phase with an open-pin
-    // failure; this will
+    // failure; this would cause the power controller to lock up.
     let pin_states = get_pin_states(subargs, hubris, core, context)?;
 
     // Filter out VGEN phases

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1805,7 +1805,7 @@ fn rendmp_phase_check<'a>(
             .get(&phase_name.parse().unwrap())
             .ok_or_else(|| anyhow!("could not get rail for {phase_name}"))?;
         let ctrl_addr = (0xEA0D + 0x80 * rail) as u16;
-        let index = rail_indexes[rail as usize];
+        let index = rail_indexes[rail];
         // Not totally sure if these operations need to be separate, but we
         // were seeing processor errors under certain circumstances.
 
@@ -1826,7 +1826,15 @@ fn rendmp_phase_check<'a>(
             || iter.next().ok_or_else(|| anyhow!("early termination"));
         match next()? {
             Ok(v) => v.expect_write_dma()?,
-            Err(e) => bail!("failed to enable phase {phase_name}: {e}"),
+            Err(e) => bail!(
+                "failed to enable forced-freq pwm for phase {phase_name}: {e}"
+            ),
+        }
+        match next()? {
+            Ok(v) => v.expect_write_dma()?,
+            Err(e) => {
+                bail!("failed to enable pwm mode for phase {phase_name}: {e}")
+            }
         }
         for (j, _) in ctrl.iter().enumerate() {
             match next()? {

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -902,14 +902,11 @@ impl SupportedDevice {
 
 impl std::fmt::Display for SupportedDevice {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                SupportedDevice::ISL68224 => "ISL68221",
-                SupportedDevice::RAA229618 => "RAA229618",
-            }
-        )
+        let s = match self {
+            SupportedDevice::ISL68224 => "ISL68224",
+            SupportedDevice::RAA229618 => "RAA229618",
+        };
+        write!(f, "{s}",)
     }
 }
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1918,6 +1918,8 @@ fn rendmp(context: &mut ExecutionContext) -> Result<()> {
     } else if subargs.open_pin {
         return rendmp_open_pin(&subargs, hubris, core, &mut context);
     } else if subargs.phase_check {
+        // Bail out early if the arguments are invalid
+        let _ = check_addr(&subargs, hubris)?;
         let out = rendmp_phase_check(&subargs, hubris, core, &mut context);
         if let Err(e) =
             restore_default_config(&subargs, hubris, core, &mut context)

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1424,7 +1424,6 @@ impl<'a, 'b> HifWorker<'a, 'b> {
         let mut ops = std::mem::take(&mut self.ops);
         ops.push(Op::Done);
         let r = self.context.run(core, &ops, None)?;
-        // TODO: decode error messages here
         if r.len() != self.calls.len() {
             bail!("mismatched result lengths");
         }

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1816,7 +1816,7 @@ fn rendmp_phase_check<'a>(
 
         // Force the rail on
         use pmbus::commands::raa229618::CommandCode::ON_OFF_CONFIG;
-        worker.write_byte(index, true, ON_OFF_CONFIG as u8, 0);
+        worker.write_byte(index, true, ON_OFF_CONFIG as u8, 0)?;
 
         // Execute this operation and confirm that it worked
         let results = worker.run(core)?;

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1026,9 +1026,9 @@ fn get_pin_states(
         ],
     };
     let mut ops = vec![];
-    for r in regs {
+    for &r in regs {
         let payload =
-            op.payload(&[("addr", addr.into()), ("reg", (*r).into())])?;
+            op.payload(&[("addr", addr.into()), ("reg", r.into())])?;
         context.idol_call_ops(&op, &payload, &mut ops)?;
     }
     ops.push(hif::Op::Done);

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1684,15 +1684,16 @@ fn rendmp_phase_check<'a>(
                 }
 
                 // Clear bit 0 of DMA register EA5B and write it back
-                let mut reg_ea5b = match next()? {
+                // (the name part_fast_add comes from Power Navigator)
+                let mut part_fast_add = match next()? {
                     Ok(v) => v.expect_read_dma()?,
                     Err(e) => {
                         bail!("worker.failed to read EA5B for rail {rail}: {e}")
                     }
                 };
-                reg_ea5b &= !1; // clear bit 0
+                part_fast_add &= !1; // clear bit 0
                 let reg = (0xEA5B + rail * 0x80) as u16;
-                worker.write_dma(addr, reg, reg_ea5b)?;
+                worker.write_dma(addr, reg, part_fast_add)?;
             }
         }
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1142,6 +1142,7 @@ fn rendmp_phase_check<'a>(
         read_dma: IdolOperation<'a>,
         write_dma: IdolOperation<'a>,
         read_word: IdolOperation<'a>,
+        read_word32: IdolOperation<'a>,
         write_word: IdolOperation<'a>,
         write_word32: IdolOperation<'a>,
 
@@ -1159,6 +1160,8 @@ fn rendmp_phase_check<'a>(
                 hubris.get_idol_command("Power.rendmp_dma_write")?;
             let read_word =
                 hubris.get_idol_command("Power.raw_pmbus_read_word")?;
+            let read_word32 =
+                hubris.get_idol_command("Power.raw_pmbus_read32_word")?;
             let write_word =
                 hubris.get_idol_command("Power.raw_pmbus_write_word")?;
             let write_word32 =
@@ -1168,6 +1171,7 @@ fn rendmp_phase_check<'a>(
                 read_dma,
                 write_dma,
                 read_word,
+                read_word32,
                 write_word,
                 write_word32,
                 ops: vec![],
@@ -1241,6 +1245,25 @@ fn rendmp_phase_check<'a>(
             ])?;
             self.context.idol_call_ops(
                 &self.write_word,
+                &payload,
+                &mut self.ops,
+            )?;
+            Ok(())
+        }
+
+        fn read_word32(
+            &mut self,
+            index: u32,
+            has_rail: bool,
+            op: u8,
+        ) -> Result<()> {
+            let payload = self.read_word32.payload(&[
+                ("index", index.into()),
+                ("has_rail", has_rail.into()),
+                ("op", op.into()),
+            ])?;
+            self.context.idol_call_ops(
+                &self.read_word32,
                 &payload,
                 &mut self.ops,
             )?;
@@ -1338,7 +1361,7 @@ fn rendmp_phase_check<'a>(
 
         // Read LOOPCFG and PEAK_OCUC_COUNT; they will be modified and written
         // back later
-        worker.read_word(index, true, LOOPCFG as u8)?;
+        worker.read_word32(index, true, LOOPCFG as u8)?;
         worker.read_word(index, true, PEAK_OCUC_COUNT as u8)?;
 
         // Set PMBus command codes 0xD0 and 0xD1 to 0x8000 (disable VMon)

--- a/humility-idol/src/lib.rs
+++ b/humility-idol/src/lib.rs
@@ -33,6 +33,15 @@ pub enum IdolArgument<'a> {
     Scalar(u64),
 }
 
+impl<T> From<T> for IdolArgument<'_>
+where
+    T: Into<u64>,
+{
+    fn from(t: T) -> Self {
+        Self::Scalar(t.into())
+    }
+}
+
 #[derive(Debug)]
 pub enum IdolError<'a> {
     CLike(&'a HubrisEnum),

--- a/humility-pmbus/Cargo.toml
+++ b/humility-pmbus/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "humility-pmbus"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow.workspace = true
+humility.workspace = true

--- a/humility-pmbus/src/lib.rs
+++ b/humility-pmbus/src/lib.rs
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{anyhow, bail, Result};
+use humility::{core::Core, hubris::*};
+use std::collections::BTreeMap;
+
+/// Returns a map from voltage `SensorId` to position in `CONTROLLER_CONFIG`
+pub fn sensor_id_map(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+) -> Result<BTreeMap<u32, usize>> {
+    // Read CONTROLLER_CONFIG from the core, which we'll use to compute
+    // indices for rails when using raw PMBus functions.
+    let (_name, var) = hubris
+        .qualified_variables()
+        .find(|&(n, _v)| n == "task_power::bsp::CONTROLLER_CONFIG")
+        .ok_or_else(|| anyhow!("could not find CONTROLLER_CONFIG"))?;
+    let mut buf: Vec<u8> = vec![0u8; var.size];
+    core.halt()?;
+    core.read_8(var.addr, buf.as_mut_slice())?;
+    core.run()?;
+    let controller_config = humility::reflect::load_value(
+        hubris,
+        &buf,
+        hubris.lookup_type(var.goff)?,
+        0,
+    )?;
+
+    // Destructure CONTROLLER_CONFIG to build a map of voltage sensor IDs
+    // (which we can easily compute) to index in the CONTROLLER_CONFIG
+    // array.
+    use humility::reflect::{Base, Value};
+    let Value::Array(array) = controller_config else {
+        bail!("invalid shape for CONTROLLER_CONFIG: {controller_config:?}");
+    };
+    let mut sensor_id_to_index = BTreeMap::new();
+    for (i, cfg) in array.iter().enumerate() {
+        let Value::Struct(s) = cfg else {
+            bail!("invalid shape for CONTROLLER_CONFIG[{i}]: {cfg:?}");
+        };
+        let v = &s["voltage"];
+        let Value::Tuple(t) = v else {
+            bail!("could not get 'voltage': {v:?}");
+        };
+        let Value::Base(b) = &t[0] else {
+            bail!("could not get sensor ID from 'voltage': {v:?}");
+        };
+        let Base::U32(sensor_id) = b else {
+            bail!("bad sensor id type: {b:?}");
+        };
+        sensor_id_to_index.insert(*sensor_id, i);
+    }
+    Ok(sensor_id_to_index)
+}

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.18
+humility 0.10.19
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.18
+humility 0.10.19
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.18
+humility 0.10.19
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.18
+humility 0.10.19
 
 ```


### PR DESCRIPTION
This PR implements per-phase checks for Renesas multiphase power converts.

It's a bit of a mess, but that's mostly due to intrinsic complexity:
- We have do a mix of writes and read-modify-writes to configure the chip
- HIF calls are slow, so we want to group them into a single larger program

The result is a system which batches up a bunch of Idol calls, executes them, then iterates over the resulting values.

The actual implementation is based on https://github.com/oxidecomputer/humility/issues/367 as well as email communications with Renesas FAEs.  We understand about 90% of it; it would be nice to get the canonical names for DMA registers from the Power Navigator logs.

We're also suffering from https://github.com/oxidecomputer/hubris/issues/1342:
- DMA read/write operations expect an I2C address (which is easy to find, but could be a non-unique identifier); PMBus operations added in https://github.com/oxidecomputer/hubris/pull/1340 use index within the `CONTROLLER_CONFIG` array (which is globally unique but harder to compute)

This is totally untested, so I'm opening it as a draft for now; it's possible that we're overflowing the Idol text space with these large programs and will want to restructure.  We'll test it once Eric is back from Rochester.

TODO:
- [x] Test on real hardware
- [x] Improve output (print in tabular form)