### PR TITLE
Look for ELF symbols as a fallback in stack traces

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2962,7 +2962,7 @@ impl HubrisArchive {
                 Some((addr, sym)) if pc < *addr + sym.size => {
                     Some(HubrisStackSymbol {
                         addr: sym.addr,
-                        name: sym.demangled_name.to_owned(),
+                        name: &sym.demangled_name,
                         goff: Some(sym.goff),
                     })
                 }
@@ -2970,7 +2970,7 @@ impl HubrisArchive {
                     Some((addr, (name, len))) if pc < *addr + *len => {
                         Some(HubrisStackSymbol {
                             addr: *addr,
-                            name: name.to_owned(),
+                            name,
                             goff: None,
                         })
                     }
@@ -6356,8 +6356,8 @@ pub enum HubrisTarget {
 
 /// Lightweight stack symbol with either DWARF or ELF symbol info
 #[derive(Clone, Debug)]
-pub struct HubrisStackSymbol {
-    pub name: String,
+pub struct HubrisStackSymbol<'a> {
+    pub name: &'a str,
     pub addr: u32,
     pub goff: Option<HubrisGoff>,
 }
@@ -6365,7 +6365,7 @@ pub struct HubrisStackSymbol {
 #[derive(Clone, Debug)]
 pub struct HubrisStackFrame<'a> {
     pub cfa: u32,
-    pub sym: Option<HubrisStackSymbol>,
+    pub sym: Option<HubrisStackSymbol<'a>>,
     pub registers: BTreeMap<ARMRegister, u32>,
     pub inlined: Option<Vec<HubrisInlined<'a>>>,
 }

--- a/humility-stack/src/lib.rs
+++ b/humility-stack/src/lib.rs
@@ -55,14 +55,13 @@ impl StackPrinter {
                 }
             }
 
-            if let Some(sym) = frame.sym {
-                println!(
-                    "0x{:08x} 0x{:08x} {}",
-                    frame.cfa, *pc, sym.demangled_name
-                );
+            if let Some(sym) = &frame.sym {
+                println!("0x{:08x} 0x{:08x} {}", frame.cfa, *pc, sym.name);
 
                 if self.line {
-                    if let Some(src) = hubris.lookup_src(sym.goff) {
+                    if let Some(src) =
+                        sym.goff.and_then(|g| hubris.lookup_src(g))
+                    {
                         print_indent();
                         println!("{:11}@ {}:{}", "", src.fullpath(), src.line);
                     }

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.stdout
@@ -300,7 +300,9 @@ ID TASK                       GEN PRI STATE
    |                 @ /hubris/sys/userlib/src/lib.rs:368
    |      0x240591e8 0x0808e0c4 core::ops::function::FnOnce::call_once
    |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250
-   |      0x240592e8 0x0808db12
+   |      0x240592e8 0x0808db12 core::ptr::read_volatile
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1667
+   |      0x240592e8 0x0808db12 drv_stm32xx_i2c::I2cController::operate_as_target
    |      0x24059380 0x0808e2f4 main
    |                 @ /hubris/task/spd/src/main.rs:81
    |

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.stdout
@@ -300,7 +300,9 @@ ID TASK                       GEN PRI STATE
    |                 @ /hubris/sys/userlib/src/lib.rs:368
    |      0x240591e8 0x0808e0c4 core::ops::function::FnOnce::call_once
    |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250
-   |      0x240592e8 0x0808db12
+   |      0x240592e8 0x0808db12 core::ptr::read_volatile
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1667
+   |      0x240592e8 0x0808db12 drv_stm32xx_i2c::I2cController::operate_as_target
    |      0x24059380 0x0808e2f4 main
    |                 @ /hubris/task/spd/src/main.rs:81
    |

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
@@ -381,7 +381,7 @@ ID TASK                       GEN PRI STATE
                 }
 
  6 spd                          0   2 RUNNING
-   stack unwind failed: failed to read cfa 0x9, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200042d0, sym: Some(HubrisSymbol { addr: 8041f8a, name: "sys_recv_stub", demangled_name: "userlib::sys_recv_stub", size: 22, goff: HubrisGoff { object: 7, goff: 13d7c } }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 200042e8, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042d0, LR: 8040675, PC: 8041f9e, PSR: 41000000}, inlined: Some([]) }, HubrisStackFrame { cfa: 200042f0, sym: Some(HubrisSymbol { addr: 8040660, name: "call_once<task_spd::main::{closure#4}, (u32)>", demangled_name: "core::ops::function::FnOnce::call_once", size: 20, goff: HubrisGoff { object: 7, goff: ecf } }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 1, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042f0, LR: 804044b, PC: 8040674, PSR: 41000000}, inlined: Some([]) }]
+   stack unwind failed: failed to read cfa 0x9, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200042d0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 8041f8a, goff: Some(HubrisGoff { object: 7, goff: 13d7c }) }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 200042e8, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042d0, LR: 8040675, PC: 8041f9e, PSR: 41000000}, inlined: Some([]) }, HubrisStackFrame { cfa: 200042f0, sym: Some(HubrisStackSymbol { name: "core::ops::function::FnOnce::call_once", addr: 8040660, goff: Some(HubrisGoff { object: 7, goff: ecf }) }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 1, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042f0, LR: 804044b, PC: 8040674, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
     address (0x5) below range (HubrisRegion { daddr: Some(800766c), base: 20004000, size: 4000, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(6)] })
@@ -499,7 +499,7 @@ Caused by:
                 }
 
  8 power                        0   3 ready
-   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200143e0, sym: Some(HubrisSymbol { addr: 80512fa, name: "sys_recv_stub", demangled_name: "userlib::sys_recv_stub", size: 22, goff: HubrisGoff { object: 9, goff: 1c35b } }), registers: {R0: 8051bdc, R1: 0, R2: 80000000, R3: 2001448c, R4: 0, R5: ffff, R6: 80000000, R7: 0, R8: 0, R9: 0, R10: 8051bdc, R11: 1, R12: 0, SP: 200143e0, LR: 8050163, PC: 8051302, PSR: 41000000}, inlined: Some([]) }]
+   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200143e0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 80512fa, goff: Some(HubrisGoff { object: 9, goff: 1c35b }) }), registers: {R0: 8051bdc, R1: 0, R2: 80000000, R3: 2001448c, R4: 0, R5: ffff, R6: 80000000, R7: 0, R8: 0, R9: 0, R10: 8051bdc, R11: 1, R12: 0, SP: 200143e0, LR: 8050163, PC: 8051302, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
     address (0x4) below range (HubrisRegion { daddr: Some(80076ac), base: 20014000, size: 800, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(8)] })


### PR DESCRIPTION
Adds a new `HubrisStackSymbol` type which can be populated either from ELF or DWARF data, and uses that type when printing stack traces (instead of `HubrisSymbol`, which is DWARF-specific).

This finds additional function names in some cases; see the test suite changes for an example.