### PR TITLE
Check for hiffy variables in humility manifest

### DIFF
--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -123,6 +123,21 @@ fn manifestcmd(context: &mut ExecutionContext) -> Result<()> {
         id += 1;
     }
 
+    // We've had problems with variables getting optimized out of hiffy
+    if hubris.modules().any(|x| x.name == "hiffy") {
+        let _ = hubris.lookup_variable("HIFFY_VERSION_MAJOR")?;
+        let _ = hubris.lookup_variable("HIFFY_VERSION_MINOR")?;
+        let _ = hubris.lookup_variable("HIFFY_VERSION_PATCH")?;
+        let _ = hubris.lookup_variable("HIFFY_READY")?;
+        let _ = hubris.lookup_variable("HIFFY_KICK")?;
+        let _ = hubris.lookup_variable("HIFFY_RSTACK")?;
+        let _ = hubris.lookup_variable("HIFFY_REQUESTS")?;
+        let _ = hubris.lookup_variable("HIFFY_ERRORS")?;
+        let _ = hubris.lookup_variable("HIFFY_FAILURE")?;
+        // We can't check for `HIFFY_SCRATCH` or `HIFFY_DATA`
+        // as some old archives didn't include it
+    }
+
     if !manifest.i2c_buses.is_empty() {
         let mut controllers = HashSet::new();
 

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.4.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.4.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_VERSION_MAJOR not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.4.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.4.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.4 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.49.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.49.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.49.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.49.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.49 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.50.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.50.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.50.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.50.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.50 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.51.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.51.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.51.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.51.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.51 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.52.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.52.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.52.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.52.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.52 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.53.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.53.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.53.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.53.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.53 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.6.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.6.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.6.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.6.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.6 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.7.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.7.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.7.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.7.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.7 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.8.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.8.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.8.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.8.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.kiowa.8 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.49.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.49.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.49.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.49.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.49 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.50.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.50.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.50.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.50.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.50 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.51.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.51.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.51.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.51.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.51 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.52.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.52.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.52.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.52.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.52 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.53.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.53.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.53.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.53.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.53 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.54.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.54.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.54.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.54.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.54 manifest"
-
+status.code = 1

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.55.stderr
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.55.stderr
@@ -1,0 +1,1 @@
+humility manifest failed: variable HIFFY_FAILURE not found

--- a/humility-bin/tests/cmd/manifest/manifest.ouray.55.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.ouray.55.toml
@@ -7,4 +7,4 @@
 fs.base = "../cores"
 bin.name = "humility"
 args = "-d hubris.core.ouray.55 manifest"
-
+status.code = 1


### PR DESCRIPTION
We've had problems with global symbols getting optimized out despite our desire to use them. Check for these in humility manifest which is easy to run in CI without hardware.