### PR TITLE
Better backtraces from stack overflows

### DIFF
--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -306,7 +306,8 @@ fn test(context: &mut ExecutionContext) -> Result<()> {
         writeln!(out, "==== Task state")?;
 
         cmd_tasks::print_tasks(
-            &mut out, core, hubris, false, false, false, false, false, None,
+            &mut out, core, hubris, false, false, false, false, false, false,
+            None,
         )?;
     }
     println!("Ran a total of {} cases", ran_cases);

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -190,7 +190,7 @@ fn make_all_tests() -> Result<()> {
         Test::witharg(Kind::Postmortem, "sensors-read", "sensors", ""),
         Test::basic(Kind::Postmortem, "stackmargin"),
         Test::basic(Kind::Postmortem, "tasks"),
-        Test::witharg(Kind::Postmortem, "tasks-slvr", "tasks", "-slvr"),
+        Test::witharg(Kind::Postmortem, "tasks-slvr", "tasks", "-slvr --guess"),
         Test::basic(Kind::Postmortem, "counters"),
         Test::witharg(Kind::Postmortem, "counters-list", "counters", "list"),
         Test::witharg(Kind::Postmortem, "counters-full", "counters", "--full"),

--- a/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.chilly.0 tasks -slvr"
+args = "-d hubris.core.chilly.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
@@ -2,6 +2,7 @@ system time = 6193
 ID TASK                       GEN PRI STATE    
 19 control_plane_agent          1   6 FAULT: stack overflow; sp=0x2402ff90 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x2402ff90
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x24001108 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
@@ -2,7 +2,30 @@ system time = 6193
 ID TASK                       GEN PRI STATE    
 19 control_plane_agent          1   6 FAULT: stack overflow; sp=0x2402ff90 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x2402ff90
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x24030090 0x08027790 drv_lpc55_update_api::_::<impl serde::de::Deserialize for drv_lpc55_update_api::RotBootInfo>::deserialize
+   |                 @ /hubris/drv/lpc55-update-api/src/lib.rs:102
+   |      0x24030198 0x0802883c <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
+   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/result.rs:1985
+   |      0x24030198 0x0802882e hubpack::de::deserialize
+   |                 @ /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hubpack-0.1.2/src/de.rs:22
+   |      0x24030198 0x0802883c drv_sprot_api::SpRot::rot_boot_info
+   |      0x24030890 0x0801c218 <task_control_plane_agent::mgs_handler::MgsHandler as gateway_messages::sp_impl::SpHandler>::sp_state
+   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:556
+   |      0x24030890 0x0801c2aa gateway_messages::sp_impl::handle_mgs_request
+   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:684
+   |      0x24031000 0x08023c8c <core::option::Option<T> as core::ops::try_trait::Try>::branch
+   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/option.rs:2476
+   |      0x24031000 0x08023628 gateway_messages::sp_impl::handle_message
+   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:402
+   |      0x24031000 0x08022b32 <task_control_plane_agent::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:253
+   |      0x24031000 0x080229f8 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |      0x24031000 0x08023c8c main
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:216
+   |
    |
    +-----------> 0x24001108 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.control_plane_agent.overflow.0 tasks -slvr"
+args = "-d hubris.core.control_plane_agent.overflow.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.counters.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.counters.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.counters.0 tasks -slvr"
+args = "-d hubris.core.counters.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.duplicate_HostFlash_hash_REPLY.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.duplicate_HostFlash_hash_REPLY.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.duplicate_HostFlash_hash_REPLY tasks -slvr"
+args = "-d hubris.core.duplicate_HostFlash_hash_REPLY tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.extern-regions.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.extern-regions.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.extern-regions tasks -slvr"
+args = "-d hubris.core.extern-regions tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.flash-ram-mismatch.0.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.flash-ram-mismatch.0 tasks -slvr"
+args = "-d hubris.core.flash-ram-mismatch.0 tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.host-panic.0 tasks -slvr"
+args = "-d hubris.core.host-panic.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.1.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.host-panic.1 tasks -slvr"
+args = "-d hubris.core.host-panic.1 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.2.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.2.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.host-panic.2 tasks -slvr"
+args = "-d hubris.core.host-panic.2 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.host-panic.3 tasks -slvr"
+args = "-d hubris.core.host-panic.3 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.host-panic.4 tasks -slvr"
+args = "-d hubris.core.host-panic.4 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.idol-returns-an-enum.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.idol-returns-an-enum.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.idol-returns-an-enum tasks -slvr"
+args = "-d hubris.core.idol-returns-an-enum tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.igor.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.igor.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.igor.0 tasks -slvr"
+args = "-d hubris.core.igor.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.in_bootloader.0 tasks -slvr"
+args = "-d hubris.core.in_bootloader.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.inheritance.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.inheritance.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.inheritance.0 tasks -slvr"
+args = "-d hubris.core.inheritance.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ipc-counts.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ipc-counts.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ipc-counts.0 tasks -slvr"
+args = "-d hubris.core.ipc-counts.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kernel-panic.0 tasks -slvr"
+args = "-d hubris.core.kernel-panic.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.1.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kernel-panic.1 tasks -slvr"
+args = "-d hubris.core.kernel-panic.1 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
@@ -2,7 +2,8 @@ system time = 120445
 ID TASK                       GEN PRI STATE    
  0 runner                       0   0 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: Do not have unwind info for the given address.
    |
    +-----------> 0x200000a8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
@@ -2,6 +2,7 @@ system time = 120445
 ID TASK                       GEN PRI STATE    
  0 runner                       0   0 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200000a8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.0 tasks -slvr"
+args = "-d hubris.core.kiowa.0 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
@@ -194,7 +194,11 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: failed to read cfa 0x20002400, offset 0xfffffffffffffffc: []
+
+Caused by:
+    address (0x200023fc) below range (HubrisRegion { daddr: Some(8004b1c), base: 20002400, size: 400, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(5)] })
    |
    +-----------> 0x20000328 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
