### PR TITLE
"humility lpc55gpio" should be better documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,7 +1079,103 @@ normal, or `--start`/`-s` to run it once but catch the next fault.
 
 ### `humility lpc55gpio`
 
-The LPC55-equivalent of `humility gpio`.
+The LPC55-equivalent of `humility gpio`, allowing for GPIO pins to
+be set, reset, queried or configured on LPC55 targets.  Commands:
+
+- `--set` (`-s`): Sets a pin (sets it high)
+- `--reset` (`-r`): Resets a pin (sets it low)
+- `--toggle` (`-t`): Toggles a pin (sets it high if low, low if high)
+- `--input` (`-i`): Queries the state of a pin (or all pins if no pin
+  is specified)
+- `--configure` (`-c`): Configures a pin
+- `--direction` (`-d`): Configure the direction of a pin
+
+#### Set, reset, toggle
+
+To change the state of a pin (or pins), specify the pin (or pins) and
+the desired command.  For example, to toggle the state on pin 14 on
+port B:
+
+```console
+$ humility lpc55gpio --toggle --pins PIO0_17
+humility: attached via CMSIS-DAP
+[Ok([])]
+```
+
+To set pins PIO0_15, PIO0_16 and PIO0_17:
+
+```console
+$ humility lpc55gpio --set --pins PIO0_15,PIO0_16,PIO0_17
+humility: attached via CMSIS-DAP
+[Ok([]), Ok([]), Ok([])]
+```
+
+To reset pin PIO0_17:
+
+```console
+$ humility lpc55gpio --reset --pins PIO0_17
+humility: attached via CMSIS-DAP
+[Ok([])]
+```
+
+#### Input
+
+To get input values for a particular pin:
+
+```console
+$ humility lpc55gpio --input --pins PIO0_10,PIO0_11,PIO1_0
+humility: attached via CMSIS-DAP
+PIO0_10 = 0
+PIO0_11 = 1
+PIO1_0 = 0
+```
+
+To get input values for all pins, leave the pin unspecified:
+
+```console
+$ humility lpc55gpio --input
+humility: attached via ST-Link V3
+humility: attached to 1fc9:0143:12UNOSLDXOK51 via CMSIS-DAP
+PIO0_0 = 0
+PIO0_1 = 0
+PIO0_2 = 0
+PIO0_3 = 0
+PIO0_4 = 0
+PIO0_5 = 1
+PIO0_6 = 0
+PIO0_7 = 0
+PIO0_8 = 0
+PIO0_9 = 1
+PIO0_10 = 0
+PIO0_11 = 1
+PIO0_13 = 0
+...
+```
+
+#### Configure, direction
+
+To configure a pin, the configuration should be specified as a
+colon-delimited 6-tuple consisting of:
+
+- Alternate function: one of `Alt0` through `Alt9`
+- Mode:  `NoPull`, `PullDown`, `PullUp`, or `Repeater`
+- Slew: `Standard` or `Fast`
+- Invert: `Disable`, or `Enabled`
+- Digital mode: `Analog` or `Digital`
+- Open drain: `Normal` or `OpenDrain`
+
+Note that the direction of the pin should also likely be configured;
+this is done via the `--direction` command to either `Input` or `Output`.
+For example, to configure pin PIO0_17 to be an output:
+
+```console
+$ humility lpc55gpio -c Alt0:NoPull:Standard:Disable:Digital:Normal -p PIO0_17
+humility: attached via CMSIS-DAP
+[Ok([])]
+$ humility lpc55gpio -p PIO0_17 --direction Output
+humility: attached via CMSIS-DAP
+[Ok([])]
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -1093,8 +1093,7 @@ be set, reset, queried or configured on LPC55 targets.  Commands:
 #### Set, reset, toggle
 
 To change the state of a pin (or pins), specify the pin (or pins) and
-the desired command.  For example, to toggle the state on pin 14 on
-port B:
+the desired command.  For example, to toggle the state on pin PIO0_17:
 
 ```console
 $ humility lpc55gpio --toggle --pins PIO0_17
@@ -1165,8 +1164,8 @@ colon-delimited 6-tuple consisting of:
 - Open drain: `Normal` or `OpenDrain`
 
 Note that the direction of the pin should also likely be configured;
-this is done via the `--direction` command to either `Input` or `Output`.
-For example, to configure pin PIO0_17 to be an output:
+this is done via the `--direction` option, specifying either `Input` or
+`Output`.  For example, to configure pin PIO0_17 to be an output:
 
 ```console
 $ humility lpc55gpio -c Alt0:NoPull:Standard:Disable:Digital:Normal -p PIO0_17

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -50,6 +50,10 @@
 //! ```console
 //! $ humility gpio --input --pins PIO0_10,:
 //! humility: attached via CMSIS-DAP
+//! 10 = 0
+//! 11 = 1
+//! 12 = 1
+
 //! B:0  = 1
 //! B:14 = 1
 //! E:1  = 0
