### PR TITLE
bump version to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.0
+humility 0.11.1
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.0
+humility 0.11.1
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.0
+humility 0.11.1
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.0
+humility 0.11.1
 
 ```


### PR DESCRIPTION
As suggested by @bcantrill in [this comment][1], recent changes from PRs #452 and # 453 have added new user-visible features, so we ought to bump the patch version of Humility to indicate this.

[1]: https://github.com/oxidecomputer/humility/pull/453#pullrequestreview-1934969010