### PR TITLE
Finish and clear progress bars rather than leave them possibly finished.

### DIFF
--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -254,6 +254,7 @@ impl<'a> AuxFlashHandler<'a> {
             bar.set_position(offset as u64);
         }
         bar.set_position(out.len() as u64);
+        bar.finish_and_clear();
 
         Ok(out)
     }
@@ -349,6 +350,7 @@ impl<'a> AuxFlashHandler<'a> {
             bar.set_position(offset as u64);
         }
         bar.set_position(data.len() as u64);
+        bar.finish_and_clear();
         humility::msg!("done");
         Ok(())
     }

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -2693,6 +2693,7 @@ fn rendmp(context: &mut ExecutionContext) -> Result<()> {
                 }
             }
         }
+        bar.finish_and_clear();
     }
 
     Ok(())

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -99,7 +99,7 @@ impl<'a> EepromHandler<'a> {
             }
             bar.set_position(offset as u64);
         }
-
+        bar.finish_and_clear();
         Ok(out)
     }
 


### PR DESCRIPTION
Inidcatif suggests you need to `.finish()` or `.finish_and_clear() `progress bars.  I surveyed the uses of humility progress bars and added finish_and_clear() when it was missing.

Resolves #502 