### PR TITLE
Improve NetCore's message when archive is missing.

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -401,7 +401,16 @@ pub struct HubrisFlashMap {
 }
 
 impl HubrisFlashMap {
+    /// # Errors
+    ///
+    /// (Non-exhaustive list added when surprising error conditions were
+    /// discovered:)
+    ///
+    /// This will fail if the `HubrisArchive` is fake, i.e. contains zero bytes.
     pub fn new(hubris: &HubrisArchive) -> Result<Self> {
+        if hubris.archive().is_empty() {
+            bail!("archive is required for network use but was not provided");
+        }
         //
         // We want to read in the "final.elf" from our archive and use that
         // to determine the memory that constitutes flash.


### PR DESCRIPTION
So @hawkw noticed this behavior:

```
$ cargo run -q -- --ip barf%eth0 probe
humility probe failed: invalid Zip archive: Invalid zip header
```

which confused us both. This is different from the normal "archive not provided" message, and `probe` itself doesn't require an archive at all!

It turns out to be a sequence of things:

- It appears that if you don't provide an archive, Humility internally makes a fake one with an archive byte string of &[].
- NetCore itself has an undocumented assumption that the HubrisArchive is not in this class.
- NetCore requires this no matter whether the command uses the archive, or not.

So, by inserting an explicit check in NetCore instead of letting the zip crate fail, we get somewhat better feedback:

```
humility probe failed: archive is required for network use but was not provided
```