### PR TITLE
improve dump handling with respect to space consumed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.10"
+version = "0.11.11"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -97,7 +97,7 @@ struct DumpArgs {
     timeout: u32,
 
     /// show dump agent status
-    #[clap(long, conflicts_with_all = &["simulation", "task", "all"])]
+    #[clap(long, conflicts_with_all = &["simulation", "task", "extract-all"])]
     dump_agent_status: bool,
 
     /// force use of the dump agent when directly attached with a debug probe
@@ -111,12 +111,12 @@ struct DumpArgs {
     /// force manual initiation, leaving target halted
     #[clap(
         long, requires = "force-dump-agent",
-        conflicts_with_all = &["all", "task"]
+        conflicts_with_all = &["extract-all", "task"]
     )]
     force_manual_initiation: bool,
 
     /// force existing in situ dump to be read
-    #[clap(long, conflicts_with_all = &["simulation", "task", "all"])]
+    #[clap(long, conflicts_with_all = &["simulation", "task", "extract-all"])]
     force_read: bool,
 
     /// initialize dump state, clearing any dump at the dump agent
@@ -141,7 +141,7 @@ struct DumpArgs {
     /// in addition to simulating the dumper, generate a stock dump
     #[clap(
         long, requires = "simulation",
-        conflicts_with_all = &["task", "all"],
+        conflicts_with_all = &["task", "extract-all"],
         value_name = "filename",
     )]
     stock_dumpfile: Option<String>,
@@ -154,7 +154,7 @@ struct DumpArgs {
     /// simulates a single-task dump
     #[clap(
         long,
-        conflicts_with_all = &["area", "stock-dumpfile", "list"],
+        conflicts_with_all = &["extract", "stock-dumpfile", "list"],
         requires = "simulate-dumper",
         value_name = "task",
     )]
@@ -163,7 +163,7 @@ struct DumpArgs {
     /// dumps a single task
     #[clap(
         long,
-        conflicts_with_all = &["simulation", "list", "area"],
+        conflicts_with_all = &["simulation", "list", "extract"],
         value_name = "task",
     )]
     task: Option<String>,
@@ -179,7 +179,7 @@ struct DumpArgs {
     #[clap(
         long,
         alias = "all",
-        conflicts_with_all = &["simulation", "list", "area", "task"]
+        conflicts_with_all = &["simulation", "list", "extract", "task"]
     )]
     extract_all: bool,
 
@@ -188,7 +188,7 @@ struct DumpArgs {
     leave_halted: bool,
 
     /// list all dump areas
-    #[clap(long, short, conflicts_with_all = &["simulation", "area"])]
+    #[clap(long, short, conflicts_with_all = &["simulation", "extract"])]
     list: bool,
 
     /// print dump breakdown

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -401,7 +401,7 @@ fn dump_via_agent(
     // will discover the task when we actually read our dump headers, so
     // leave it as None for now...
     //
-    let task = match &subargs.simulate_task_dump {
+    let mut task = match &subargs.simulate_task_dump {
         Some(task) => {
             if !subargs.simulate_dumper {
                 bail!("--simulate-task-dump requires --simulate-dumper");
@@ -657,7 +657,8 @@ fn dump_via_agent(
         //
         // If we're here, we have a dump in situ -- time to pull it.
         //
-        let (task, breakdown) = agent.read_dump(area, &mut out, true)?;
+        let (t, breakdown) = agent.read_dump(area, &mut out, true)?;
+        task = t;
 
         print_dump_breakdown(&breakdown);
 
@@ -802,11 +803,13 @@ fn dump_all(
 
             let mut out = DumpAgentCore::new(HubrisFlashMap::new(hubris)?);
             let started = Some(Instant::now());
-            let (task, _breakdown) = agent.read_dump(
+            let (task, breakdown) = agent.read_dump(
                 Some(DumpArea::ByIndex(*area)),
                 &mut out,
                 true,
             )?;
+            print_dump_breakdown(&breakdown);
+
             assert!(task.is_some());
             hubris.dump(&mut out, task, Some(&dumpfile), started)?;
         }

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.10
+humility 0.11.11
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.10
+humility 0.11.11
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.10
+humility 0.11.11
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.10
+humility 0.11.11
 
 ```


### PR DESCRIPTION
Draft comment:

```
hubris#1804 resulted in needlessly opaque symptoms.  This cleans up
"humility dump" to give a better error message when we have run out of
space, and adds a new option (--print-dump-breakdown) to explain where
the space went.  This also cleans up the options a bit (e.g., ditching
the confusing -F; renaming --all to --extract-all, but perserving the
old name as an alias), makes the emulated code match what we actually
do in the RoT with respect to buffer sizing, and improves the message
when dumps are already present to guide the user to extract them
rather than overwrite them.
```