@@ -194,6 +194,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000328 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.1 tasks -slvr"
+args = "-d hubris.core.kiowa.1 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.10 tasks -slvr"
+args = "-d hubris.core.kiowa.10 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.11 tasks -slvr"
+args = "-d hubris.core.kiowa.11 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.12 tasks -slvr"
+args = "-d hubris.core.kiowa.12 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.13 tasks -slvr"
+args = "-d hubris.core.kiowa.13 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.14 tasks -slvr"
+args = "-d hubris.core.kiowa.14 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.15 tasks -slvr"
+args = "-d hubris.core.kiowa.15 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.16 tasks -slvr"
+args = "-d hubris.core.kiowa.16 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.toml
@@ -6,7 +6,7 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.17 tasks -slvr"
+args = "-d hubris.core.kiowa.17 tasks -slvr --guess"
 
 #
 # This dump is somehow short by exactly 6K -- which results in an error

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.18 tasks -slvr"
+args = "-d hubris.core.kiowa.18 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.19 tasks -slvr"
+args = "-d hubris.core.kiowa.19 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
@@ -194,7 +194,11 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: failed to read cfa 0x20002400, offset 0xfffffffffffffffc: []
+
+Caused by:
+    address (0x200023fc) below range (HubrisRegion { daddr: Some(8004b58), base: 20002400, size: 400, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(5)] })
    |
    +-----------> 0x20000308 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
