### PR TITLE
Further fix `Complex` error size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.27"
+version = "0.10.28"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.27"
+version = "0.10.28"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1233,12 +1233,11 @@ pub fn hiffy_call(
     // and copy it into the incoming HiffyLease::Read argument
     let out = match lease {
         Some(HiffyLease::Read(data)) => {
-            let ok_size = hubris.typesize(op.ok)?;
+            let ok_size = op.reply_size()?;
             if let Ok(v) = v.as_mut() {
                 let extra_data = v.drain(ok_size..).collect::<Vec<u8>>();
                 data.copy_from_slice(&extra_data);
             }
-
             // Shoehorn that extra data in, assuming decoding worked.
             hiffy_decode(hubris, op, v)?
         }

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.27
+humility 0.10.28
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.27
+humility 0.10.28
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.27
+humility 0.10.28
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.27
+humility 0.10.28
 
 ```


### PR DESCRIPTION
Commit 47d3d20b5311c3b47d72e98b41aafaf9e1dc8ce7 fixed changes for `Complex` error types in Idol but missed the Read Lease case causing us to slice the wrong amount off. Fixes #412 