### PR TITLE
humility-core: fix pointer type handling.

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3733,7 +3733,11 @@ impl HubrisArchive {
             (HubrisType::Union(lt), HubrisType::Union(rt)) => {
                 lt.differs(self, rt)
             }
-            (HubrisType::Ptr(l), HubrisType::Ptr(r)) => self.differ(l, r),
+            (HubrisType::Ptr(l), HubrisType::Ptr(r)) => {
+                let pointee_l = self.lookup_ptrtype(l)?;
+                let pointee_r = self.lookup_ptrtype(r)?;
+                self.differ(pointee_l, pointee_r)
+            }
             _ => Ok(true),
         }
     }


### PR DESCRIPTION
Dedup of pointer types would enter an infinite loop, because instead of traversing the pointee-type, it was just getting back the same type over and over.

Fixes #523.