@@ -194,6 +194,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000308 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.2 tasks -slvr"
+args = "-d hubris.core.kiowa.2 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.20 tasks -slvr"
+args = "-d hubris.core.kiowa.20 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.21 tasks -slvr"
+args = "-d hubris.core.kiowa.21 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.22 tasks -slvr"
+args = "-d hubris.core.kiowa.22 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.23 tasks -slvr"
+args = "-d hubris.core.kiowa.23 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.24 tasks -slvr"
+args = "-d hubris.core.kiowa.24 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.25 tasks -slvr"
+args = "-d hubris.core.kiowa.25 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.26 tasks -slvr"
+args = "-d hubris.core.kiowa.26 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.27 tasks -slvr"
+args = "-d hubris.core.kiowa.27 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.28 tasks -slvr"
+args = "-d hubris.core.kiowa.28 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.29 tasks -slvr"
+args = "-d hubris.core.kiowa.29 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.3.fails.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.3.fails.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.3.fails tasks -slvr"
+args = "-d hubris.core.kiowa.3.fails tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.30 tasks -slvr"
+args = "-d hubris.core.kiowa.30 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.31 tasks -slvr"
+args = "-d hubris.core.kiowa.31 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.4 tasks -slvr"
+args = "-d hubris.core.kiowa.4 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.49 tasks -slvr"
+args = "-d hubris.core.kiowa.49 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
@@ -480,7 +480,8 @@ ID TASK                       GEN PRI STATE
 
 10 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
@@ -480,6 +480,7 @@ ID TASK                       GEN PRI STATE
 
 10 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.5 tasks -slvr"
+args = "-d hubris.core.kiowa.5 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.50 tasks -slvr"
+args = "-d hubris.core.kiowa.50 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.51 tasks -slvr"
+args = "-d hubris.core.kiowa.51 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.52 tasks -slvr"
+args = "-d hubris.core.kiowa.52 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.53 tasks -slvr"
+args = "-d hubris.core.kiowa.53 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.6 tasks -slvr"
+args = "-d hubris.core.kiowa.6 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.7 tasks -slvr"
+args = "-d hubris.core.kiowa.7 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.8 tasks -slvr"
+args = "-d hubris.core.kiowa.8 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.9 tasks -slvr"
+args = "-d hubris.core.kiowa.9 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.idol.qpsi.1 tasks -slvr"
+args = "-d hubris.core.kiowa.idol.qpsi.1 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.rick.0 tasks -slvr"
+args = "-d hubris.core.kiowa.rick.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.kiowa.stm32h743-nucleo.0 tasks -slvr"
+args = "-d hubris.core.kiowa.stm32h743-nucleo.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.new-ringbuf.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.new-ringbuf.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.new-ringbuf tasks -slvr"
+args = "-d hubris.core.new-ringbuf tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.new-sensors.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.new-sensors.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.new-sensors tasks -slvr"
+args = "-d hubris.core.new-sensors tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.nightly-2022-11-01.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.nightly-2022-11-01.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.nightly-2022-11-01 tasks -slvr"
+args = "-d hubris.core.nightly-2022-11-01 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
@@ -430,6 +430,7 @@ ID TASK                       GEN PRI STATE
 
  9 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000558 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
@@ -430,7 +430,8 @@ ID TASK                       GEN PRI STATE
 
  9 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x20000558 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.0 tasks -slvr"
+args = "-d hubris.core.ouray.0 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
@@ -244,6 +244,7 @@ ID TASK                       GEN PRI STATE
 
  5 i2c_target                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200003b8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
@@ -244,7 +244,8 @@ ID TASK                       GEN PRI STATE
 
  5 i2c_target                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200003b8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.1 tasks -slvr"
+args = "-d hubris.core.ouray.1 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
@@ -96,7 +96,8 @@ ID TASK                       GEN PRI STATE
 
  2 usart_driver                 0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: Do not have unwind info for the given address.
    |
    +-----------> 0x200001e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
@@ -96,6 +96,7 @@ ID TASK                       GEN PRI STATE
 
  2 usart_driver                 0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200001e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.10 tasks -slvr"
+args = "-d hubris.core.ouray.10 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
@@ -194,7 +194,11 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20002400 0x08014130 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |
    |
    +-----------> 0x20000388 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
