### PR TITLE
Update Rust toolchain

### DIFF
--- a/cmd/doc/build.rs
+++ b/cmd/doc/build.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
     write!(
         output,
         r##"
+#[allow(clippy::needless_raw_string_hashes)]
 fn cmd_docs(lookup: &str) -> Option<&'static str> {{
     let mut m = HashMap::new();
 "##
@@ -107,6 +108,7 @@ fn cmd_docs(lookup: &str) -> Option<&'static str> {{
     m.get(lookup).as_ref().map(|result| result as _)
 }}
 
+#[allow(clippy::needless_raw_string_hashes)]
 fn docs() -> &'static str {{
     r##""##
     )?;

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -741,10 +741,7 @@ fn monorail_status(
             .collect::<Result<Vec<Result<_, _>>>>()?;
 
         // Decode the port and phy status values into reflect::Value
-        port_results
-            .into_iter()
-            .zip(phy_results.into_iter())
-            .collect::<Vec<_>>()
+        port_results.into_iter().zip(phy_results).collect::<Vec<_>>()
     };
 
     // Convert ports in a lookup-friendly structure

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -220,6 +220,7 @@ fn cpuid(
             r.cpuid2(eax, ecx)
         }
     }
+    #[allow(clippy::arc_with_non_send_sync)]
     let workspace = WorkspaceRef {
         cell: Arc::new(RefCell::new(SbrmiWorkspace {
             hubris,

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -104,7 +104,7 @@ use humility_idol::{self as idol, HubrisIdol};
 use raw_cpuid::{CpuId, CpuIdResult};
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::rc::Rc;
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -212,7 +212,7 @@ fn cpuid(
     }
     #[derive(Clone)]
     struct WorkspaceRef<'a, 'b> {
-        cell: Arc<RefCell<SbrmiWorkspace<'a, 'b>>>,
+        cell: Rc<RefCell<SbrmiWorkspace<'a, 'b>>>,
     }
     impl<'a, 'b> raw_cpuid::CpuIdReader for WorkspaceRef<'a, 'b> {
         fn cpuid2(&self, eax: u32, ecx: u32) -> raw_cpuid::CpuIdResult {
@@ -220,9 +220,8 @@ fn cpuid(
             r.cpuid2(eax, ecx)
         }
     }
-    #[allow(clippy::arc_with_non_send_sync)]
     let workspace = WorkspaceRef {
-        cell: Arc::new(RefCell::new(SbrmiWorkspace {
+        cell: Rc::new(RefCell::new(SbrmiWorkspace {
             hubris,
             core,
             context,

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -1269,7 +1269,7 @@ impl Core for DumpCore {
         let rsize = data.len();
 
         if let Some((&base, &(size, offset))) =
-            self.regions.range(..=addr).rev().next()
+            self.regions.range(..=addr).next_back()
         {
             if base <= addr && addr < (base + size) {
                 if (addr - base) + rsize as u32 > size {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -438,7 +438,7 @@ impl HubrisFlashMap {
 
     pub fn read(&self, addr: u32, data: &mut [u8]) -> Option<()> {
         if let Some((&base, &(size, offset))) =
-            self.regions.range(..=addr).rev().next()
+            self.regions.range(..=addr).next_back()
         {
             if base <= addr && base + size > addr {
                 let start = (addr - base) as usize;
@@ -1142,7 +1142,7 @@ impl HubrisArchive {
     fn load_archive(&mut self, archive: &[u8]) -> Result<()> {
         let cursor = Cursor::new(archive);
         let mut archive = zip::ZipArchive::new(cursor)?;
-        let mut manifest = &mut self.manifest;
+        let manifest = &mut self.manifest;
 
         macro_rules! byname {
             ($name:tt) => {
@@ -2766,7 +2766,7 @@ impl HubrisArchive {
             let val = u32::from_le_bytes(stack[o..o + 4].try_into().unwrap());
 
             let reg = match r {
-                0 | 1 | 2 | 3 => ARMRegister::from_usize(r).unwrap(),
+                0..=3 => ARMRegister::from_usize(r).unwrap(),
                 4 => ARMRegister::R12,
                 5 => ARMRegister::LR,
                 6 => ARMRegister::PC,

--- a/humility-dump-agent/src/lib.rs
+++ b/humility-dump-agent/src/lib.rs
@@ -122,7 +122,7 @@ impl DumpAgentCore {
 
     fn read(&mut self, addr: u32, data: &mut [u8]) -> Result<()> {
         if let Some((&base, contents)) =
-            self.ram_regions.range(..=addr).rev().next()
+            self.ram_regions.range(..=addr).next_back()
         {
             if base > addr || base + (contents.len() as u32) <= addr {
                 //

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.72.1"
 components = ["clippy"]

--- a/src/cmd_repl.rs
+++ b/src/cmd_repl.rs
@@ -224,7 +224,7 @@ impl Completer for ClapCompleter {
                 let mut words = line.split(' ');
                 let command = words.next().unwrap();
                 if let Some(command) = self.commands.get(command) {
-                    let last_word = words.rev().next().unwrap();
+                    let last_word = words.next_back().unwrap();
                     let span = Span::new(line.len() - last_word.len(), pos);
 
                     let mut completions = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ where
     let input: Vec<_> = input.into_iter().collect();
     let input2 = input.clone();
 
-    let m = match command.try_get_matches_from(input.into_iter()) {
+    let m = match command.try_get_matches_from(input) {
         Ok(m) => m,
         Err(e) => {
             e.print().unwrap();
@@ -94,7 +94,7 @@ where
 
     // If we're here, we know that our arguments pass muster from the Clap
     // perspective.
-    Some((commands, m, Cli::parse_from(input2.into_iter())))
+    Some((commands, m, Cli::parse_from(input2)))
 }
 
 #[test]


### PR DESCRIPTION
Use the `1.72.1` channel, which is the latest `stable` version as of 2023-10-05.

Should fix the CI build failures seen in #418, including clippy.