### PR TITLE
Restore v8 archive flashing compatibility.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.12"
+version = "0.11.13"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.12"
+version = "0.11.13"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -1559,7 +1559,9 @@ impl HubrisArchive {
             )
         })?;
 
-        let config: HubrisFlashMeta = ron::de::from_reader(flash_ron)?;
+        let config: HubrisFlashMeta = ron::options::Options::default()
+            .with_default_extension(ron::extensions::Extensions::IMPLICIT_SOME)
+            .from_reader(flash_ron)?;
 
         // This is incredibly ugly! It also gives us backwards compatibility!
         let chip: Option<String> = match config.chip {

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.12
+humility 0.11.13
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.12
+humility 0.11.13
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.12
+humility 0.11.13
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.12
+humility 0.11.13
 
 ```


### PR DESCRIPTION
A field in the archive switched from a T to an Option<T> in the v9 format change. Unfortunately, this means old v8 archives are missing a Some() that RON expects. My intention was to gloss over this issue by enabling RON's IMPLICIT_SOME option... but I failed to.

It turns out that the flash loading stuff is not covered by Humility's test suites, which is good to know.

This change enables IMPLICIT_SOME and works with both v8 and v9.