@@ -194,6 +194,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000388 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.11 tasks -slvr"
+args = "-d hubris.core.ouray.11 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
@@ -324,7 +324,19 @@ ID TASK                       GEN PRI STATE
 
  5 spd                         61   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20002ba0 0x080190d8 rust_begin_unwind
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874
+   |      0x20002bb8 0x080182b2 core::panicking::panic_fmt
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78//library/core/src/panicking.rs:77
+   |      0x20002bf0 0x08018190 core::panicking::panic_bounds_check
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78//library/core/src/panicking.rs:64
+   |      0x20002bf8 0x08018110 task_spd::Ringbuf<T,_>::entry
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:114
+   |      0x20002c00 0x080180fa main
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:117
+   |
    |
    +-----------> 0x200004f8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
@@ -324,6 +324,7 @@ ID TASK                       GEN PRI STATE
 
  5 spd                         61   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200004f8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.12 tasks -slvr"
+args = "-d hubris.core.ouray.12 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
@@ -258,7 +258,29 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200022e8 0x08015ee0 drv_stm32h7_i2c::max7358::write_reg
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:90
+   |      0x20002310 0x08016212 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:164
+   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:110
+   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:75
+   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:102
+   |      0x20002400 0x0801451c drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:315
+   |      0x20002400 0x0801451c userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
+   |      0x20002400 0x080144c2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |      0x20002400 0x080144c2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |      0x20002400 0x080147c4 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |
    |
    +-----------> 0x20000488 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
@@ -258,6 +258,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000488 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.13 tasks -slvr"
+args = "-d hubris.core.ouray.13 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
@@ -764,6 +764,7 @@ ID TASK                       GEN PRI STATE
 
 12 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000a08 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
@@ -764,7 +764,15 @@ ID TASK                       GEN PRI STATE
 
 12 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x2000a100 0x08040054 cortex_m::asm::inline::__wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:180
+   |      0x2000a100 0x08040054 cortex_m::asm::wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:54
+   |      0x2000a100 0x08040054 main
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |
    |
    +-----------> 0x20000a08 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.14 tasks -slvr"
+args = "-d hubris.core.ouray.14 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
@@ -386,7 +386,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.15 tasks -slvr"
+args = "-d hubris.core.ouray.15 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
@@ -770,6 +770,7 @@ ID TASK                       GEN PRI STATE
 
 12 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000a08 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
@@ -770,7 +770,15 @@ ID TASK                       GEN PRI STATE
 
 12 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x2000a100 0x08040054 cortex_m::asm::inline::__wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:180
+   |      0x2000a100 0x08040054 cortex_m::asm::wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:54
+   |      0x2000a100 0x08040054 main
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |
    |
    +-----------> 0x20000a08 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.16 tasks -slvr"
+args = "-d hubris.core.ouray.16 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
@@ -386,7 +386,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.17 tasks -slvr"
+args = "-d hubris.core.ouray.17 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
@@ -388,6 +388,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
@@ -388,7 +388,10 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x00000000
+   |
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.18 tasks -slvr"
+args = "-d hubris.core.ouray.18 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
@@ -258,7 +258,8 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x20000488 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
@@ -258,6 +258,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000488 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.19 tasks -slvr"
+args = "-d hubris.core.ouray.19 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
@@ -236,7 +236,11 @@ ID TASK                       GEN PRI STATE
 
  5 log                          0   3 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: failed to read cfa 0x20004000, offset 0xfffffffffffffffc: []
+
+Caused by:
+    address (0x20003ffc) below range (HubrisRegion { daddr: Some(80047d0), base: 20004000, size: 1000, attr: HubrisRegionAttr { read: true, write: true, execute: true, device: false, dma: false, external: false }, tasks: [Task(6)] })
    |
    +-----------> 0x20000358 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
@@ -236,6 +236,7 @@ ID TASK                       GEN PRI STATE
 
  5 log                          0   3 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000358 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.2 tasks -slvr"
