### PR TITLE
`humility ibc black-box` should skip empty events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.34"
+version = "0.10.35"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -228,6 +228,16 @@ impl<'a> IbcHandler<'a> {
     }
 
     fn print_event(&self, e: IbcEvent, verbose: bool, vout_mode: u8) {
+        // In that case that a log contains no entries, the newest event index
+        // reported will be the lowest slot for the log type, which will be
+        // empty. Reading an empty event will return 0xFF in all bytes.
+        if e.timestamp.get() == u32::MAX
+            && e.event_id.get() == u16::MAX
+            && e.status_word.get() == u16::MAX
+        {
+            println!("  EMPTY");
+            return;
+        }
         println!(
             "  TIMESTAMP           {:#010x} = {}",
             e.timestamp.get(),

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -211,23 +211,30 @@ impl<'a> IbcHandler<'a> {
                 Err(e) => bail!("Failed to read event {i}: {e}"),
             }
         }
+        let mut base_timestamp: u32 = 0;
         for i in 0..=newest_fault_event_index {
             let e = events[i as usize];
             println!("{}", "FAULT EVENT".red());
             println!("  EVENT_INDEX:        {i}");
-            self.print_event(e, verbose, vout_mode);
+            self.print_event(e, verbose, vout_mode, &mut base_timestamp);
         }
         for i in 24..=newest_lifecycle_event_index {
             let e = events[i as usize];
             println!("{}", "LIFECYCLE EVENT".green());
             println!("  EVENT_INDEX:        {i}");
-            self.print_event(e, verbose, vout_mode);
+            self.print_event(e, verbose, vout_mode, &mut base_timestamp);
         }
 
         Ok(())
     }
 
-    fn print_event(&self, e: IbcEvent, verbose: bool, vout_mode: u8) {
+    fn print_event(
+        &self,
+        e: IbcEvent,
+        verbose: bool,
+        vout_mode: u8,
+        base_timestamp: &mut u32,
+    ) {
         // In that case that a log contains no entries, the newest event index
         // reported will be the lowest slot for the log type, which will be
         // empty. Reading an empty event will return 0xFF in all bytes.
@@ -238,12 +245,6 @@ impl<'a> IbcHandler<'a> {
             println!("  EMPTY");
             return;
         }
-        println!(
-            "  TIMESTAMP           {:#010x} = {}",
-            e.timestamp.get(),
-            Self::format_time(e.timestamp.get())
-        );
-        println!("  EVENT_ID            {:#06x}", e.event_id.get());
 
         // Decoding is extracted from revision A and B of the datasheet, which
         // contain non-overlapping sets of decoding information.  They don't
@@ -260,6 +261,30 @@ impl<'a> IbcHandler<'a> {
         //   28710-FGB 100 378 Rev A (Application Note 326), May 2023
 
         let status_word = e.status_word.get();
+
+        // When a BOOT_EVENT or TIME_ERASE_EVENT is seen, record the timestamp
+        // so that the times for following events can be displayed relative to
+        // this.
+        if e.status_word.get() == 1 && (e.status_mfr == 0 || e.status_mfr == 6)
+        {
+            *base_timestamp = e.timestamp.get();
+        }
+
+        if *base_timestamp != 0 && *base_timestamp <= e.timestamp.get() {
+            println!(
+                "  TIMESTAMP           {:#010x} = +{}",
+                e.timestamp.get(),
+                Self::format_time(e.timestamp.get() - *base_timestamp)
+            );
+        } else {
+            println!(
+                "  TIMESTAMP           {:#010x} = {}",
+                e.timestamp.get(),
+                Self::format_time(e.timestamp.get())
+            );
+        }
+        println!("  EVENT_ID            {:#06x}", e.event_id.get());
+
         println!("  STATUS_WORD         {:#06x}", status_word);
         for (bit, name) in [
             (0, "System event"),

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.34
+humility 0.10.35
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.34
+humility 0.10.35
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.34
+humility 0.10.35
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.34
+humility 0.10.35
 
 ```


### PR DESCRIPTION
Fixes #433 

```
jeeves% ./humility ibc black-box
FAULT EVENT
  EVENT_INDEX:        0
  EMPTY
LIFECYCLE EVENT
  EVENT_INDEX:        24
  TIMESTAMP           0xffd5872f = 3 day, 5 hr, 19 min, 4.0 sec
  EVENT_ID            0x0350
  STATUS_WORD         0x0001
    0x0001: System event
  STATUS_MFR          0x05
    0x05: ERASE_OVFL_EVENT
  V_IN                0xf86c = 54.000V
  V_OUT               0x0000 = 0.000V
  I_OUT               0x07ff = -1.000A
  TEMPERATURE         0x0013 = 19.000°C
```