### PR TITLE
Add subcommand to "hydrate" a task dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "humility"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "humility-cmd-hash",
  "humility-cmd-hiffy",
  "humility-cmd-host",
+ "humility-cmd-hydrate",
  "humility-cmd-i2c",
  "humility-cmd-ibc",
  "humility-cmd-itm",
@@ -1689,6 +1690,27 @@ dependencies = [
  "humility-doppel",
  "humility-log",
  "ipcc-data",
+]
+
+[[package]]
+name = "humility-cmd-hydrate"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.23",
+ "colored",
+ "hubpack",
+ "humility-arch-arm",
+ "humility-cli",
+ "humility-cmd",
+ "humility-core",
+ "humility-log",
+ "humpty",
+ "indexmap 1.9.3",
+ "parse_int",
+ "serde",
+ "zerocopy",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "indexmap 1.9.3",
  "parse_int",
  "serde",
+ "serde_json",
  "zerocopy",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "humility"
 #
 # Be sure to check in and push all of the files that change.  Happy versioning!
 #
-version = "0.11.13"
+version = "0.11.14"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "cmd/hash",
     "cmd/hiffy",
     "cmd/host",
+    "cmd/hydrate",
     "cmd/rpc",
     "cmd/i2c",
     "cmd/ibc",
@@ -166,6 +167,7 @@ cmd-gpio = { path = "./cmd/gpio", package = "humility-cmd-gpio" }
 cmd-hash = { path = "./cmd/hash", package = "humility-cmd-hash" }
 cmd-hiffy = { path = "./cmd/hiffy", package = "humility-cmd-hiffy" }
 cmd-host = { path = "./cmd/host", package = "humility-cmd-host" }
+cmd-hydrate = { path = "./cmd/hydrate", package = "humility-cmd-hydrate" }
 cmd-i2c = { path = "./cmd/i2c", package = "humility-cmd-i2c" }
 cmd-ibc = { path = "./cmd/ibc", package = "humility-cmd-ibc" }
 cmd-itm = { path = "./cmd/itm", package = "humility-cmd-itm" }
@@ -314,6 +316,7 @@ cmd-gpio = { workspace = true }
 cmd-hash = { workspace = true }
 cmd-host = { workspace = true }
 cmd-hiffy = { workspace = true }
