### PR TITLE
Remove misfiring IP address presence check.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.10.38"
+version = "0.10.39"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.10.38"
+version = "0.10.39"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -106,10 +106,6 @@ pub fn subcommand(
                 bail!("cannot specify a dump for {} command", cmd);
             }
 
-            if context.cli.ip.is_some() {
-                bail!("cannot specify IP address for {} command", cmd);
-            }
-
             if context.cli.probe.is_some() {
                 bail!("cannot specify probe for {} command", cmd);
             }

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.10.38
+humility 0.10.39
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.10.38
+humility 0.10.39
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.10.38
+humility 0.10.39
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.10.38
+humility 0.10.39
 
 ```


### PR DESCRIPTION
This check assumed that IP addresses are only given for debugging with NetCore, but since @hawkw's improvements recently, that is no longer the case.

Now, this check is actually preventing anyone from using the gimlet subcommand, which is a Detached command.

I glanced over the commands that use this, and I don't think this check is pulling its weight -- I don't think it's worth introducing another piece of command metadata to specify "I'm detached but also I'd like an IP address." So, I've removed it.