### PR TITLE
offer some advice if we fail to open the requested probe

### DIFF
--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -1525,10 +1525,11 @@ fn open_probe_from_selector(
     {
         if selector.serial_number.is_some() {
             bail!(
-                "Could not find probe {}. Because a serial number is present, \
-                this may be due to not running humility with permission to \
-                read USB device serial numbers; if not root already, run again \
-                as root?",
+                "Could not find probe {}.\n\
+                \n\
+                Because a serial number is present, this may be due to not \
+                running humility with permission to read USB device serial \
+                numbers; if not root already, run again as root?",
                 selector
             );
         } else {


### PR DESCRIPTION
earlier this evening i was somewhat perplexed by
```
$ humility -t sidecar sensors
humility sensors failed: Probe could not be created

Caused by:
    Probe was not found.
```

but the probe i wanted _definitely_ was connected to the system.

eventually i realized that `probe_rs` tries to [read the serial number](https://github.com/oxidecomputer/probe-rs/blob/4d52bdc3fc44fc50fc2d81f8d936c3dacf40c7b8/probe-rs/src/probe/stlink/usb_interface.rs#L123-L124), fails (because i was not root), believes the device must simply not be the one i wanted (but it was!!), and reports `ProbeCreationError::NotFound`.

so, in the specific case that you're opening a probe by `vid:pid:serial` *and* the error is `NotFound`, hint that we might not have been able to look quite as fully as the user might have hoped.

i'd typically check if `libc::getuid() == 0` before suggesting "try as root", but i saw some `#[cfg]` that suggest Humility is expected to work on Windows (neat!) and i'm not sure if that applies so generally. and on some systems users could be in the `usb` group so you might not _need_ root to get a serial number anyway. so i decided to leave it at "if not root already..." in the hopes that whoever reads it understands the right meaning in their context.

with this change, the same command errors somewhat more helpfully:
```
$ ./humility -t sidecar sensors
humility sensors failed: Could not find probe 0483:374e:002900184741500520383733. 

Because a serial number is present, this may be due to not running humility with permission to read USB device serial numbers; if not root already, run again as root?
```