### PR TITLE
lsusb: new subcommand for portable USB listings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.36"
+version = "0.10.37"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -1132,6 +1132,7 @@ dependencies = [
  "humility-cmd-itm",
  "humility-cmd-jefe",
  "humility-cmd-lpc55gpio",
+ "humility-cmd-lsusb",
  "humility-cmd-manifest",
  "humility-cmd-map",
  "humility-cmd-monorail",
@@ -1571,6 +1572,18 @@ dependencies = [
  "humility-cmd",
  "humility-hiffy",
  "parse_int",
+]
+
+[[package]]
+name = "humility-cmd-lsusb"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "humility-cli",
+ "humility-cmd",
+ "humility-core",
+ "rusb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.36"
+version = "0.10.37"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -65,6 +65,7 @@ members = [
     "cmd/itm",
     "cmd/jefe",
     "cmd/lpc55gpio",
+    "cmd/lsusb",
     "cmd/manifest",
     "cmd/map",
     "cmd/monorail",
@@ -165,6 +166,7 @@ cmd-ibc = { path = "./cmd/ibc", package = "humility-cmd-ibc" }
 cmd-itm = { path = "./cmd/itm", package = "humility-cmd-itm" }
 cmd-jefe = { path = "./cmd/jefe", package = "humility-cmd-jefe" }
 cmd-lpc55gpio = { path = "./cmd/lpc55gpio", package = "humility-cmd-lpc55gpio" }
+cmd-lsusb = { path = "./cmd/lsusb", package = "humility-cmd-lsusb" }
 cmd-manifest = { path = "./cmd/manifest", package = "humility-cmd-manifest" }
 cmd-map = { path = "./cmd/map", package = "humility-cmd-map" }
 cmd-monorail = { path = "./cmd/monorail", package = "humility-cmd-monorail" }
@@ -308,6 +310,7 @@ cmd-ibc = { workspace = true }
 cmd-itm = { workspace = true }
 cmd-jefe = { workspace = true }
 cmd-lpc55gpio = { workspace = true }
+cmd-lsusb = { workspace = true }
 cmd-manifest = { workspace = true }
 cmd-map = { workspace = true }
 cmd-monorail = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility itm](#humility-itm): commands for ARM's Instrumentation Trace Macrocell (ITM)
 - [humility jefe](#humility-jefe): influence jefe externally
 - [humility lpc55gpio](#humility-lpc55gpio): LPC55 GPIO pin manipulation
+- [humility lsusb](#humility-lsusb): List all USB devices visible to Humility
 - [humility manifest](#humility-manifest): print archive manifest
 - [humility map](#humility-map): print memory map, with association of regions to tasks
 - [humility monorail](#humility-monorail): Management network control and debugging
@@ -957,55 +958,89 @@ loss.
 
 Here's an example:
 ```console
-$ humility -tsn5 ibc black-box
+$ humility ibc black-box
 humility: attached to 0483:374e:001B00083156501320323443 via ST-Link V3
 FAULT EVENT
   EVENT_INDEX:        0
-  TIMESTAMP           0x000001ca = 45.5 sec
+  TIMESTAMP           0x000a3747 = 18 hr, 35 min, 51.1 sec
   EVENT_ID            0x0000
   STATUS_WORD         0x0010
-  STATUS_IOUT         0x0080
-  V_IN                0xf869 = 52.50V
-  V_OUT               0x5f00 = 11.88V
-  I_OUT               0x004e = 78.00A
-  TEMPERATURE         0x001c = 28.00°C
+    0x0010: Output overcurrent fault
+  STATUS_IOUT         0x80
+    0x80: Iout Overcurrent Fault
+  STATUS_MFR          0x00
+  V_IN                0xf84f = 39.500V
+  V_OUT               0x6000 = 12.000V
+  I_OUT               0x0075 = 117.000A
+  TEMPERATURE         0x0023 = 35.000°C
 FAULT EVENT
   EVENT_INDEX:        1
-  TIMESTAMP           0x000001d4 = 46.6 sec
+  TIMESTAMP           0x000a3751 = 18 hr, 35 min, 52.1 sec
   EVENT_ID            0x0001
   STATUS_WORD         0x0001
-  STATUS_MFG          0x0001
-    b0 = BOOT_EVENT
-  V_IN                0xf83c = 30.00V
-  V_OUT               0x0000 = 0.00V
-  I_OUT               0x0000 = 0.00A
-  TEMPERATURE         0x0000 = 0.00°C
+    0x0001: System event
+  STATUS_MFR          0x01
+    0x01: INPUT_LOW_EVENT
+  V_IN                0xf83c = 30.000V
+  V_OUT               0x0000 = 0.000V
+  I_OUT               0x0000 = 0.000A
+  TEMPERATURE         0x0000 = 0.000°C
 FAULT EVENT
   EVENT_INDEX:        2
-  TIMESTAMP           0x000002c4 = 1 min, 10.0 sec
+  TIMESTAMP           0x2809e751 = 777 day, 11 hr, 22 min, 48.1 sec
   EVENT_ID            0x0002
-  STATUS_WORD         0x0010
-  STATUS_IOUT         0x0080
-  V_IN                0xf877 = 59.50V
-  V_OUT               0x5f00 = 11.88V
-  I_OUT               0x0070 = 112.00A
-  TEMPERATURE         0x002c = 44.00°C
+  STATUS_WORD         0x0001
+    0x0001: System event
+  STATUS_MFR          0x02
+    0x02: CANCEL_EVENT
+  V_IN                0xf86b = 53.500V
+  V_OUT               0x5f00 = 11.875V
+  I_OUT               0x0000 = 0.000A
+  TEMPERATURE         0x0012 = 18.000°C
 FAULT EVENT
   EVENT_INDEX:        3
-  TIMESTAMP           0x27ffb2c4 = 776 day, 16 hr, 48 min, 6.6 sec
+  TIMESTAMP           0x50099751 = 1554 day, 4 hr, 9 min, 44.1 sec
   EVENT_ID            0x0003
   STATUS_WORD         0x0001
-  STATUS_MFG          0x0002
-    b1 = INPUT_LOW_EVENT
-  V_IN                0xf86b = 53.50V
-  V_OUT               0x6000 = 12.00V
-  I_OUT               0x0000 = 0.00A
-  TEMPERATURE         0x0016 = 22.00°C
+    0x0001: System event
+  STATUS_MFR          0x02
+    0x02: CANCEL_EVENT
+  V_IN                0xf86b = 53.500V
+  V_OUT               0x6000 = 12.000V
+  I_OUT               0x0000 = 0.000A
+  TEMPERATURE         0x0020 = 32.000°C
+LIFECYCLE EVENT
+  EVENT_INDEX:        24
+  TIMESTAMP           0xffef8ad0 = 4969 day, 18 hr, 41 min, 12.0 sec
+  EVENT_ID            0x0680
+  STATUS_WORD         0x0001
+    0x0001: System event
+  STATUS_MFR          0x04
+    0x04: CLR_EVENT
+  V_IN                0xf86b = 53.500V
+  V_OUT               0x5f00 = 11.875V
+  I_OUT               0x0000 = 0.000A
+  TEMPERATURE         0x001a = 26.000°C
+LIFECYCLE EVENT
+  EVENT_INDEX:        25
+  TIMESTAMP           0xffef8bd4 = 4969 day, 18 hr, 41 min, 38.0 sec
+  EVENT_ID            0x0681
+  STATUS_WORD         0x0001
+    0x0001: System event
+  STATUS_MFR          0x05
+    0x05: ERASE_OVFL_EVENT
+  V_IN                0xf860 = 48.000V
+  V_OUT               0x5f00 = 11.875V
+  I_OUT               0x0000 = 0.000A
+  TEMPERATURE         0x001b = 27.000°C
+
 ```
 
-The log doesn't appear to be _completely_ reliable, so take it with a grain
-of salt and with the datasheet close at hand.  For example, the machine in
-the example above had **not** be up for 776 days.
+The log doesn't appear to be _completely_ reliable, especially with
+respect to timestamps, so take it with a grain of salt and with the
+datasheet close at hand.  For example, the machine in the example above
+had **not** be up for 777 days (or, for that matter, for 4,969).
+
 
 
 ### `humility itm`
@@ -1231,6 +1266,12 @@ humility: attached via CMSIS-DAP
 [Ok([])]
 ```
 
+
+
+### `humility lsusb`
+
+`humility lsusb` will show you Humility's view of the USB devices available
+on the system, to help you choose probes and/or diagnose permissions issues.
 
 
 ### `humility manifest`

--- a/cmd/lsusb/Cargo.toml
+++ b/cmd/lsusb/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "humility-cmd-lsusb"
+version = "0.1.0"
+edition = "2021"
+description = "List all USB devices visible to Humility"
+
+[dependencies]
+humility = { workspace = true }
+humility-cmd = { workspace = true }
+humility-cli = { workspace = true }
+clap = { workspace = true }
+anyhow = { workspace = true }
+rusb = {workspace = true}

--- a/cmd/lsusb/src/lib.rs
+++ b/cmd/lsusb/src/lib.rs
@@ -1,0 +1,112 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility lsusb`
+//!
+//! `humility lsusb` will show you Humility's view of the USB devices available
+//! on the system, to help you choose probes and/or diagnose permissions issues.
+
+use anyhow::{anyhow, Result};
+use clap::{CommandFactory, Parser};
+use humility_cli::{ExecutionContext, Subcommand};
+use humility_cmd::{Archive, Command, CommandKind};
+use std::time::Duration;
+
+#[derive(Parser, Debug)]
+#[clap(name = "lsusb", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct Args {
+    // None as yet
+}
+
+fn lsusb(context: &mut ExecutionContext) -> Result<()> {
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+    let _subargs = Args::try_parse_from(subargs)?;
+
+    let devices = rusb::devices()?;
+    let mut successes = vec![];
+    let mut failures = vec![];
+    for dev in devices.iter() {
+        match list1(&dev) {
+            Ok(summary) => successes.push(summary),
+            Err(e) => {
+                failures.push((
+                    dev.bus_number(),
+                    dev.address(),
+                    dev.port_number(),
+                    e,
+                ));
+            }
+        }
+    }
+
+    humility::msg!(
+        "USB device scan, {} successful and {} failed",
+        successes.len(),
+        failures.len()
+    );
+
+    if !successes.is_empty() {
+        successes.sort();
+        humility::msg!("--- successfully opened devices ---");
+        humility::msg!(
+            "format: VID:PID:SERIAL, then manufacturer name, \
+            then product name"
+        );
+        for summary in successes {
+            humility::msg!("{}", summary);
+        }
+    }
+
+    if !failures.is_empty() {
+        failures.sort_by_key(|(b, a, p, _)| (*b, *a, *p));
+        humility::msg!("--- failures ---");
+        humility::msg!("could not access {} devices:", failures.len());
+        for (bus, addr, port, e) in failures {
+            humility::msg!("bus {bus}, addr {addr}, port {port}: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+fn list1(dev: &rusb::Device<impl rusb::UsbContext>) -> Result<String> {
+    const TIMEOUT: Duration = Duration::from_secs(1);
+
+    let desc = dev.device_descriptor()?;
+    let vid = desc.vendor_id();
+    let pid = desc.product_id();
+
+    let handle = match dev.open() {
+        Ok(handle) => handle,
+        Err(e) => {
+            return Err(anyhow!("{pid:04x}:{vid:04x}:???\topen failed: {e}"));
+        }
+    };
+    let lang = *handle
+        .read_languages(TIMEOUT)?
+        .iter()
+        .find(|lang| lang.primary_language() == rusb::PrimaryLanguage::English)
+        .ok_or_else(|| anyhow!("can't find English strings"))?;
+
+    let man = handle
+        .read_manufacturer_string(lang, &desc, TIMEOUT)
+        .unwrap_or_else(|_| "(manufacturer unknown)".to_string());
+    let prod = handle
+        .read_product_string(lang, &desc, TIMEOUT)
+        .unwrap_or_else(|_| "(product unknown)".to_string());
+    let serial = handle
+        .read_serial_number_string(lang, &desc, TIMEOUT)
+        .unwrap_or_else(|_| "(serial unknown)".to_string());
+
+    Ok(format!("{pid:04x}:{vid:04x}:{serial}\t{man}\t{prod}"))
+}
+
+pub fn init() -> Command {
+    Command {
+        app: Args::command(),
+        name: "lsusb",
+        run: lsusb,
+        kind: CommandKind::Unattached { archive: Archive::Ignored },
+    }
+}

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.36
+humility 0.10.37
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.36
+humility 0.10.37
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.36
+humility 0.10.37
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.36
+humility 0.10.37
 
 ```


### PR DESCRIPTION
It occurred to us this morning that actually obtaining the `pid:vid:serial` combination used by Humility's `-p` argument is complex if you're on an unfamiliar platform. Illumos in particular has no direct equivalent to `lsusb`.

So, here's a subcommand in Humility that uses libusb as the portability layer, and prints things in the appropriate format.