+cmd-hydrate = { workspace = true }
 cmd-i2c = { workspace = true }
 cmd-ibc = { workspace = true }
 cmd-itm = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility hash](#humility-hash): Access to the HASH block
 - [humility hiffy](#humility-hiffy): manipulate HIF execution
 - [humility host](#humility-host): Pretty-printing of host state
+- [humility hydrate](#humility-hydrate): Rehydrate a bare memory dump
 - [humility i2c](#humility-i2c): scan for and read I2C devices
 - [humility ibc](#humility-ibc): interface to the BMR491 power regulator
 - [humility itm](#humility-itm): commands for ARM's Instrumentation Trace Macrocell (ITM)
@@ -1064,6 +1065,22 @@ humility: reading LAST_HOST_BOOT_FAIL
 ```
 
 
+### `humility hydrate`
+
+`humility hydrate` combines a raw memory dump (obtained from MGS) and a
+Hubris archive, forming a proper Hubris dump.
+
+```console
+$ humility -a build-grapefruit-image-default.zip hydrate hubris.dry.0
+```
+
+The archive is required, because the raw memory dump does not contain debug
+information.
+
+By default, this writes to `hubris.core.TASK_NAME.N` (where `N` is the
+lowest available value); use `--out` to specify a different path name.
+
+
 ### `humility i2c`
 
 On platforms that have I<sup>2</sup>C support, `humility i2c` can be used
@@ -1769,6 +1786,7 @@ It is fully functional on
 - Sidecar
 - PSC
 - `gimletlet-mgmt`
+
 These PCAs have the KSZ8463 switch + VSC85x2 PHY which is our standard
 management network interface.
 

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -80,6 +80,7 @@ use humpty::DumpTask;
 use indicatif::{HumanBytes, HumanDuration, ProgressBar, ProgressStyle};
 use num_traits::FromPrimitive;
 use std::cell::RefCell;
+use std::path::PathBuf;
 use std::time::Instant;
 
 #[derive(Clone, Parser, Debug)]
@@ -144,7 +145,7 @@ struct DumpArgs {
         conflicts_with_all = &["task", "extract-all"],
         value_name = "filename",
     )]
-    stock_dumpfile: Option<String>,
+    stock_dumpfile: Option<PathBuf>,
 
     /// emulate in situ dumper by reading directly from target and writing
     /// compressed memory back to agent's dump region
@@ -195,7 +196,7 @@ struct DumpArgs {
     #[clap(long)]
     print_dump_breakdown: bool,
 
-    dumpfile: Option<String>,
+    dumpfile: Option<PathBuf>,
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -812,8 +813,8 @@ fn dump_all(
             };
 
             let dumpfile = (0..)
-                .map(|i| format!("hubris.core.{task_name}.{i}"))
-                .find(|f| std::fs::File::open(f).is_err())
+                .map(|i| PathBuf::from(format!("hubris.core.{task_name}.{i}")))
+                .find(|f| !f.exists())
                 .unwrap();
             humility::msg!("dumping {task_name} (area {area})");
 

--- a/cmd/hydrate/Cargo.toml
+++ b/cmd/hydrate/Cargo.toml
@@ -20,5 +20,6 @@ humpty.workspace = true
 indexmap.workspace = true
 parse_int.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 zerocopy.workspace = true
 zip.workspace = true

--- a/cmd/hydrate/Cargo.toml
+++ b/cmd/hydrate/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "humility-cmd-hydrate"
+version = "0.1.0"
+edition = "2021"
+description = "Rehydrate a bare memory dump"
+
+[dependencies]
+humility.workspace = true
+humility-arch-arm.workspace = true
+humility-cli.workspace = true
+humility-cmd.workspace = true
+humility-log.workspace = true
+
+hubpack.workspace = true
+
+anyhow.workspace = true
+clap.workspace = true
+colored.workspace = true
+humpty.workspace = true
+indexmap.workspace = true
+parse_int.workspace = true
+serde.workspace = true
+zerocopy.workspace = true
+zip.workspace = true

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -107,6 +107,20 @@ fn run(context: &mut ExecutionContext) -> Result<()> {
     let mut z = zip::ZipArchive::new(f)?;
 
     let mut s = String::new();
+    z.by_name("meta.json")?.read_to_string(&mut s)?;
+    #[derive(serde::Deserialize)]
+    struct Meta {
+        version: u64,
+    }
+    let meta: Meta = serde_json::from_str(&s)?;
+    if meta.version != 1 {
+        bail!(
+            "invalid version in `meta.json`: expected 1, got {}",
+            meta.version
+        );
+    }
+
+    let mut s = String::new();
     z.by_name("TASK_INDEX")?.read_to_string(&mut s)?;
     let task_id: u16 = s.trim().parse()?;
 

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -1,0 +1,191 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility hydrate`
+//!
+//! `humility hydrate` combines a raw memory dump (obtained from MGS) and a
+//! Hubris archive, forming a proper Hubris dump.
+//!
+//! ```console
+//! $ humility -a build-grapefruit-image-default.zip hydrate hubris.dry.0
+//! ```
+
+use anyhow::{anyhow, bail, Result};
+use clap::{ArgGroup, IntoApp, Parser};
+use humility_arch_arm::ARMRegister;
+use humility_cli::{ExecutionContext, Subcommand};
+use humility_cmd::{Archive, Command, CommandKind};
+use humility_log::msg;
+use std::{collections::BTreeMap, io::Read, path::PathBuf};
+
+#[derive(Parser, Debug)]
+#[clap(
+    name = "hydrate", about = env!("CARGO_PKG_DESCRIPTION"),
+    group = ArgGroup::new("target").multiple(false)
+)]
+struct Args {
+    /// Path to the raw memory dump
+    file: PathBuf,
+}
+
+struct DryCore {
+    mem: BTreeMap<u32, Vec<u8>>,
+}
+
+// Helper macro to stub out functions
+macro_rules! unsupported{
+    ($fn_name:ident($($arg_name:ident: $arg_type:ty),*)) => {
+        unsupported!($fn_name($($arg_name: $arg_type),*) -> Result<()>);
+    };
+    ($fn_name:ident($($arg_name:ident: $arg_type:ty),*) -> $out:ty) => {
+        fn $fn_name(&mut self, $($arg_name: $arg_type),*) -> $out {
+            bail!(concat!(
+                "DryCore does not support ",
+                stringify!($fn_name)))
+        }
+    };
+}
+
+impl humility::core::Core for DryCore {
+    unsupported!(run());
+    unsupported!(halt());
+    unsupported!(step());
+    unsupported!(load(_path: &std::path::Path));
+    unsupported!(reset());
+    unsupported!(write_8(_addr: u32, _data: &[u8]));
+    unsupported!(op_done());
+    unsupported!(op_start());
+    unsupported!(read_reg(_reg: ARMRegister) -> Result<u32>);
+    unsupported!(init_swv());
+    unsupported!(read_swv() -> Result<Vec<u8>>);
+    unsupported!(write_reg(_reg: ARMRegister, _value: u32));
+    unsupported!(write_word_32(_addr: u32, _data: u32));
+    unsupported!(reset_and_halt(_dur: std::time::Duration));
+    unsupported!(wait_for_halt(_dur: std::time::Duration));
+
+    fn info(&self) -> (String, Option<String>) {
+        ("DryCore".to_owned(), None)
+    }
+    fn is_archive(&self) -> bool {
+        false
+    }
+    fn is_dump(&self) -> bool {
+        true // I guess?
+    }
+    fn is_net(&self) -> bool {
+        false
+    }
+    fn vid_pid(&self) -> Option<(u16, u16)> {
+        None
+    }
+
+    fn read_8(&mut self, addr: u32, data: &mut [u8]) -> Result<()> {
+        todo!()
+    }
+}
+
+fn run(context: &mut ExecutionContext) -> Result<()> {
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+    let subargs = Args::try_parse_from(subargs)?;
+    let f = std::fs::File::open(&subargs.file)?;
+    let mut z = zip::ZipArchive::new(f)?;
+
+    let mut s = String::new();
+    z.by_name("TASK_INDEX")?.read_to_string(&mut s)?;
+    let task_id: u16 = s.trim().parse()?;
+
+    let mut s = String::new();
+    z.by_name("TIMESTAMP")?.read_to_string(&mut s)?;
+    let timestamp: u64 = s.trim().parse()?;
+
+    let mut bord = String::new();
+    z.by_name("BORD")?.read_to_string(&mut bord)?;
+    bord.pop(); // remove newline
+
+    let mut gitc = String::new();
+    z.by_name("GITC")?.read_to_string(&mut gitc)?;
+    gitc.pop(); // remove newline
+
+    let vers = match z.by_name("VERS") {
+        Ok(mut v) => {
+            let mut s = String::new();
+            v.read_to_string(&mut s)?;
+            s.pop();
+            Some(s)
+        }
+        Err(zip::result::ZipError::FileNotFound) => None,
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut s = String::new();
+    z.by_name("ARCHIVE_ID")?.read_to_string(&mut s)?;
+    let mut archive_id = [0u8; 8];
+    for (i, b) in archive_id.iter_mut().enumerate() {
+        *b = u8::from_str_radix(&s[i * 2..][..2], 16)?;
+    }
+
+    let mut mem = BTreeMap::new();
+    let mem_files = z
+        .file_names()
+        .filter(|f| f.starts_with("0x"))
+        .map(|s| s.to_owned())
+        .collect::<Vec<_>>();
+    for f in mem_files {
+        let num = f.strip_suffix(".bin").unwrap().strip_prefix("0x").unwrap();
+        let addr = u32::from_str_radix(num, 16)?;
+        let mut data = z.by_name(&f)?;
+        let mut v = vec![];
+        data.read_to_end(&mut v)?;
+        mem.insert(addr, v);
+    }
+
+    let mut core = DryCore { mem };
+    msg!("read dehydrated crash dump");
+    msg!("  task index: {task_id}");
+    msg!("  crash time: {timestamp}");
+    msg!("  archive id: {archive_id:02x?}");
+    msg!("  board:      {bord}");
+    msg!("  git commit: {gitc}");
+    msg!("  version:    {}", vers.as_deref().unwrap_or("[missing]"));
+    msg!("  {} memory regions:", core.mem.len());
+    for (k, v) in &core.mem {
+        msg!("    {k:#08x}: {} bytes", v.len());
+    }
+
+    // compare archive ID
+    if context.cli.archive.is_none() {
+        bail!("must provide an archive");
+    }
+    let archive = context.archive.as_ref().unwrap();
+    let expected_id = archive
+        .image_id()
+        .ok_or_else(|| anyhow!("missing image ID in archive"))?;
+    if archive_id != expected_id {
+        bail!(
+            "image ID mismatch: expected {expected_id:?} (from archive), \
+             got {archive_id:?} (from raw dump)"
+        );
+    }
+
+    archive.dump(
+        &mut core,
+        Some(humpty::DumpTask {
+            magic: humpty::DUMP_TASK_MAGIC,
+            id: task_id,
+            pad: 0u32,
+            time: timestamp,
+        }),
+        None,
+        Some(std::time::Instant::now()),
+    )
+}
+
+pub fn init() -> Command {
+    Command {
+        app: Args::command(),
+        name: "hydrate",
+        run,
+        kind: CommandKind::Detached { archive: Archive::Optional },
+    }
+}

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2525,7 +2525,7 @@ impl HubrisArchive {
                     }
 
                     core.read_8(taddr, &mut indices).context(format!(
-                        "failed to read region desriptors for task {} at 0x{:x}",
+                        "failed to read region descriptors for task {} at 0x{:x}",
                         i, taddr)
                     )?;
 

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -16,7 +16,7 @@ use std::fs::{self, OpenOptions};
 use std::io::Cursor;
 use std::mem::size_of;
 use std::num::TryFromIntError;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
 use std::time::Instant;
 
@@ -3227,7 +3227,7 @@ impl HubrisArchive {
         &self,
         core: &mut dyn crate::core::Core,
         task: Option<DumpTask>,
-        dumpfile: Option<&str>,
+        dumpfile: Option<&Path>,
         started: Option<Instant>,
     ) -> Result<()> {
         use indicatif::{HumanBytes, HumanDuration};
@@ -3315,8 +3315,8 @@ impl HubrisArchive {
                 };
 
                 (0..)
-                    .map(|i| format!("{prefix}{i}"))
-                    .find(|f| std::fs::File::open(f).is_err())
+                    .map(|i| PathBuf::from(format!("{prefix}{i}")))
+                    .find(|f| !f.exists())
                     .unwrap()
             }
         };
@@ -3327,7 +3327,7 @@ impl HubrisArchive {
         let mut file =
             OpenOptions::new().write(true).create_new(true).open(&filename)?;
 
-        msg!("dumping to {filename}");
+        msg!("dumping to {filename:?}");
 
         file.iowrite_with(header, ctx)?;
 

--- a/tests/cmd/chip.trycmd
+++ b/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.11.13
+humility 0.11.14
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.11.13
+humility 0.11.14
 
 ```
 

--- a/tests/cmd/version.trycmd
+++ b/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.11.13
+humility 0.11.14
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.11.13
+humility 0.11.14
 
 ```


### PR DESCRIPTION
See https://github.com/oxidecomputer/management-gateway-service/pull/316
and https://github.com/oxidecomputer/hubris/pull/1921 for details

This PR adds a new `humility hydrate` subcommand, which takes a "dry" task dump and staples it to a Hubris archive, creating a normal Hubris core file.