### PR TITLE
Online debug authentication with permission-slip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-num"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488557e97528174edaa2ee268b23a809e0c598213a4bbcb4f34575a46fda147e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1298,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "clap",
+ "clap-num",
  "humility-cli",
  "humility-cmd",
  "humility-cortex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,15 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap-num"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488557e97528174edaa2ee268b23a809e0c598213a4bbcb4f34575a46fda147e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1298,7 +1289,6 @@ dependencies = [
  "anyhow",
  "byteorder",
  "clap",
- "clap-num",
  "humility-cli",
  "humility-cmd",
  "humility-cortex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,6 @@ bitfield = "0.13.2"
 byteorder = "1.3.4"
 cargo_metadata = "0.12.0"
 clap = { version = "3.0.12", features = ["derive", "env"] }
-clap-num = "1.0"
 colored = "2.0.0"
 crc-any = "2.3.5"
 crossbeam-channel = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.29"
+version = "0.10.30"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ bitfield = "0.13.2"
 byteorder = "1.3.4"
 cargo_metadata = "0.12.0"
 clap = { version = "3.0.12", features = ["derive", "env"] }
+clap-num = "1.0"
 colored = "2.0.0"
 crc-any = "2.3.5"
 crossbeam-channel = "0.5.6"

--- a/cmd/debugmailbox/Cargo.toml
+++ b/cmd/debugmailbox/Cargo.toml
@@ -8,7 +8,6 @@ description = "interact with the debug mailbox on the LPC55"
 anyhow.workspace = true
 byteorder.workspace = true
 clap.workspace = true
-clap-num.workspace = true
 parse_int.workspace = true
 probe-rs.workspace = true
 

--- a/cmd/debugmailbox/Cargo.toml
+++ b/cmd/debugmailbox/Cargo.toml
@@ -8,6 +8,7 @@ description = "interact with the debug mailbox on the LPC55"
 anyhow.workspace = true
 byteorder.workspace = true
 clap.workspace = true
+clap-num.workspace = true
 parse_int.workspace = true
 probe-rs.workspace = true
 

--- a/cmd/debugmailbox/src/lib.rs
+++ b/cmd/debugmailbox/src/lib.rs
@@ -21,11 +21,17 @@
 //! entered ISP mode!
 //! ```
 
-use std::{fs::File, path::PathBuf};
+use std::{
+    fs::File,
+    path::PathBuf,
+    process::{Command as Process, Stdio},
+    thread::spawn,
+};
 
 use anyhow::{bail, Context, Result};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use clap::{CommandFactory, Parser};
+use clap_num::maybe_hex;
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Command, CommandKind};
 use probe_rs::{
@@ -82,6 +88,14 @@ enum DebugMailboxCmd {
     AuthChallenge { out: PathBuf },
     /// Send a Debug Authentication Response
     AuthResponse { dar: PathBuf },
+    /// Debug Authentication Challenge/Response with online signing via `permslip`
+    AuthOnline {
+        /// Debug credential key name (try `permslip list-keys -t`)
+        key_name: String,
+        /// Authentication beacon (UM11126 §51.7)
+        #[clap(long, default_value_t = 0, value_parser=maybe_hex::<u16>)]
+        beacon: u16,
+    },
 }
 
 fn poll_raw_ap_register(
@@ -329,7 +343,7 @@ fn debugmailboxcmd(context: &mut ExecutionContext) -> Result<()> {
 
             let dar_bytes = std::fs::read(dar)?;
             if dar_bytes.len() % 4 != 0 {
-                bail!("Debug Authentication Response is not an even number of words (bytes: {}", dar_bytes.len());
+                bail!("Debug Authentication Response is not an even number of words ({} bytes)", dar_bytes.len());
             }
 
             let mut dar_words = vec![0u32; dar_bytes.len() / 4];
@@ -342,6 +356,58 @@ fn debugmailboxcmd(context: &mut ExecutionContext) -> Result<()> {
                 dar_words.as_slice(),
             )?;
 
+            let _ = write_req(&mut iface, &dm_port, DMCommand::ExitDM, &[])?;
+        }
+        DebugMailboxCmd::AuthOnline { key_name, beacon } => {
+            // Get the challenge from the chip.
+            alive(&mut iface, &dm_port, true)?;
+            let dac = write_req(
+                &mut iface,
+                &dm_port,
+                DMCommand::DebugChallenge,
+                &[],
+            )?;
+
+            // Ask permission-slip to sign it.
+            let mut permslip = Process::new("permslip")
+                .arg("sign")
+                .arg(key_name)
+                .arg("--kind=debug-authn-challenge")
+                .arg(format!("--beacon={beacon}"))
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .spawn()
+                .context("Unable to execute `permslip`, is it in your PATH and executable?")?;
+
+            // Send the challenge to permission-slip ...
+            let mut input =
+                permslip.stdin.take().context("Opening permslip stdin")?;
+            spawn(move || -> Result<()> {
+                for word in dac {
+                    input.write_u32::<LittleEndian>(word)?;
+                }
+                Ok(())
+            });
+
+            // ... and read the response from it.
+            let dar_bytes = permslip
+                .wait_with_output()
+                .context("Reading permslip stdout")?
+                .stdout;
+            if dar_bytes.len() % 4 != 0 {
+                bail!("Debug Authentication Response is not an even number of words ({} bytes)", dar_bytes.len());
+            }
+            let mut dar_words = vec![0u32; dar_bytes.len() / 4];
+            LittleEndian::read_u32_into(&dar_bytes, &mut dar_words);
+
+            // Send the response to the chip.
+            alive(&mut iface, &dm_port, false)?;
+            let _ = write_req(
+                &mut iface,
+                &dm_port,
+                DMCommand::DebugResponse,
+                dar_words.as_slice(),
+            )?;
             let _ = write_req(&mut iface, &dm_port, DMCommand::ExitDM, &[])?;
         }
     };

--- a/cmd/debugmailbox/src/lib.rs
+++ b/cmd/debugmailbox/src/lib.rs
@@ -31,7 +31,6 @@ use std::{
 use anyhow::{bail, Context, Result};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use clap::{CommandFactory, Parser};
-use clap_num::maybe_hex;
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Command, CommandKind};
 use probe_rs::{
@@ -93,7 +92,7 @@ enum DebugMailboxCmd {
         /// Debug credential key name (try `permslip list-keys -t`)
         key_name: String,
         /// Authentication beacon (UM11126 §51.7)
-        #[clap(long, default_value_t = 0, value_parser=maybe_hex::<u16>)]
+        #[clap(long, default_value_t = 0, parse(try_from_str = parse_int::parse))]
         beacon: u16,
     },
 }

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.29
+humility 0.10.30
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.29
+humility 0.10.30
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.29
+humility 0.10.30
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.29
+humility 0.10.30
 
 ```


### PR DESCRIPTION
For debugging locked (production) roots of trust, we must use LPC55 debug authentication to protect our secrets. Debug authentication requires access to a credential certificate which must be signed by an (offline) root, and an online debug credential key which we would like to treat as sensitive (but not as sensitive as a root). [Permission Slip](https://github.com/oxidecomputer/permission-slip) lets us keep the sensitive keys locked down (in AWS KMS) while still being able to sign various kinds of artifacts; oxidecomputer/permission-slip#102 adds support for LPC55 debug authentication artifact types.

This change adds a new `debugmailbox auth-online` sub-command that gets a debug authentication challenge from an LPC55, sends it to the permslip server (the "online signing service"), receives the signed response, and writes it back to the LPC55. It is like a combination of the commands `debugmailbox auth-challenge foo.dac && lpc55_sign debug-auth-response ... foo.dar && debugmailbox auth-response foo.dar`, but without requiring direct access to the debug credential private key:
```
lamia:~/oxide/humility% humility reset
humility: Opened probe MCU-LINK (r0FF) CMSIS-DAP V2.263
lamia:~/oxide/humility% alias beacon='humility readmem -H 0x50000fc0 4'
lamia:~/oxide/humility% beacon
humility: attached via CMSIS-DAP
               \/    2    4    6    8    a    c    e
0x50000fc0 | 0000 0000                               | ....            
lamia:~/oxide/humility% humility debugmailbox auth-online bart --beacon=0x5678
Looks like a plausible debug mailbox
Resetting chip via SYSREQRESET!
lamia:~/oxide/humility% beacon                                                
humility: attached via CMSIS-DAP
               \/    2    4    6    8    a    c    e
0x50000fc0 | 2710 5678                               | .'xV            
```