### PR TITLE
hiffy: Add plumbing necessary to call hif ops w/ a read & write lease.

### DIFF
--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -19,7 +19,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Attach, Command, Validate};
-use humility_hiffy::{HiffyContext, HiffyLease};
+use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
 
 const DEFAULT_SLOT_SIZE_BYTES: usize = 2 * 1024 * 1024;
@@ -102,6 +102,7 @@ impl<'a> AuxFlashHandler<'a> {
             &op,
             &[],
             None,
+            None,
         )?;
         let v = match value {
             Ok(v) => v,
@@ -122,6 +123,7 @@ impl<'a> AuxFlashHandler<'a> {
             &mut self.context,
             &op,
             &[],
+            None,
             None,
         )?;
         let v = match value {
@@ -144,6 +146,7 @@ impl<'a> AuxFlashHandler<'a> {
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
+            None,
         )?;
         match value {
             Ok(..) => Ok(()),
@@ -159,6 +162,7 @@ impl<'a> AuxFlashHandler<'a> {
             &mut self.context,
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+            None,
             None,
         )?;
         let v = match value {
@@ -241,7 +245,8 @@ impl<'a> AuxFlashHandler<'a> {
                     ("slot", IdolArgument::Scalar(slot as u64)),
                     ("offset", IdolArgument::Scalar(offset as u64)),
                 ],
-                Some(HiffyLease::Read(chunk)),
+                None,
+                Some(chunk),
             )?;
             if let Err(e) = value {
                 bail!("Got Hubris error: {:?}", e);
@@ -335,7 +340,8 @@ impl<'a> AuxFlashHandler<'a> {
                     ("slot", IdolArgument::Scalar(slot as u64)),
                     ("offset", IdolArgument::Scalar(offset as u64)),
                 ],
-                Some(HiffyLease::Write(chunk)),
+                Some(chunk),
+                None,
             )?;
             if let Err(e) = value {
                 bail!("Got Hubris error: {:?}", e);

--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -19,7 +19,7 @@ use termios::Termios;
 use humility::core::Core;
 use humility::hubris::HubrisArchive;
 use humility_cli::{ExecutionContext, Subcommand};
-use humility_hiffy::{HiffyContext, HiffyLease};
+use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
 
 use super::UartConsoleArgs;
@@ -59,7 +59,8 @@ impl<'a> UartConsoleHandler<'a> {
             &mut self.context,
             &op,
             &[],
-            Some(HiffyLease::Read(buf)),
+            None,
+            Some(buf),
         )?;
 
         let v = match value {
@@ -85,7 +86,8 @@ impl<'a> UartConsoleHandler<'a> {
             &mut self.context,
             &op,
             &[],
-            Some(HiffyLease::Write(buf)),
+            Some(buf),
+            None,
         )?;
 
         let v = match value {
@@ -185,6 +187,7 @@ impl<'a> UartConsoleHandler<'a> {
             &op,
             &[("attach", IdolArgument::String("false"))],
             None,
+            None,
         )?;
 
         match value {
@@ -204,6 +207,7 @@ impl<'a> UartConsoleHandler<'a> {
             &mut self.context,
             &op,
             &[],
+            None,
             None,
         )?;
 

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -329,6 +329,7 @@ fn monorail_read(
         &op,
         &[("addr", IdolArgument::Scalar(u64::from(addr)))],
         None,
+        None,
     )?;
     match value {
         Ok(v) => {
@@ -379,6 +380,7 @@ fn monorail_write(
             ("addr", IdolArgument::Scalar(u64::from(addr))),
             ("value", IdolArgument::Scalar(u64::from(value))),
         ],
+        None,
         None,
     )?;
     match value {
@@ -468,6 +470,7 @@ fn monorail_phy_read(
             ("reg", IdolArgument::Scalar(u64::from(reg.reg))),
         ],
         None,
+        None,
     )?;
     match value {
         Ok(v) => {
@@ -511,6 +514,7 @@ fn monorail_phy_write(
             ("reg", IdolArgument::Scalar(u64::from(reg.reg))),
             ("value", IdolArgument::Scalar(u64::from(value))),
         ],
+        None,
         None,
     )?;
     match value {
@@ -894,6 +898,7 @@ fn monorail_mac_table(
         &op_mac_count,
         &[],
         None,
+        None,
     )?;
     let mac_count = match value {
         Ok(v) => {
@@ -998,6 +1003,7 @@ fn monorail_reset_counters(
         &op,
         &[("port", IdolArgument::Scalar(u64::from(port)))],
         None,
+        None,
     )?;
     value.map(|_| ()).map_err(|err| anyhow!("Got error {err}"))
 }
@@ -1015,6 +1021,7 @@ fn monorail_counters(
         context,
         &op,
         &[("port", IdolArgument::Scalar(u64::from(port)))],
+        None,
         None,
     )?;
     let decode_count = |s: &Value| match s {

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -92,6 +92,7 @@ fn net_ip(context: &mut ExecutionContext) -> Result<()> {
         &op,
         &[],
         None,
+        None,
     )?;
     let v = match value {
         Ok(v) => v,
@@ -153,6 +154,7 @@ fn net_mac_table(context: &mut ExecutionContext) -> Result<()> {
         &mut hiffy_context,
         &op_mac_count,
         &[],
+        None,
         None,
     )?;
     let mac_count = match value {
@@ -276,6 +278,7 @@ fn net_status(context: &mut ExecutionContext) -> Result<()> {
         &op,
         &[],
         None,
+        None,
     )?;
     let v = match value {
         Ok(v) => v,
@@ -356,6 +359,7 @@ fn net_counters(context: &mut ExecutionContext) -> Result<()> {
         &mut hiffy_context,
         &op,
         &[],
+        None,
         None,
     )?;
     let v = match value {

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -1001,6 +1001,7 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
             &hubris.get_idol_command("HostFlash.write_persistent_data")?,
             &[("dev_select", IdolArgument::String(dev_select))],
             None,
+            None,
         )?;
         if let Err(e) = out {
             bail!("write_persistent_data failed: {e}");

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1006,8 +1006,15 @@ fn rendmp_blackbox(
 ) -> Result<()> {
     let (addr, _dev) = check_addr(&subargs, hubris)?;
     let op = hubris.get_idol_command("Power.rendmp_blackbox_dump")?;
-    let value =
-        hiffy_call(hubris, core, context, &op, &[("addr", addr.into())], None)?;
+    let value = hiffy_call(
+        hubris,
+        core,
+        context,
+        &op,
+        &[("addr", addr.into())],
+        None,
+        None,
+    )?;
     match value {
         Ok(Value::Enum(e)) => {
             let contents = e
@@ -1545,7 +1552,8 @@ fn rendmp_phase_check<'a>(
         .get_idol_command("Sequencer.tofino_seq_state")
         .or_else(|_| hubris.get_idol_command("Sequencer.get_state"))
         .context("could not get power state HIF operation")?;
-    let r = hiffy_call(hubris, core, context, &power_state_op, &[], None)?;
+    let r =
+        hiffy_call(hubris, core, context, &power_state_op, &[], None, None)?;
     if let Err(e) = r {
         bail!("power state check got an error: {e}");
     }

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -15,7 +15,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_cmd::{Archive, Attach, Command, Validate};
-use humility_hiffy::{HiffyContext, HiffyLease};
+use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
 
 // Limited to 128 bytes due to the write buffer in the EEPROM
@@ -91,7 +91,8 @@ impl<'a> EepromHandler<'a> {
                 &mut self.context,
                 &op,
                 &[("offset", IdolArgument::Scalar(offset as u64))],
-                Some(HiffyLease::Read(chunk)),
+                None,
+                Some(chunk),
             )?;
             if let Err(e) = value {
                 bail!("Got Hubris error: {:?}", e);
@@ -127,7 +128,8 @@ impl<'a> EepromHandler<'a> {
                 &mut self.context,
                 &op,
                 &[("offset", IdolArgument::Scalar(offset as u64))],
-                Some(HiffyLease::Write(chunk)),
+                Some(chunk),
+                None,
             )?;
             if let Err(e) = value {
                 bail!("Got Hubris error: {:?}", e);


### PR DESCRIPTION
This uses the new `SendLeaseReadWrite` hif function.