### PR TITLE
stop installing `cargo-readme` on ci

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -34,7 +34,6 @@ fi
 pkg list -v "${need[@]}"
 
 cargo --version
-cargo install cargo-readme
 rustc --version
 
 banner test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --locked --profile=ci
+          args: --profile=ci
   check:
     name: Check
     strategy:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --locked  --profile=ci
+          args: --profile=ci
   test:
     name: Test
     strategy:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --locked  --all --profile=ci
+          args: --all --profile=ci
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -92,4 +92,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --locked --profile=ci -- -D warnings
+          args: --profile=ci -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --profile=ci
+          args: --locked  --profile=ci
   check:
     name: Check
     strategy:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --profile=ci
+          args: --locked  --profile=ci
   test:
     name: Test
     strategy:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --profile=ci
+          args: --locked  --all --profile=ci
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -92,4 +92,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --profile=ci -- -D warnings
+          args: --locked --profile=ci -- -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --locked  --profile=ci
+          args: --locked --profile=ci
   check:
     name: Check
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,10 +26,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install cargo-readme
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-readme
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -57,10 +53,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install cargo-readme
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-readme
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -83,10 +75,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install cargo-readme
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-readme
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -101,10 +89,6 @@ jobs:
         with:
           submodules: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install cargo-readme
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-readme
       - uses: actions-rs/cargo@v1
         with:
           command: clippy

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,10 +20,6 @@ jobs:
           toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install cargo-readme
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-readme
       - uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
Currently, the Humility CI workflow attempts to run `cargo install
cargo-readme`. Unfortunately, this is now broken on our MSRV, because
`cargo-readme` won't build with un-locked dependencies on our MSRV (e.g.
[this failed CI job][1]). Fortunately, however, we no longer actually
need to install `cargo-readme` using `cargo-install`; as of #444, our
build scripts now depend on it as a normal lib dep, instead. And because
we depend on it as a normal Cargo lib dep, it's in our lockfile, and the
version in the lockfile should (hopefully) build on MSRV.

This commit removes the `cargo install cargo-readme` step from CI.
Hopefully, this fixes the CI build...

[1]: https://github.com/oxidecomputer/humility/actions/runs/8072478131/job/22054313203?pr=449