+args = "-d hubris.core.ouray.2 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
@@ -392,6 +392,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
@@ -392,7 +392,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.20 tasks -slvr"
+args = "-d hubris.core.ouray.20 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
@@ -386,7 +386,11 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x0801c094 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.21 tasks -slvr"
+args = "-d hubris.core.ouray.21 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
@@ -386,7 +386,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x80010003
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.22 tasks -slvr"
+args = "-d hubris.core.ouray.22 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
@@ -386,7 +386,10 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x00000000
+   |
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.23 tasks -slvr"
+args = "-d hubris.core.ouray.23 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
@@ -386,7 +386,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x80010003
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.24 tasks -slvr"
+args = "-d hubris.core.ouray.24 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
@@ -386,7 +386,11 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x0801c094 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.25 tasks -slvr"
+args = "-d hubris.core.ouray.25 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
@@ -386,7 +386,10 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x00000000
+   |
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.26 tasks -slvr"
+args = "-d hubris.core.ouray.26 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
@@ -834,7 +834,15 @@ ID TASK                       GEN PRI STATE
 
 13 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x2000a900 0x08044054 cortex_m::asm::inline::__wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/../asm/inline.rs:181
+   |      0x2000a900 0x08044054 cortex_m::asm::wfi
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/asm.rs:54
+   |      0x2000a900 0x08044054 main
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |
    |
    +-----------> 0x20000ae0 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
@@ -834,6 +834,7 @@ ID TASK                       GEN PRI STATE
 
 13 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000ae0 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.27 tasks -slvr"
+args = "-d hubris.core.ouray.27 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.28.fails.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.28.fails.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.28.fails tasks -slvr"
+args = "-d hubris.core.ouray.28.fails tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
@@ -386,7 +386,10 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x200033e8 0x00000000
+   |
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.29 tasks -slvr"
+args = "-d hubris.core.ouray.29 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
@@ -192,7 +192,10 @@ ID TASK                       GEN PRI STATE
 
  4 ping                         1   4 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20002200 0x00000000
+   |
    |
    +-----------> 0x200002c8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
@@ -192,6 +192,7 @@ ID TASK                       GEN PRI STATE
 
  4 ping                         1   4 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200002c8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.3 tasks -slvr"
+args = "-d hubris.core.ouray.3 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
@@ -386,6 +386,7 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 notif: bit0(irq84)
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
@@ -386,7 +386,8 @@ ID TASK                       GEN PRI STATE
 
  6 spi_driver                   0   2 notif: bit0(irq84)
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x80010003
    |
    +-----------> 0x20000610 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.30 tasks -slvr"
+args = "-d hubris.core.ouray.30 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.31.fails.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.31.fails.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.31.fails tasks -slvr"
+args = "-d hubris.core.ouray.31.fails tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.32.fails.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.32.fails.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.32.fails tasks -slvr"
+args = "-d hubris.core.ouray.32.fails tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
@@ -2,7 +2,10 @@ system time = 289452420
 ID TASK                       GEN PRI STATE    
  0 jefe                         0   0 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20001400 0x00000000
+   |
    |
    +-----------> 0x200001a8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
@@ -2,6 +2,7 @@ system time = 289452420
 ID TASK                       GEN PRI STATE    
  0 jefe                         0   0 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200001a8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.33 tasks -slvr"
+args = "-d hubris.core.ouray.33 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.34.fails.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.34.fails.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.34.fails tasks -slvr"
+args = "-d hubris.core.ouray.34.fails tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.35 tasks -slvr"
+args = "-d hubris.core.ouray.35 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.36 tasks -slvr"
+args = "-d hubris.core.ouray.36 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.37 tasks -slvr"
+args = "-d hubris.core.ouray.37 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.38 tasks -slvr"
+args = "-d hubris.core.ouray.38 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.39 tasks -slvr"
+args = "-d hubris.core.ouray.39 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
@@ -96,6 +96,7 @@ ID TASK                       GEN PRI STATE
 
  2 usart_driver                 0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200001e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