@@ -225,9 +229,9 @@ fn gpio(context: &mut ExecutionContext) -> Result<()> {
 
     if let Some(ref pins) = subargs.pins {
         for pin in pins {
-            let pin = gpio_toggle.lookup_argument(hubris, "pin", 0, pin)?;
+            let p = gpio_toggle.lookup_argument(hubris, "pin", 0, pin)?;
 
-            args.push((pin, pin.to_string()));
+            args.push((p, pin.to_string()));
         }
     }
 

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -4,7 +4,95 @@
 
 //! ## `humility lpc55gpio`
 //!
-//! The LPC55-equivalent of `humility gpio`.
+//! The LPC55-equivalent of `humility gpio`, allowing for GPIO pins to
+//! be set, reset, queried or configured on LPC55 targets.  Commands:
+//!
+//! - `--set` (`-s`): Sets a pin (sets it high)
+//! - `--reset` (`-r`): Resets a pin (sets it low)
+//! - `--toggle` (`-t`): Toggles a pin (sets it high if low, low if high)
+//! - `--input` (`-i`): Queries the state of a pin (or all pins if no pin
+//!   is specified)
+//! - `--configure` (`-c`): Configures a pin
+//! - `--direction` (`-d`): Configure the direction of a pin
+//! 
+//! ### Set, reset, toggle
+//!
+//! To change the state of a pin (or pins), specify the pin (or pins) and
+//! the desired command.  For example, to toggle the state on pin 14 on
+//! port B:
+//!
+//! ```console
+//! $ humility lpc55gpio --toggle --pins PIO0_17
+//! humility: attached via CMSIS-DAP
+//! [Ok([])]
+//! ```
+//!
+//! To set pins PIO0_15, PIO0_16 and PIO0_17:
+//!
+//! ```console
+//! $ humility gpio --set --pins PIO0_15,PIO0_16,PIO0_17
+//! humility: attached via CMSIS-DAP
+//! [Ok([]), Ok([]), Ok([])]
+//! ```
+//!
+//! To reset pin PIO0_17:
+//!
+//! ```console
+//! $ humility gpio --reset --pins PIO0_17
+//! humility: attached via CMSIS-DAP
+//! [Ok([])]
+//! ```
+//!
+//! ### Input
+//!
+//! To get input values for a particular pin:
+//!
+//! ```console
+//! $ humility gpio --input --pins PIO0_10,:
+//! humility: attached via CMSIS-DAP
+//! B:0  = 1
+//! B:14 = 1
+//! E:1  = 0
+//! ```
+//!
+//! To get input values for all pins, leave the pin unspecified:
+//!
+//! ```console
+//! $ humility gpio --input
+//! humility: attached via ST-Link V3
+//! Pin       0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
+//! -----------------------------------------------------------------------
+//! Port A    0   0   1   0   0   0   0   0   0   0   0   0   0   1   1   1
+//! Port B    1   0   0   0   1   0   0   0   0   0   0   0   0   0   1   0
+//! Port C    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port D    0   0   0   0   0   0   0   0   1   1   0   0   0   0   1   0
+//! Port E    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port F    1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port G    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port H    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port I    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port J    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! Port K    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! ```
+//!
+//! ### Configure
+//!
+//! To configure a pin, the configuration should be specified as a
+//! colon-delimited 5-tuple consisting of:
+//!
+//! - Mode: `Input`, `Output`, `Alternate`, or `Analog`
+//! - Output type: `PushPull` or `OpenDrain`
+//! - Speed: `Low`, `Medium`, `High`, or `VeryHigh`
+//! - Pull direction: `None`, `Up`, or `Down`
+//! - Alternate function: one of `AF0` through `AF15`
+//!
+//! For example, to configure pin 5 on port A as a push-pull output:
+//!
+//! ```console
+//! $ humility gpio -c Output:PushPull:High:None:AF0 -p A:5
+//! ```
+//!
+
 //!
 
 use humility_cli::{ExecutionContext, Subcommand};
@@ -64,7 +152,7 @@ struct GpioArgs {
     direction: Option<String>,
 
     /// specifies GPIO pins on which to operate
-    #[clap(long, short, value_name = "pins")]
+    #[clap(long, short, value_name = "pins", use_value_delimiter = true)]
     pins: Option<Vec<String>>,
 }
 

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -14,7 +14,7 @@
 //!   is specified)
 //! - `--configure` (`-c`): Configures a pin
 //! - `--direction` (`-d`): Configure the direction of a pin
-//! 
+//!
 //! ### Set, reset, toggle
 //!
 //! To change the state of a pin (or pins), specify the pin (or pins) and
@@ -30,7 +30,7 @@
 //! To set pins PIO0_15, PIO0_16 and PIO0_17:
 //!
 //! ```console
-//! $ humility gpio --set --pins PIO0_15,PIO0_16,PIO0_17
+//! $ humility lpc55gpio --set --pins PIO0_15,PIO0_16,PIO0_17
 //! humility: attached via CMSIS-DAP
 //! [Ok([]), Ok([]), Ok([])]
 //! ```
@@ -38,7 +38,7 @@
 //! To reset pin PIO0_17:
 //!
 //! ```console
-//! $ humility gpio --reset --pins PIO0_17
+//! $ humility lpc55gpio --reset --pins PIO0_17
 //! humility: attached via CMSIS-DAP
 //! [Ok([])]
 //! ```
@@ -48,55 +48,59 @@
 //! To get input values for a particular pin:
 //!
 //! ```console
-//! $ humility gpio --input --pins PIO0_10,:
+//! $ humility lpc55gpio --input --pins PIO0_10,PIO0_11,PIO1_0
 //! humility: attached via CMSIS-DAP
-//! 10 = 0
-//! 11 = 1
-//! 12 = 1
-
-//! B:0  = 1
-//! B:14 = 1
-//! E:1  = 0
+//! PIO0_10 = 0
+//! PIO0_11 = 1
+//! PIO1_0 = 0
 //! ```
 //!
 //! To get input values for all pins, leave the pin unspecified:
 //!
 //! ```console
-//! $ humility gpio --input
+//! $ humility lpc55gpio --input
 //! humility: attached via ST-Link V3
-//! Pin       0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
-//! -----------------------------------------------------------------------
-//! Port A    0   0   1   0   0   0   0   0   0   0   0   0   0   1   1   1
-//! Port B    1   0   0   0   1   0   0   0   0   0   0   0   0   0   1   0
-//! Port C    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port D    0   0   0   0   0   0   0   0   1   1   0   0   0   0   1   0
-//! Port E    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port F    1   1   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port G    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port H    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port I    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port J    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
-//! Port K    0   0   0   0   0   0   0   0   0   0   0   0   0   0   0   0
+//! humility: attached to 1fc9:0143:12UNOSLDXOK51 via CMSIS-DAP
+//! PIO0_0 = 0
+//! PIO0_1 = 0
+//! PIO0_2 = 0
+//! PIO0_3 = 0
+//! PIO0_4 = 0
+//! PIO0_5 = 1
+//! PIO0_6 = 0
+//! PIO0_7 = 0
+//! PIO0_8 = 0
+//! PIO0_9 = 1
+//! PIO0_10 = 0
+//! PIO0_11 = 1
+//! PIO0_13 = 0
+//! ...
 //! ```
 //!
-//! ### Configure
+//! ### Configure, direction
 //!
 //! To configure a pin, the configuration should be specified as a
-//! colon-delimited 5-tuple consisting of:
+//! colon-delimited 6-tuple consisting of:
 //!
-//! - Mode: `Input`, `Output`, `Alternate`, or `Analog`
-//! - Output type: `PushPull` or `OpenDrain`
-//! - Speed: `Low`, `Medium`, `High`, or `VeryHigh`
-//! - Pull direction: `None`, `Up`, or `Down`
-//! - Alternate function: one of `AF0` through `AF15`
+//! - Alternate function: one of `Alt0` through `Alt9`
+//! - Mode:  `NoPull`, `PullDown`, `PullUp`, or `Repeater`
+//! - Slew: `Standard` or `Fast`
+//! - Invert: `Disable`, or `Enabled`
+//! - Digital mode: `Analog` or `Digital`
+//! - Open drain: `Normal` or `OpenDrain`
 //!
-//! For example, to configure pin 5 on port A as a push-pull output:
+//! Note that the direction of the pin should also likely be configured;
+//! this is done via the `--direction` command to either `Input` or `Output`.
+//! For example, to configure pin PIO0_17 to be an output:
 //!
 //! ```console
-//! $ humility gpio -c Output:PushPull:High:None:AF0 -p A:5
+//! $ humility lpc55gpio -c Alt0:NoPull:Standard:Disable:Digital:Normal -p PIO0_17
+//! humility: attached via CMSIS-DAP
+//! [Ok([])]
+//! $ humility lpc55gpio -p PIO0_17 --direction Output
+//! humility: attached via CMSIS-DAP
+//! [Ok([])]
 //! ```
-//!
-
 //!
 
 use humility_cli::{ExecutionContext, Subcommand};

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -18,8 +18,7 @@
 //! ### Set, reset, toggle
 //!
 //! To change the state of a pin (or pins), specify the pin (or pins) and
-//! the desired command.  For example, to toggle the state on pin 14 on
-//! port B:
+//! the desired command.  For example, to toggle the state on pin PIO0_17:
 //!
 //! ```console
 //! $ humility lpc55gpio --toggle --pins PIO0_17
@@ -90,8 +89,8 @@
 //! - Open drain: `Normal` or `OpenDrain`
 //!
 //! Note that the direction of the pin should also likely be configured;
-//! this is done via the `--direction` command to either `Input` or `Output`.
-//! For example, to configure pin PIO0_17 to be an output:
+//! this is done via the `--direction` option, specifying either `Input` or
+//! `Output`.  For example, to configure pin PIO0_17 to be an output:
 //!
 //! ```console
 //! $ humility lpc55gpio -c Alt0:NoPull:Standard:Disable:Digital:Normal -p PIO0_17


### PR DESCRIPTION
@arjenroodselaar and I needed to use `humility lpc55gpio` to test some ignition work, and took much longer than it should have because the command isn't really documented at all.  (Especially important because direction needed to be configured -- an option that doesn't exist in the STM32 equivalent.)  This PR adds the documentation that I wish we had had.