### PR TITLE
Remove `i2c --lastmux`

### DIFF
--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -89,16 +89,6 @@
 //! humility: attached via ST-Link
 //! Controller I2C3, device 0x48, register 0x4 = 0x1f
 //! ```
-//!
-//! To determine the last mux and segment to be enabled on a particular
-//! controller/port, use `--lastmux` (`-l`):
-//!
-//! ```console
-//! $ humility i2c -b front --lastmux
-//! humility: attached via ST-Link V3
-//! last selected mux/segment for I2C2, port F: mux 3, segment 2
-//! ```
-//!
 
 use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser};
@@ -206,15 +196,6 @@ pub struct I2cArgs {
         requires = "device",
     )]
     flash: Option<String>,
-
-    /// indicate last selected mux/segment
-    #[clap(long, short,
-        conflicts_with_all = &[
-            "write", "raw", "nbytes", "register", "scan",
-            "writeraw", "flash", "mux", "device",
-        ],
-    )]
-    lastmux: bool,
 }
 
 fn i2c_done(
@@ -453,7 +434,6 @@ fn i2c(context: &mut ExecutionContext) -> Result<()> {
         && subargs.register.is_none()
         && !subargs.raw
         && subargs.flash.is_none()
-        && !subargs.lastmux
     {
         bail!(
             "must indicate a scan (-s/-S), specify a register (-r), \
@@ -465,8 +445,6 @@ fn i2c(context: &mut ExecutionContext) -> Result<()> {
 
     let (fname, args) = if subargs.flash.is_some() {
         ("I2cBulkWrite", 8)
-    } else if subargs.lastmux {
-        ("I2cSelectedMuxSegment", 2)
     } else {
         match (subargs.write.is_some(), subargs.writeraw) {
             (true, _) | (false, true) => ("I2cWrite", 8),
@@ -488,35 +466,6 @@ fn i2c(context: &mut ExecutionContext) -> Result<()> {
     let mut ops = vec![Op::Push(hargs.controller)];
 
     ops.push(Op::Push(hargs.port.index));
-
-    if subargs.lastmux {
-        ops.push(Op::Call(func.id));
-        ops.push(Op::Done);
-
-        let results = context.run(core, ops.as_slice(), None)?;
-
-        print!("last selected mux/segment for {}: ", hargs);
-
-        match &results[0] {
-            Ok(val) => {
-                if val.is_empty() {
-                    println!("none");
-                } else {
-                    if val.len() != 2 {
-                        bail!("unexpected mux/segment: {:?}", val);
-                    }
-
-                    println!("mux {}, segment {}", val[0], val[1]);
-                }
-            }
-            Err(IpcError::Error(err)) => {
-                println!("Err({})", func.errmap.get(err).unwrap());
-            }
-            Err(IpcError::ServerDied(_)) => println!("Err(ServerDeath)"),
-        }
-
-        return Ok(());
-    }
 
     if let Some(mux) = hargs.mux {
         ops.push(Op::Push(mux.0));


### PR DESCRIPTION
This has been invalid since June of 2023.  On the Hubris side:

```
commit dcb64088eb480d853c9ac57cdea4a8b25960cb26
Author: Bryan Cantrill <bryan@oxide.computer>
Date:   Mon Jun 19 13:19:15 2023 -0700

    ...other details elided...

    Additionally, this eliminates the selected_mux_segment entry point,
    which has outlived its usefulness.
```