### PR TITLE
lsusb: make `humility lsusb` environment-aware

### DIFF
--- a/humility-cli/src/env.rs
+++ b/humility-cli/src/env.rs
@@ -43,7 +43,7 @@ impl Environment {
         }
     }
 
-    fn read(filename: &str) -> Result<IndexMap<String, Environment>> {
+    pub fn read(filename: &str) -> Result<IndexMap<String, Environment>> {
         let path = PathBuf::from(filename);
         let input = fs::read_to_string(path)?;
         Ok(serde_json::from_str(&input)?)

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-mod env;
+pub mod env;
 
 use anyhow::Result;
 use clap::{AppSettings, ArgGroup, ArgMatches, Parser};


### PR DESCRIPTION
This commit changes `humility lsusb` to be aware of the `HUMILITY_ENVIRONMENT` env var/`--environment` CLI argument. Now, if an environment file is provided, `humility lsusb` will check whether a probe matching the VID:PID:SERIAL declared for each target in the environment file was found. If a probe is found, the target will be listed when listing probes. If no probe is found for a target, then the command will print a warning listing all the targets with missing probes.

This should be helpful for diagnosing a variety of issues. For example, we may not find probes declared in the environment file if the environment file is misconfigured, where Humility is not run with sufficient permissions to access some probes, or where a probe has been disconnected without the user's knowledge. All of these situations have happened to me personally; in particular, a typo in the environment file is hard to diagnose, since `humility lsusb` will show (correctly) that the probe is attached but does not indicate that the environment file contains a slightly different probe identifier. So, making `humility lsusb` warn about missing probes should make it a bit easier to diagnose such situations.

For example, with the following environment file:
```json
{
  "gimletlet": {
    "archive": "/home/eliza/Code/oxide/hubris/target/gimletlet/dist/default/build-gimletlet-image-default.zip",
    "probe": "0483:3754:000B00154D46501520383832"
  },
  "nucleo": {
    "archive": "/home/eliza/Code/oxide/hubris/target/demo-stm32h753-nucleo/dist/default/build-demo-stm32h753-nucleo-image-default.zip",
    "probe": "0483:375e:0030003C3431511237393330"
  },
  "rot": {
    "archive": {
      "a": "/home/eliza/Code/oxide/hubris/target/rot-carrier/dist/a/build-rot-carrier-image-a.zip",
      "b": "/home/eliza/Code/oxide/hubris/target/rot-carrier/dist/b/build-rot-carrier-image-b.zip"
    },
    "probe": "0143:1fc9:53BKD0YYVRBPB"
  }
}
```
and only the Gimletlet probe currently attached to the system, the `humility lsusb` command will output the following:

```console
$ HUMILITY_ENVIRONMENT=~/.config/humility/environment.json

$ humility lsusb
humility: USB device scan, 1 successful and 30 failed
humility: --- successfully opened devices ---
humility: format: VID:PID:SERIAL, then manufacturer name, then product name
humility: 0483:3754:000B00154D46501520383832	STMicroelectronics	STLINK-V3 (target: gimletlet)
humility: --- failures ---
humility: could not access 30 devices:
humility: bus 1, addr 1, port 0: 1d6b:0002:???	open failed: Access denied (insufficient permissions)
humility: bus 1, addr 2, port 4: 27c6:609c:???	open failed: Access denied (insufficient permissions)
humility: bus 1, addr 3, port 5: 0e8d:e616:???	open failed: Access denied (insufficient permissions)
humility: bus 2, addr 1, port 0: 1d6b:0003:???	open failed: Access denied (insufficient permissions)
humility: bus 3, addr 1, port 0: 1d6b:0002:???	open failed: Access denied (insufficient permissions)
humility: bus 3, addr 2, port 1: 0bda:5634:???	open failed: Access denied (insufficient permissions)
humility: bus 4, addr 1, port 0: 1d6b:0003:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 1, port 0: 1d6b:0002:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 58, port 1: 0424:4206:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 59, port 1: feed:1307:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 62, port 4: 0424:4216:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 64, port 5: 0424:7260:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 67, port 5: 0424:7240:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 69, port 2: 2e8a:000b:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 75, port 3: 05ac:0265:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 76, port 2: 2109:2817:???	open failed: Access denied (insufficient permissions)
humility: bus 5, addr 78, port 4: 2109:2817:???	open failed: Access denied (insufficient permissions)
humility: bus 6, addr 1, port 0: 1d6b:0003:???	open failed: Access denied (insufficient permissions)
humility: bus 6, addr 8, port 1: 0424:7206:???	open failed: Access denied (insufficient permissions)
humility: bus 6, addr 9, port 4: 0424:7216:???	open failed: Access denied (insufficient permissions)
humility: bus 6, addr 10, port 3: 0bda:8153:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 1, port 0: 1d6b:0002:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 11, port 1: 0bda:5483:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 12, port 1: 0bda:5483:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 13, port 2: 046d:0ab7:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 14, port 2: 0bda:8153:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 15, port 3: 1532:0e03:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 16, port 3: 0403:6015:???	open failed: Access denied (insufficient permissions)
humility: bus 7, addr 18, port 5: 0bda:1100:???	open failed: Access denied (insufficient permissions)
humility: bus 8, addr 1, port 0: 1d6b:0003:???	open failed: Access denied (insufficient permissions)
humility: WARNING: --- could not find 2 probes declared in HUMILITY_ENVIRONMENT ---
humility: WARNING: HUMILITY_ENVIRONMENT=/home/eliza/.config/humility/environment.json
humility: WARNING: TARGET PROBE
humility: WARNING: nucleo 0483:375e:0030003C3431511237393330
humility: WARNING: rot    0143:1fc9:53BKD0YYVRBPB
$
```

Note that:

- For the `gimletlet` target, we found a matching ST-Link probe and printed the target name next to the probe.
- For the `nucleo` and `rot` targets, we did not find probes matching the ones declared in the environment file, so we printed a warning indicating that those probes were missing.

Fixes #481