### PR TITLE
Remove almost all "unhalted reads" and make tasks display consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "humility-bin"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/cmd/bankerase/src/lib.rs
+++ b/cmd/bankerase/src/lib.rs
@@ -63,8 +63,7 @@ fn bankerasecmd(context: &mut ExecutionContext) -> Result<()> {
     };
 
     humility::msg!("attaching with chip set to {chip:x?}");
-    let mut c =
-        humility_probes_core::attach_for_flashing(probe, hubris, &chip)?;
+    let mut c = humility_probes_core::attach_for_flashing(probe, &chip)?;
     let core = c.as_mut();
 
     let ihex = tempfile::NamedTempFile::new()?;

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -367,8 +367,7 @@ fn flashcmd(context: &mut ExecutionContext) -> Result<()> {
     };
 
     humility::msg!("attaching with chip set to {chip:x?}");
-    let mut c =
-        humility_probes_core::attach_for_flashing(probe, hubris, &chip)?;
+    let mut c = humility_probes_core::attach_for_flashing(probe, &chip)?;
     let core = c.as_mut();
 
     validate(hubris, core, &subargs)?;

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -40,7 +40,7 @@ fn reset(context: &mut ExecutionContext) -> Result<()> {
                 "Need a chip to do a soft reset or halt after reset"
             )
         })?;
-        humility_probes_core::attach_to_chip(probe, hubris, Some(&chip))?
+        humility_probes_core::attach_to_chip(probe, Some(&chip))?
     } else {
         humility_probes_core::attach_to_probe(probe)?
     };

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -269,7 +269,6 @@ pub fn print_tasks(
         }
 
         let mut tasks = vec![];
-        let mut panicked = false;
         let mut regs = HashMap::new();
 
         for i in 0..task_count {
@@ -300,18 +299,6 @@ pub fn print_tasks(
             }
 
             tasks.push((i, addr, task_value, task));
-
-            if let TaskState::Faulted { fault, .. } = task.state {
-                if fault == doppel::FaultInfo::Panic {
-                    panicked = true;
-                }
-            }
-        }
-
-        let keep_halted = stack || registers || panicked;
-
-        if !keep_halted {
-            core.run()?;
         }
 
         writeln!(
@@ -480,9 +467,7 @@ pub fn print_tasks(
             )?;
         }
 
-        if keep_halted {
-            core.run()?;
-        }
+        core.run()?;
 
         if task_arg.is_some() && !found {
             bail!("\"{}\" is not a valid task", task_arg.unwrap());

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -219,7 +219,6 @@ pub fn print_tasks(
 ) -> Result<()> {
     let (base, task_count) = hubris.task_table(core)?;
     log::debug!("task table: {:#x?}, count: {}", base, task_count);
-    let ticks = if core.is_net() { None } else { Some(hubris.ticks(core)?) };
 
     let task_t = hubris.lookup_struct_byname("Task")?;
     let save = task_t.lookup_member("save")?.offset;
@@ -236,6 +235,9 @@ pub fn print_tasks(
 
     loop {
         core.halt()?;
+
+        let ticks =
+            if core.is_net() { None } else { Some(hubris.ticks(core)?) };
 
         let cur = hubris.current_task(core)?;
         let task_dump = hubris.task_dump();

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "humility-bin"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 license = "MPL-2.0"
 rust-version = "1.68"

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.12.0 
+humility 0.12.1 
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.12.0 
+humility 0.12.1 
 
 ```
 

--- a/humility-bin/tests/cmd/version.trycmd
+++ b/humility-bin/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.12.0 
+humility 0.12.1 
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.12.0 
+humility 0.12.1 
 
 ```

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3679,14 +3679,6 @@ impl HubrisArchive {
         }
     }
 
-    pub fn unhalted_reads(&self) -> bool {
-        if let Some(ref target) = self.manifest.target {
-            target != "thumbv6m-none-eabi"
-        } else {
-            false
-        }
-    }
-
     /// Reads the auxiliary flash data from a Hubris archive
     ///
     /// Returns `Ok(Some(...))` if the data is loaded, `Ok(None)` if the file


### PR DESCRIPTION
I've been tracking down reasons why Humility sometimes gives an
inconsistent snapshot of system state in things like the `tasks` output,
and I've found one of the culprits.

There's this `halt_and_read` function that we use when we want a
consistent snapshot. Uses of this function often carry comments like "We
read the entire [thing being read] at a go to get as consistent a
snapshot as possible."

Unfortunately, despite its name, `halt_and_read` doesn't necessarily
halt, and this decision is not in control of the caller or obvious to
readers of the calling code. The decision to halt is a little complex
and depends on...

- The target triple -- after discovering an M0 that doesn't support
  unhalted reads to flash, we appear to have opted out the entire
  thumbv6m architecture from this meddling.

- The exact dynamic call path to reach this point and whether anyone has
  called halt(), thereby incrementing the `halted` variable (the halt()
  call _does_ in fact halt; the `op_start` call is similarly shaped but
  only _maybe_ halts)

This behavior has been responsible for a number of bugs I keep hitting
when trying to debug _other_ bugs, which is the worst time to be hitting
such bugs. This includes

- Intermittent failures in archive ID matching on the STM32U5 series,
  where debugger flash reads are not supported while the CPU is
  executing (as on the STM32G0, but unlike the STM32H7).

- Task status output that is inconsistent, e.g. no tasks showing as
  runnable or multiple tasks ready but only the idle task actually
  running. Both of these have had me convinced that we had scheduler
  bugs; so far it does not appear that we have scheduler bugs, it's just
  the debugger misrepresenting things.

Aside: remember that whether debugger accesses to buses are allowed to
race the CPU is a _vendor dependent decision_ that varies from SoC to
SoC. It is not consistent on all ARMv6/7/8-M parts; it is not consistent
on all parts from ST; it is not consistent on all parts built around the
Cortex-M33; it is not consistent across flash, RAM, and peripherals in a
single part. Because commercial tools generally don't _do_ this, vendors
don't document the specific behavior, and you get to discover it by
things failing. In short, doing unhalted reads of anything is asking for
flake and should only be done in very specific circumstances.

This commit takes a somewhat heavy-handed approach and simply removes
the secret unhalted reads behind `halt_and_read`. There may be
situations where we legitimately want unhalted reads -- humility
dashboard comes to mind -- and IMO these commands should be using an
explicit `read_without_halting` operation that is defined as racing, and
therefore as "maybe doesn't work on your chip." I have not done that
here.

Fixes https://github.com/oxidecomputer/humility/issues/527.