### PR TITLE
Run "nightly" build on every merge to master.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,9 @@ name: 'nightly'
 on:
   schedule:
     - cron: '0 0 * * *'
+  push:
+    branches:
+      - master
 
 jobs:
   nightly-release:


### PR DESCRIPTION
Currently, we run the nightly build once per day, as its name implies. The main use for the nightly build is distributing its artifact (a Humility binary) to other builders, for use in testing compatibility in e.g. the Hubris build.

This means that currently, merging any change that affects archive compatibility involves a mandatory 24-ish hour waiting period between merging the Humility support, and changing Hubris. This is annoying, and is a great way to have me wander off and forget what I was doing (right now it's a Friday, so I'd have to come back on Monday to finish merging). Waiting for computers is dumb.

This commit changes the "nightly" build to re-run and re-clobber the release on every successful merge to master. We've been merging to Humility master far less than once per day, so this will not meaningfully increase the number of builds run.

This also makes the name of the release slightly wrong, but I would like to justify leaving it as-is for three reasons:

1. It's always night somewhere.
2. Most "nightly" builds will still be triggered by cron.
3. Identifying what scripts in other repos depend on this release name seems rather difficult.