@@ -96,7 +96,11 @@ ID TASK                       GEN PRI STATE
 
  2 usart_driver                 0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: failed to read cfa 0x20001be0, offset 0xfffffffffffffffc: []
+
+Caused by:
+    address (0x20001bdc) below range (HubrisRegion { daddr: Some(800476c), base: 20001c00, size: 400, attr: HubrisRegionAttr { read: true, write: true, execute: true, device: false, dma: false, external: false }, tasks: [Task(3)] })
    |
    +-----------> 0x200001e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.4 tasks -slvr"
+args = "-d hubris.core.ouray.4 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.40 tasks -slvr"
+args = "-d hubris.core.ouray.40 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.41 tasks -slvr"
+args = "-d hubris.core.ouray.41 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.42 tasks -slvr"
+args = "-d hubris.core.ouray.42 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.43 tasks -slvr"
+args = "-d hubris.core.ouray.43 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
@@ -258,6 +258,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                  52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x200027a8
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000490 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
@@ -258,7 +258,39 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                  52   2 FAULT: stack overflow; sp=0x200027a8 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x200027a8
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20002838 0x080160ac <userlib::panic::PrefixWrite as core::fmt::Write>::write_str
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:882
+   |      0x20002840 0x08016160 <&mut W as core::fmt::Write>::write_str
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:190
+   |      0x20002898 0x080154ca core::fmt::write
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |      0x200028d0 0x0801559c <&T as core::fmt::Display>::fmt
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:2012
+   |      0x20002928 0x08015484 core::fmt::write
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |      0x20002978 0x08015fbc <core::panic::PanicInfo as core::fmt::Display>::fmt
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panic.rs:168
+   |      0x20002978 0x08016012 <&T as core::fmt::Display>::fmt
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:2012
+   |      0x200029d0 0x08015484 core::fmt::write
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |      0x20002a08 0x08016148 core::fmt::Write::write_fmt
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:183
+   |      0x20002ab8 0x08016386 rust_begin_unwind
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874
+   |      0x20002ad0 0x08014d7e core::panicking::panic_fmt
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |      0x20002af8 0x08014c1a core::panicking::panic
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:39
+   |      0x20002b28 0x08014b38 drv_stm32h7_i2c_server::configure_port
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:500
+   |      0x20002c00 0x08014406 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:598
+   |      0x20002c00 0x08014438 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |
    |
    +-----------> 0x20000490 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.44 tasks -slvr"
+args = "-d hubris.core.ouray.44 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.45 tasks -slvr"
+args = "-d hubris.core.ouray.45 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.46 tasks -slvr"
+args = "-d hubris.core.ouray.46 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.47 tasks -slvr"
+args = "-d hubris.core.ouray.47 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.48 tasks -slvr"
+args = "-d hubris.core.ouray.48 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.49 tasks -slvr"
+args = "-d hubris.core.ouray.49 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
@@ -480,7 +480,8 @@ ID TASK                       GEN PRI STATE
 
 10 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
@@ -480,6 +480,7 @@ ID TASK                       GEN PRI STATE
 
 10 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x200005e8 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.5 tasks -slvr"
+args = "-d hubris.core.ouray.5 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.50 tasks -slvr"
+args = "-d hubris.core.ouray.50 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.51 tasks -slvr"
+args = "-d hubris.core.ouray.51 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.52 tasks -slvr"
+args = "-d hubris.core.ouray.52 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.53 tasks -slvr"
+args = "-d hubris.core.ouray.53 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.54 tasks -slvr"
+args = "-d hubris.core.ouray.54 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.55.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.55.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.55 tasks -slvr"
+args = "-d hubris.core.ouray.55 tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
@@ -194,7 +194,11 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x20002400 0x08014130 main
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |
    |
    +-----------> 0x20000348 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
