### PR TITLE
Parse `ip%scope` in CLI arguments

### DIFF
--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -7,7 +7,7 @@ mod env;
 use anyhow::Result;
 use clap::{AppSettings, ArgGroup, ArgMatches, Parser};
 use env::Environment;
-use humility::{core::Core, hubris::HubrisArchive, msg, warn};
+use humility::{core::Core, hubris::HubrisArchive, msg, net, warn};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(
@@ -61,7 +61,7 @@ pub struct Cli {
     /// HUMILITY_IP environment variable. Run "humility doc" for more
     /// information on running Humility over a network.
     #[clap(long, short, group = "hubris")]
-    pub ip: Option<String>,
+    pub ip: Option<net::ScopedV6Addr>,
 
     /// Hubris environment file. Thie may also be set via the
     /// HUMILITY_ENVIRONMENT environment variable. Run "humility doc" for
@@ -158,7 +158,7 @@ impl ExecutionContext {
             if let Ok(e) = env::var("HUMILITY_PROBE") {
                 cli.probe = Some(e);
             } else if let Ok(e) = env::var("HUMILITY_IP") {
-                cli.ip = Some(e);
+                cli.ip = Some(e.parse()?);
             } else if let Ok(e) = env::var("HUMILITY_TARGET") {
                 cli.target = Some(e);
             } else if let Ok(e) = env::var("HUMILITY_DUMP") {

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -93,7 +93,7 @@ pub fn attach_dump(
 }
 
 pub fn attach_net(args: &Cli, hubris: &HubrisArchive) -> Result<Box<dyn Core>> {
-    if let Some(ip) = &args.ip {
+    if let Some(ip) = args.ip {
         let timeout = Duration::from_millis(args.timeout as u64);
         humility_net_core::attach_net(ip, hubris, timeout)
     } else {

--- a/humility-core/src/net.rs
+++ b/humility-core/src/net.rs
@@ -5,6 +5,16 @@
 use anyhow::{bail, Context, Result};
 use std::{fmt, net::Ipv6Addr, str::FromStr};
 
+/// An IPv6 address, plus a scope ID.
+///
+/// The Rust standard library's [`Ipv6Addr`] type does not parse scoped IPv6
+/// addresses with [zone indices], which are used to disambiguate link-local
+/// addresses. This type implements [`FromStr`] by parsing an IPv6 address
+/// (using [`Ipv6Addr::from_str`]) and a trailing zone index, which may either
+/// be numeric or an interface name, if the host OS supports this. Interface
+/// names are translated to numeric zone indices using [`decode_iface`].
+///
+/// [zone indices]: https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct ScopedV6Addr {
     pub ip: Ipv6Addr,

--- a/humility-core/src/net.rs
+++ b/humility-core/src/net.rs
@@ -2,7 +2,47 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::{fmt, net::Ipv6Addr, str::FromStr};
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct ScopedV6Addr {
+    pub ip: Ipv6Addr,
+    pub scopeid: u32,
+}
+
+const SCOPE_DELIM: char = '%';
+
+impl FromStr for ScopedV6Addr {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let s = s.trim();
+        let Some((ip, scope)) = s.rsplit_once(SCOPE_DELIM) else {
+            bail!(
+                "missing scope ID (e.g. \"{SCOPE_DELIM}en0\") in IPv6 address"
+            )
+        };
+        let ip = ip
+            .parse()
+            .with_context(|| format!("{ip:?} is not a valid IPv6 address"))?;
+        let scopeid = decode_iface(scope)?;
+        Ok(ScopedV6Addr { ip, scopeid })
+    }
+}
+
+impl fmt::Display for ScopedV6Addr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { ip, scopeid } = self;
+        write!(f, "{ip}{SCOPE_DELIM}{scopeid}")
+    }
+}
+
+impl fmt::Debug for ScopedV6Addr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
 
 pub fn decode_iface(iface: &str) -> Result<u32> {
     #[cfg(not(windows))]


### PR DESCRIPTION
Currently, the Humility CLI accepts IP addresses as a `String`, and then
attempts to parse them as an `Ipv6Addr` and scope. This is a bit
unfortunate, as when argument parsing is performed by `clap`, the CLI
will emit a somewhat nicer error message when parsing fails (indicating
which argument the error occurred while parsing, including the invalid
value, and suggesting the help text). On the other hand, when we accept
the argument as a `String`, `clap` doesn't add that useful context to
the error message.

This branch adds a `ScopedV6Addr` newtype, consisting of an `Ipv6Addr`
and a scope identifier, and adds a `FromStr` implementation for that
type. Now, we can use `ScopedV6Addr` as the type of the CLI argument,
and `clap` performs the parsing for us, getting us somewhat nicer error
messages. Compare the error output from master:

```console
$ cargo run -- --ip ::%fakeiface0 probe
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/humility --ip '::%fakeiface0' probe`
humility probe failed: Could not find interface for fakeiface0

$ cargo run -- --ip :: probe
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/humility --ip '::' probe`
humility probe failed: Missing scope id in IP (e.g. '%en0')

$ cargo run -- --ip barf%eth0 probe
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/humility --ip 'barf%eth0' probe`
humility probe failed: invalid Zip archive: Invalid zip header
```

with the error output on this branch:

```console
$ cargo run -- --ip :: probe
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/humility --ip '::' probe`
error: Invalid value "::" for '--ip <IP>': missing scope ID (e.g. "%en0") in IPv6 address

For more information try --help

$ cargo run -- --ip ::%fakeiface0 probe
    Finished dev [unoptimized + debuginfo] target(s) in 8.45s
     Running `target/debug/humility --ip '::%fakeiface0' probe`
error: Invalid value "::%fakeiface0" for '--ip <IP>': Could not find interface for fakeiface0

For more information try --help

$ cargo run -- --ip barf%eth0 probe
    Finished dev [unoptimized + debuginfo] target(s) in 12.87s
     Running `target/debug/humility --ip 'barf%eth0' probe`
error: Invalid value "barf%eth0" for '--ip <IP>': "barf" is not a valid IPv6 address

For more information try --help
```

Additionally, using the `ScopedIpv6Addr` type allows us to provide a
`fmt::Display` implementation that combines the IP address and scope ID
when formatting. This lets us get rid of a little bit of repeated logic
for formatting an address with the delimiter, which seems kinda nice to
me.