### PR TITLE
Make OpenOCD/PyOCD flash config optional in archive.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.11"
+version = "0.11.12"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -121,12 +121,17 @@ fn force_openocd(
     };
 
     let payload = match &config.program {
-        FlashProgram::OpenOcd(payload) => payload,
-        _ => {
+        Some(FlashProgram::OpenOcd(payload)) => payload,
+        Some(other) => {
             bail!(
                 "cannot force OpenOCD for non-OpenOCD \
-                flash configuration: {:?}",
-                config.program
+                flash configuration: {other:?}",
+            );
+        }
+        None => {
+            bail!(
+                "cannot force OpenOCD, this archive was \
+                built after support was removed"
             );
         }
     };

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.11
+humility 0.11.12
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.11
+humility 0.11.12
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.11
+humility 0.11.12
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.11
+humility 0.11.12
 
 ```


### PR DESCRIPTION
The support for forcing flashing with openocd winds up producing a bunch of extra support code in the build system, for a feature we basically never use anymore.

The support for PyOCD has, apparently, never been finished, and does not work.

So I'm hoping to remove them from the Hubris build system, but the first step toward that is teaching Humility to behave gracefully if they're omitted from the img/flash.ron file.

This change makes the fields optional, and Humility now only requires their presence if the user explicitly asks for the old --force-openocd switch.