### PR TITLE
add "humility writeword" + "humility vpd --lock-all"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,6 +2036,8 @@ dependencies = [
  "indexmap",
  "indicatif",
  "parse_int",
+ "ron 0.7.1",
+ "serde",
  "tlvc",
  "tlvc-text",
  "zerocopy",
@@ -2899,7 +2901,7 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 [[package]]
 name = "probe-rs"
 version = "0.12.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#75afc22df6bad7cae756b48728c5d788906aefe0"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#5e43fff3b0466e0981adb91cd8e32e09c413ce17"
 dependencies = [
  "anyhow",
  "base64",
@@ -2930,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "probe-rs-target"
 version = "0.12.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#75afc22df6bad7cae756b48728c5d788906aefe0"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#5e43fff3b0466e0981adb91cd8e32e09c413ce17"
 dependencies = [
  "base64",
  "jep106",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -1146,6 +1146,7 @@ dependencies = [
  "humility-cmd-update",
  "humility-cmd-validate",
  "humility-cmd-vpd",
+ "humility-cmd-writeword",
  "humility-core",
  "humility-cortex",
  "indexmap",
@@ -2038,6 +2039,19 @@ dependencies = [
  "tlvc",
  "tlvc-text",
  "zerocopy",
+]
+
+[[package]]
+name = "humility-cmd-writeword"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "humility-cli",
+ "humility-cmd",
+ "humility-core",
+ "parse-size",
+ "parse_int",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.23"
+version = "0.10.24"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -92,6 +92,7 @@ members = [
     "cmd/update",
     "cmd/validate",
     "cmd/vpd",
+    "cmd/writeword",
     "xtask",
 ]
 
@@ -191,6 +192,7 @@ cmd-test = { path = "./cmd/test", package = "humility-cmd-test" }
 cmd-update = { path = "./cmd/update", package = "humility-cmd-update" }
 cmd-validate = { path = "./cmd/validate", package = "humility-cmd-validate" }
 cmd-vpd = { path = "./cmd/vpd", package = "humility-cmd-vpd" }
+cmd-writeword = { path = "./cmd/writeword", package = "humility-cmd-writeword" }
 
 # crates.io deps
 anyhow = { version = "1.0.44", features = ["backtrace"] }
@@ -331,6 +333,7 @@ cmd-test = { workspace = true }
 cmd-update = { workspace = true }
 cmd-validate = { workspace = true }
 cmd-vpd = { workspace = true }
+cmd-writeword = { workspace = true }
 
 fallible-iterator = { workspace = true }
 log = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -3092,8 +3092,10 @@ ID  C P  MUX ADDR DEVICE        DESCRIPTION               LOCKED
  2  1 B  1:3 0x50 at24csw080    Sidecar Fan VPD           unlocked
 ```
 
-To read from a device, specify it by either id (`--id`) or by some
-(case-insensitive) substring of its description (`--device`):
+To read from all devices, combine `--list` with `--read`.  To read from a
+particular device, use `--read` alone, and specify the device by either id
+(`--id`) or by some (case-insensitive) substring of its description
+(`--device`):
 
 ```console
 $ humility vpd --read --id 0
@@ -3165,6 +3167,12 @@ To lock a VPD device, use the `--lock` command.  This will lock the VPD
 permanently and cannot be undone; subsequent attempts to write to (or
 lock) a locked VPD device will result in an error.  The lock status of
 each device is shown in `--list`.
+
+To lock all VPD devices, use the `--lock-all` command.  This will exit
+successfully if all devices were successfully locked or are already
+locked; if a device is missing or otherwise cannot be locked, all other
+devices will be locked, but the command will exit with a non-zero exit
+status.
 
 
 

--- a/README.md
+++ b/README.md
@@ -3170,9 +3170,47 @@ each device is shown in `--list`.
 
 ### `humility writeword`
 
-To the specified word-aligned address, writes the specified 32-bit value.
+Given a word-aligned address, writes the specified 32-bit value.
 If multiple values are specified, writes each in turn, incrementing
 the address by the word size after each write.
+
+**It should go without saying that this should be only used with care.**
+In particular, the target is **not** halted before any writes (but that
+functionality can be affected by using `writeword`).
+
+For example, to write the value 0x11223344 to 0x24018900:
+
+```console
+$ humility writeword 0x24018900 0x11223344
+humility: attached via ST-Link V3
+humility: writing 0x11223344 to 0x24018900
+```
+
+Note that the word is written as single, 32-bit value -- and will therefore
+be little-endian if reading memory:
+
+```console
+$ humility readmem 0x24018900 16
+humility: attached via ST-Link V3
+             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+0x24018900 | 44 33 22 11 00 00 00 00 00 00 00 00 00 00 00 00 | D3".............
+```
+
+To write multiple values to multiple words starting at the specified
+address, specify them as additional arguments, e.g.:
+
+```console
+$ humility writeword 0x24047800 0xaa 0xbb 0xcc 0xdd
+humility: attached via ST-Link V3
+humility: writing 0xaa to 0x24047800
+humility: writing 0xbb to 0x24047804
+humility: writing 0xcc to 0x24047808
+humility: writing 0xdd to 0x2404780c
+$ humility readmem 0x24047800 16
+humility: attached via ST-Link V3
+            \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+0x24047800 | aa 00 00 00 bb 00 00 00 cc 00 00 00 dd 00 00 00 | ................
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility update](#humility-update): apply an update
 - [humility validate](#humility-validate): validate presence and operation of devices
 - [humility vpd](#humility-vpd): read or write vital product data (VPD)
+- [humility writeword](#humility-writeword): writes one or more memory words
 ### `humility apptable`
 
 This is a deprecated command that allows for the display of the app table
@@ -3164,6 +3165,14 @@ To lock a VPD device, use the `--lock` command.  This will lock the VPD
 permanently and cannot be undone; subsequent attempts to write to (or
 lock) a locked VPD device will result in an error.  The lock status of
 each device is shown in `--list`.
+
+
+
+### `humility writeword`
+
+To the specified word-aligned address, writes the specified 32-bit value.
+If multiple values are specified, writes each in turn, incrementing
+the address by the word size after each write.
 
 
 

--- a/cmd/vpd/Cargo.toml
+++ b/cmd/vpd/Cargo.toml
@@ -15,6 +15,8 @@ tlvc.workspace = true
 tlvc-text.workspace = true
 zerocopy.workspace = true
 indicatif.workspace = true
+serde.workspace = true
+ron.workspace = true
 
 humility-cmd.workspace = true
 humility-cli.workspace = true

--- a/cmd/writeword/Cargo.toml
+++ b/cmd/writeword/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "humility-cmd-writeword"
+version = "0.1.0"
+edition = "2021"
+description = "writes one or more memory words"
+
+[dependencies]
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+humility-cli = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+parse_int = { workspace = true }
+parse-size = { workspace = true }

--- a/cmd/writeword/src/lib.rs
+++ b/cmd/writeword/src/lib.rs
@@ -4,9 +4,47 @@
 
 //! ## `humility writeword`
 //!
-//! To the specified word-aligned address, writes the specified 32-bit value.
+//! Given a word-aligned address, writes the specified 32-bit value.
 //! If multiple values are specified, writes each in turn, incrementing
 //! the address by the word size after each write.
+//!
+//! **It should go without saying that this should be only used with care.**
+//! In particular, the target is **not** halted before any writes (but that
+//! functionality can be affected by using `writeword`).
+//!
+//! For example, to write the value 0x11223344 to 0x24018900:
+//!
+//! ```console
+//! $ humility writeword 0x24018900 0x11223344
+//! humility: attached via ST-Link V3
+//! humility: writing 0x11223344 to 0x24018900
+//! ```
+//!
+//! Note that the word is written as single, 32-bit value -- and will therefore
+//! be little-endian if reading memory:
+//!
+//! ```console
+//! $ humility readmem 0x24018900 16
+//! humility: attached via ST-Link V3
+//!              \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+//! 0x24018900 | 44 33 22 11 00 00 00 00 00 00 00 00 00 00 00 00 | D3".............
+//! ```
+//!
+//! To write multiple values to multiple words starting at the specified
+//! address, specify them as additional arguments, e.g.:
+//!
+//! ```console
+//! $ humility writeword 0x24047800 0xaa 0xbb 0xcc 0xdd
+//! humility: attached via ST-Link V3
+//! humility: writing 0xaa to 0x24047800
+//! humility: writing 0xbb to 0x24047804
+//! humility: writing 0xcc to 0x24047808
+//! humility: writing 0xdd to 0x2404780c
+//! $ humility readmem 0x24047800 16
+//! humility: attached via ST-Link V3
+//!             \/  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+//! 0x24047800 | aa 00 00 00 bb 00 00 00 cc 00 00 00 dd 00 00 00 | ................
+//! ```
 //!
 
 use anyhow::{bail, Result};

--- a/cmd/writeword/src/lib.rs
+++ b/cmd/writeword/src/lib.rs
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility writeword`
+//!
+//! To the specified word-aligned address, writes the specified 32-bit value.
+//! If multiple values are specified, writes each in turn, incrementing
+//! the address by the word size after each write.
+//!
+
+use anyhow::{bail, Result};
+use clap::{CommandFactory, Parser};
+use humility_cli::{ExecutionContext, Subcommand};
+use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
+
+#[derive(Parser, Debug)]
+#[clap(name = "writeword", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct WritewordArgs {
+    /// address to write to
+    #[clap(parse(try_from_str = parse_int::parse))]
+    address: u32,
+
+    /// value(s) to write
+    #[clap(parse(try_from_str = parse_int::parse))]
+    value: Vec<u32>,
+}
+
+fn writeword(context: &mut ExecutionContext) -> Result<()> {
+    let core = &mut **context.core.as_mut().unwrap();
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+
+    let subargs = WritewordArgs::try_parse_from(subargs)?;
+
+    if subargs.address & 0b11 != 0 {
+        bail!("address must be word aligned");
+    }
+
+    for (offs, v) in subargs.value.iter().enumerate() {
+        let addr = subargs.address + (offs * 4) as u32;
+        humility::msg!("writing {v:#x} to {addr:#x}");
+        core.write_word_32(addr, *v)?;
+    }
+
+    Ok(())
+}
+
+pub fn init() -> Command {
+    Command {
+        app: WritewordArgs::command(),
+        name: "writeword",
+        run: writeword,
+        kind: CommandKind::Attached {
+            archive: Archive::Optional,
+            attach: Attach::LiveOnly,
+            validate: Validate::None,
+        },
+    }
+}

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.23
+humility 0.10.24
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.23
+humility 0.10.24
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.23
+humility 0.10.24
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.23
+humility 0.10.24
 
 ```


### PR DESCRIPTION
Draft comment:

```
- Adds a new "humility writeword" command
- Adds a "humility vpd --lock-all" to lock all VPDs in a system
- Allows "--read" to be combined with "humility vpd --list"
- Downgrades the probe-rs "custom sequence for LPC55S69" message from
  a warning to an informational message
```