### PR TITLE
Make `udprpc` optional in `NetCore`

### DIFF
--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -385,7 +385,8 @@ impl<'a> RpcClient<'a> {
         let rpc_task = hubris.lookup_task("udprpc").ok_or_else(|| {
             anyhow!(
                 "Could not find `udprpc` task in this image. \
-                 Is it up to date?"
+                 Only -dev and -lab images include `udprpc`; \
+                 are you running a production image?"
             )
         })?;
         let rpc_reply_type = hubris

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -352,10 +352,14 @@ impl<'a> HiffyContext<'a> {
             state: State::Initialized,
             functions: HiffyFunctions(function_map),
             rpc_reply_type: if core.is_net() {
-                //
-                // This should have been checked when we initially attached.
-                //
-                let rpc_task = hubris.lookup_task("udprpc").unwrap();
+                let rpc_task =
+                    hubris.lookup_task("udprpc").ok_or_else(|| {
+                        anyhow!(
+                            "Could not find `udprpc` task in this image. \
+                             Only -dev and -lab images include `udprpc`; \
+                             are you running a production image?"
+                        )
+                    })?;
 
                 Some(
                     hubris

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -55,12 +55,7 @@ impl NetCore {
 
         let scopeid = decode_iface(iface)?;
 
-        let udprpc_socket = if let Some(t) = hubris.lookup_task("udprpc") {
-            // Look up the reply type just to make sure it exists
-            let _rpc_reply_type = hubris
-                .lookup_module(*t)?
-                .lookup_enum_byname(hubris, "RpcReply")?;
-
+        let udprpc_socket = if hubris.lookup_task("udprpc").is_some() {
             // See oxidecomputer/oana for standard Hubris UDP ports
             let target = format!("[{}%{}]:998", ip, scopeid);
 
@@ -321,7 +316,7 @@ impl Core for NetCore {
                 if let Some(d) = self.udprpc_socket.as_ref() {
                     d.send(buf)
                 } else {
-                    bail!("no `udprpc` socket; is this a -dev or -lab image?");
+                    bail!("no `udprpc` socket");
                 }
             }
             NetAgent::DumpAgent => {
@@ -341,7 +336,7 @@ impl Core for NetCore {
                 if let Some(d) = self.udprpc_socket.as_ref() {
                     d.recv(buf)
                 } else {
-                    bail!("no `udprpc` socket; is this a -dev or -lab image?");
+                    bail!("no `udprpc` socket");
                 }
             }
             NetAgent::DumpAgent => {


### PR DESCRIPTION
Production images don't have `udprpc`, but we can still use `dump-agent` to read memory remotely.