### PR TITLE
idol: assume missing args structs are ZST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.5"
+version = "0.11.6"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -705,7 +705,7 @@ fn monorail_status(
         // They're placed back-to-back in Hiffy code, so we'll call the two
         // loops one after the other (i.e. values are not interleaved!)
         for op in [&op_port, &op_phy] {
-            assert_eq!(op.args.members.len(), 1); // Sanity-check!
+            assert_eq!(op.args.unwrap().members.len(), 1); // Sanity-check!
             let ret_size = hubris.typesize(op.ok)? as u32;
 
             // Here we go!

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.5
+humility 0.11.6
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.5
+humility 0.11.6
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.5
+humility 0.11.6
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.5
+humility 0.11.6
 
 ```


### PR DESCRIPTION
We've got a range of versions of the idolatry code generator in the wild where rustc doesn't emit the foo_ARGS structs for arg-less functions, particularly when using encoding other than zerocopy. Humility won't send arg-less IPCs to firmware in this range of versions.

This is the root cause of https://github.com/oxidecomputer/hubris/issues/1777

I'm also patching Idolatry to make it more likely to produce DWARF, but I think it's best for Humility to tolerate such unused zero-size structs not being omitted.