### PR TITLE
Fix CI complaints

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,0 @@
-[alias]
-xtask = "run --package xtask --"
-
-[profile.release]
-overflow-checks = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,7 +1253,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "capstone",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
 ]
 
@@ -1337,7 +1337,7 @@ dependencies = [
  "jep106",
  "log",
  "multimap",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parse_int",
  "pmbus",
@@ -1833,7 +1833,7 @@ dependencies = [
  "humility-idol",
  "humility-pmbus",
  "indicatif",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parse_int",
  "pmbus",
@@ -2054,7 +2054,7 @@ dependencies = [
  "humility-idol",
  "humility-pmbus",
  "indicatif",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parse_int",
  "pmbus",
@@ -2344,7 +2344,7 @@ dependencies = [
  "libc",
  "log",
  "multimap",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parse_int",
  "rayon",
@@ -2371,7 +2371,7 @@ dependencies = [
  "jep106",
  "log",
  "multimap",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "paste 0.1.18",
 ]
@@ -2489,7 +2489,7 @@ dependencies = [
  "humpty",
  "indicatif",
  "log",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "parse_int",
  "probe-rs",
@@ -2942,6 +2942,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,7 +3207,7 @@ dependencies = [
  "anyhow",
  "convert_case",
  "libm",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "ron 0.8.0",
  "serde",
@@ -3810,7 +3821,7 @@ name = "spd"
 version = "0.1.0"
 source = "git+https://github.com/oxidecomputer/spd#e37e79f6d7d4805b8a6a8c4d37699c4bd60222ea"
 dependencies = [
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,7 +216,7 @@ libc = "0.2"
 log = {version = "0.4.8", features = ["std"]}
 lzss = "0.8"
 multimap = "0.8.1"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
 parse-size = { version = "1.0", features = ["std"]}
 parse_int = "0.4.0"

--- a/humility-jefe/src/lib.rs
+++ b/humility-jefe/src/lib.rs
@@ -57,7 +57,7 @@ impl<'a> JefeVariables<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         timeout: u32,
-    ) -> Result<JefeVariables> {
+    ) -> Result<JefeVariables<'a>> {
         Ok(Self {
             hubris,
             ready: Self::variable(hubris, "JEFE_EXTERNAL_READY", true)?,


### PR DESCRIPTION
- Remove `.cargo/config`, because it's identical to `.cargo/config.toml`
- Bump `num-derive` to fix [RFC 3373](https://github.com/rust-lang/rfcs/pull/3373) warnings (we'll want to do this in `spd` and `pmbus` as well to minimize dependencies)
- Add missing lifetime which has a name