@@ -194,6 +194,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000348 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.6 tasks -slvr"
+args = "-d hubris.core.ouray.6 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.61.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.61.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.61 tasks -slvr"
+args = "-d hubris.core.ouray.61 tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.62.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.62.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.62 tasks -slvr"
+args = "-d hubris.core.ouray.62 tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.63 tasks -slvr"
+args = "-d hubris.core.ouray.63 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.64 tasks -slvr"
+args = "-d hubris.core.ouray.64 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.65 tasks -slvr"
+args = "-d hubris.core.ouray.65 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.66 tasks -slvr"
+args = "-d hubris.core.ouray.66 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.67 tasks -slvr"
+args = "-d hubris.core.ouray.67 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.68 tasks -slvr"
+args = "-d hubris.core.ouray.68 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.69 tasks -slvr"
+args = "-d hubris.core.ouray.69 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
@@ -194,6 +194,7 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000328 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
@@ -194,7 +194,11 @@ ID TASK                       GEN PRI STATE
 
  4 i2c_driver                   0   2 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: failed to read cfa 0x20002400, offset 0xfffffffffffffffc: []
+
+Caused by:
+    address (0x200023fc) below range (HubrisRegion { daddr: Some(8004b24), base: 20002400, size: 400, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(5)] })
    |
    +-----------> 0x20000328 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.7 tasks -slvr"
+args = "-d hubris.core.ouray.7 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.70 tasks -slvr"
+args = "-d hubris.core.ouray.70 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.71 tasks -slvr"
+args = "-d hubris.core.ouray.71 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
@@ -528,7 +528,8 @@ ID TASK                       GEN PRI STATE
 
 11 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x20000678 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
@@ -528,6 +528,7 @@ ID TASK                       GEN PRI STATE
 
 11 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000678 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.8 tasks -slvr"
+args = "-d hubris.core.ouray.8 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
@@ -528,7 +528,8 @@ ID TASK                       GEN PRI STATE
 
 11 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   stack unwind failed: read of 4 bytes from invalid address: 0x4
    |
    +-----------> 0x20000678 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
@@ -528,6 +528,7 @@ ID TASK                       GEN PRI STATE
 
 11 idle                         0   5 RUNNING
    could not read registers: register PC not found in dump
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x20000678 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.toml
@@ -6,4 +6,4 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.ouray.9 tasks -slvr"
+args = "-d hubris.core.ouray.9 tasks -slvr --guess"

--- a/tests/cmd/tasks-slvr/tasks-slvr.panic-on-boot.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.panic-on-boot.toml
@@ -6,6 +6,6 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.panic-on-boot tasks -slvr"
+args = "-d hubris.core.panic-on-boot tasks -slvr --guess"
 
 status.code = 1

