### PR TITLE
diagnose: support newer kernels

### DIFF
--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -14,7 +14,7 @@
 //! into things the _application_ may think are fishy -- only general behaviors
 //! at the OS level, like faults.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
@@ -94,9 +94,9 @@ fn diagnose(context: &mut ExecutionContext) -> Result<()> {
     println!("Taking initial snapshot of task status...");
 
     // Mise en place:
-    let base = core.read_word_32(hubris.lookup_symword("TASK_TABLE_BASE")?)?;
-    let task_count =
-        core.read_word_32(hubris.lookup_symword("TASK_TABLE_SIZE")?)? as usize;
+    let (base, task_count) =
+        hubris.task_table(core).context("failed to load task table")?;
+    let task_count = task_count as usize;
     let task_t = hubris.lookup_struct_byname("Task")?.clone();
 
     // Park the core so that we don't have stuff changing out from under us.

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -14,7 +14,7 @@
 //! into things the _application_ may think are fishy -- only general behaviors
 //! at the OS level, like faults.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
@@ -94,8 +94,7 @@ fn diagnose(context: &mut ExecutionContext) -> Result<()> {
     println!("Taking initial snapshot of task status...");
 
     // Mise en place:
-    let (base, task_count) =
-        hubris.task_table(core).context("failed to load task table")?;
+    let (base, task_count) = hubris.task_table(core)?;
     let task_count = task_count as usize;
     let task_t = hubris.lookup_struct_byname("Task")?.clone();
 


### PR DESCRIPTION
Currently, the `humility diagnose` command contains its own code for looking up the task table. This code only uses the `TASK_TABLE_BASE` symbol used by older kernels, and does not look for the `TASK_TABLE_SPACE` symbol used by newer kernels. This means that on a recent kernel, the `diagnose` command will fail:

```console
$ humility -t gimletlet diagnose
humility: attached to 0483:3754:000B00154D46501520383832 via ST-Link V3

--- Initial Inspection ---

Taking initial snapshot of task status...
humility diagnose failed: expected symbol TASK_TABLE_BASE not found

```

This commit changes `humility diagnose` to use the `HubrisArchive::task_table` method to look up the task table, instead. Unlike the previous code, this method will look for both the `TASK_TABLE_BASE` and `TASK_TABLE_SIZE` symbols of older kernels, _and_ the `TASK_TABLE_SPACE` symbol of newer kernels. Now, it works for my recent Hubris build:

```console
$ humility -t gimletlet diagnose
humility: attached to 0483:3754:000B00154D46501520383832 via ST-Link V3

--- Initial Inspection ---

Taking initial snapshot of task status...
System last rebooted 791183 ticks ago; assuming tick=millisecond, 791.183s ago
Snapshot taken, 25 tasks in application.

--- Tasks: First Pass ---

Checking for any suspicious task attributes...

--- Advancing Time ---

Resuming core for a bit...
Core halted after 1001 more ticks.

--- Tasks: Second Pass ---

--- Generating Coredump ---

humility: dumping to hubris.core.0
humility: dumped 731.46KB in 29 seconds
Leaving CPU halted in case you want to inspect.

--- End Of Report ---

```

Fixes #483