### PR TITLE
lsusb: fix backwards VID:PID output

### DIFF
--- a/cmd/lsusb/src/lib.rs
+++ b/cmd/lsusb/src/lib.rs
@@ -80,7 +80,7 @@ fn list1(dev: &rusb::Device<impl rusb::UsbContext>) -> Result<String> {
     let handle = match dev.open() {
         Ok(handle) => handle,
         Err(e) => {
-            return Err(anyhow!("{pid:04x}:{vid:04x}:???\topen failed: {e}"));
+            return Err(anyhow!("{vid:04x}:{pid:04x}:???\topen failed: {e}"));
         }
     };
     let lang = *handle
@@ -99,7 +99,7 @@ fn list1(dev: &rusb::Device<impl rusb::UsbContext>) -> Result<String> {
         .read_serial_number_string(lang, &desc, TIMEOUT)
         .unwrap_or_else(|_| "(serial unknown)".to_string());
 
-    Ok(format!("{pid:04x}:{vid:04x}:{serial}\t{man}\t{prod}"))
+    Ok(format!("{vid:04x}:{pid:04x}:{serial}\t{man}\t{prod}"))
 }
 
 pub fn init() -> Command {


### PR DESCRIPTION
I just lost a kind of embarassing amount of time to the fact that `humility lsusb` _claims_ to print USB devices in the format `VID:PID:SERIAL`, but actually outputs `PID:VID:SERIAL`. To spare others from the suffering this caused me, this commit changes the command to actually print what it says it does.

I chose to bring the output in line with the help text, rather than the other way around, because the help text's format is the same format used by the `--probe` CLI flag and the `environment.json` file format, and using `PID:VID:SERIAL` with `--probe` or in the config file will make Humility unhappy.

Fixes #479