### PR TITLE
Fail if `humility readvar` doesn't find the variable

### DIFF
--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -135,14 +135,19 @@ fn readvar(context: &mut ExecutionContext) -> Result<()> {
         n == v || n.ends_with(&suffix)
     }
 
-    if let Some(ref variable) = subargs.variable {
+    if let Some(variable) = &subargs.variable {
         let m =
             if variable.contains("::") { match_exact } else { match_suffix };
 
+        let mut found = false;
         for (n, v) in
             hubris.qualified_variables().filter(|&(n, _)| m(n, variable))
         {
             readvar_dump(hubris, core, v, n, &subargs)?;
+            found = true;
+        }
+        if !found {
+            bail!("variable '{variable}' not found; use \"-l\" to list");
         }
     } else {
         bail!("expected variable (use \"-l\" to list)");

--- a/tests/cmd/readvar-ticks/readvar-ticks.extern-regions.stderr
+++ b/tests/cmd/readvar-ticks/readvar-ticks.extern-regions.stderr
@@ -1,1 +1,2 @@
 humility: attached to dump
+humility readvar failed: variable 'TICKS' not found; use "-l" to list

--- a/tests/cmd/readvar-ticks/readvar-ticks.extern-regions.toml
+++ b/tests/cmd/readvar-ticks/readvar-ticks.extern-regions.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.extern-regions readvar TICKS"
-
+status.code = 1 # Hand-edit: no TICKS variable is present in this image

--- a/tests/cmd/readvar-ticks/readvar-ticks.task.net.stderr
+++ b/tests/cmd/readvar-ticks/readvar-ticks.task.net.stderr
@@ -1,1 +1,2 @@
 humility: attached to dump
+humility readvar failed: variable 'TICKS' not found; use "-l" to list

--- a/tests/cmd/readvar-ticks/readvar-ticks.task.net.toml
+++ b/tests/cmd/readvar-ticks/readvar-ticks.task.net.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.task.net readvar TICKS"
-
+status.code = 1 # Hand-edit: no TICKS variable is present in this image


### PR DESCRIPTION
Previously, it would return successfully, without any warnings.