### PR TITLE
Support bitflags 2.x, fixing `humility dump`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.37"
+version = "0.10.38"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.37"
+version = "0.10.38"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2583,7 +2583,12 @@ impl HubrisArchive {
 
         let base_offs = self.member_offset(desc, "base")?;
         let size_offs = self.member_offset(desc, "size")?;
-        let attr_offs = self.member_offset(desc, "attributes.bits")?;
+
+        // bitflags 1.x versus 2.x encode bitfields differently
+        let attr_offs = self
+            .member_offset(desc, "attributes.bits")
+            .or_else(|_| self.member_offset(desc, "attributes.__0"))
+            .context("could not find attributes.bits")?;
 
         //
         // Regrettably copied out of Hubris -- there isn't DWARF for this.

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.37
+humility 0.10.38
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.37
+humility 0.10.38
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.37
+humility 0.10.38
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.37
+humility 0.10.38
 
 ```


### PR DESCRIPTION
Reading region attributes (as part of the dump) was broken, because `bitflags 2.x` changed the way that it encodes the inner field.