### PR TITLE
Add readmem option to save to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,7 @@ dependencies = [
  "humility-cli",
  "humility-cmd",
  "humility-core",
+ "humility-log",
  "parse-size",
  "parse_int",
 ]

--- a/cmd/readmem/Cargo.toml
+++ b/cmd/readmem/Cargo.toml
@@ -8,6 +8,7 @@ description = "read and display memory region"
 humility = { workspace = true }
 humility-cmd = { workspace = true }
 humility-cli = { workspace = true }
+humility-log = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 parse_int = { workspace = true }


### PR DESCRIPTION
It's useful to be able to save arbitrary memory ranges as a binary like gdb/pyOCD/openocd do