--- a/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.spoopy.0 tasks -slvr"
+args = "-d hubris.core.spoopy.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.sprot_status.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.sprot_status.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.sprot_status tasks -slvr"
+args = "-d hubris.core.sprot_status tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.static-tasks.0 tasks -slvr"
+args = "-d hubris.core.static-tasks.0 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.static-tasks.1 tasks -slvr"
+args = "-d hubris.core.static-tasks.1 tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.task.net.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.task.net.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.task.net tasks -slvr"
+args = "-d hubris.core.task.net tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
@@ -2,7 +2,41 @@ system time = 76648
 ID TASK                       GEN PRI STATE    
  8 power                        0   6 FAULT: stack overflow; sp=0x24043fa0 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x24043fa0
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x24044040 0x08088a20 core::fmt::write
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |      0x24044090 0x08088a20 core::fmt::write
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |      0x240440e0 0x0808a8e8 <core::panic::panic_info::PanicInfo as core::fmt::Display>::fmt
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panic/panic_info.rs:152
+   |      0x240440e0 0x0808a93c <&T as core::fmt::Display>::fmt
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:2373
+   |      0x24044130 0x08088a20 core::fmt::write
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |      0x24044168 0x0808a9c8 core::fmt::Write::write_fmt
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:191
+   |      0x240441a0 0x0808abbc rust_begin_unwind
+   |                 @ /hubris/sys/userlib/src/lib.rs:1298
+   |      0x240441c0 0x08087fca core::panicking::panic_fmt
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:50
+   |      0x240441e8 0x080895dc drv_i2c_api::I2cDevice::response_code
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:128
+   |      0x24044240 0x080897b6 drv_i2c_api::I2cDevice::read_reg
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:158
+   |      0x240449c8 0x08084a86 <drv_i2c_devices::bmr491::Bmr491 as drv_i2c_devices::TempSensor<drv_i2c_devices::bmr491::Error>>::read_temperature
+   |                 @ /hubris/drv/i2c-devices/src/bmr491.rs:95
+   |      0x240449c8 0x08084a86 task_power::Device::read_temperature
+   |                 @ /hubris/task/power/src/main.rs:101
+   |      0x240449c8 0x08084958 task_power::ServerImpl::handle_timer_fired
+   |                 @ /hubris/task/power/src/main.rs:439
+   |      0x240449c8 0x08084958 <task_power::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/power/src/main.rs:627
+   |      0x240449c8 0x08084906 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f86afe0/runtime/src/lib.rs:228
+   |      0x240449c8 0x08084a90 main
+   |                 @ /hubris/task/power/src/main.rs:411
+   |
    |
    +-----------> 0x240009d0 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
@@ -2,6 +2,7 @@ system time = 76648
 ID TASK                       GEN PRI STATE    
  8 power                        0   6 FAULT: stack overflow; sp=0x24043fa0 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x24043fa0
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x240009d0 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.task.power.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.task.power.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.task.power tasks -slvr"
+args = "-d hubris.core.task.power tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
@@ -2,7 +2,14 @@ system time = 23233
 ID TASK                       GEN PRI STATE    
 10 gimlet_seq                  12   4 FAULT: stack overflow; sp=0x24047fc0 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x24047fc0
-   use `--guess` to guess at stack trace
+   guessing at stack trace using saved frame pointer
+   |
+   +--->  0x240480c0 0x0807afd4 drv_gimlet_seq_server::ringbuf_entry_v3p3_sys_a0_vout
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:1398
+   |      0x240482b0 0x0807a4c0 drv_gimlet_seq_server::ServerImpl<S>::set_state_internal
+   |      0x24048640 0x08079c2a main
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:145
+   |
    |
    +-----------> 0x24000b20 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
+++ b/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
@@ -2,6 +2,7 @@ system time = 23233
 ID TASK                       GEN PRI STATE    
 10 gimlet_seq                  12   4 FAULT: stack overflow; sp=0x24047fc0 (was: ready)
    could not read registers: read of 32 bytes from invalid address: 0x24047fc0
+   use `--guess` to guess at stack trace
    |
    +-----------> 0x24000b20 Task {
                     save: SavedState {

--- a/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.u16-ringbuf tasks -slvr"
+args = "-d hubris.core.u16-ringbuf tasks -slvr --guess"
 

--- a/tests/cmd/tasks-slvr/tasks-slvr.v6.toml
+++ b/tests/cmd/tasks-slvr/tasks-slvr.v6.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../cores"
 bin.name = "humility"
-args = "-d hubris.core.v6 tasks -slvr"
+args = "-d hubris.core.v6 tasks -slvr --guess"
 


### PR DESCRIPTION
(Staged on top of #508)

This PR adds a new `--guess` argument to `humility tasks`, which tries to use the saved frame pointer to get a stack trace under exceptional circumstances.  I deliberately implemented it as a suspicious-sounding flag instead of an automatic fallback, because it may not be 100% reliable (but it looks fine in all of the unit tests).

The PR is split into two standalone commits:
- The first commit adds the flag and its implementation
- The second commit reruns the test suite with the flag added; a handful of old cores manage to obtain reasonable-looking stack traces