### PR TITLE
Bump `pmbus` for LM5066I support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "humility-bin"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "pmbus"
 version = "0.1.7"
-source = "git+https://github.com/oxidecomputer/pmbus#1fea49a4952201f21b01038cc91fe83a6f19fd71"
+source = "git+https://github.com/oxidecomputer/pmbus?branch=mkeeter/lm5066i-part#44e8c5bde072b5329e5ec216de67e566c8942739"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ hif = { git = "https://github.com/oxidecomputer/hif" }
 humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.3" }
 idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
-pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
+pmbus = { git = "https://github.com/oxidecomputer/pmbus", branch = "mkeeter/lm5066i-part" }
 spd = { git = "https://github.com/oxidecomputer/spd" }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
 tlvc = { git = "https://github.com/oxidecomputer/tlvc" }

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "humility-bin"
-version = "0.12.5"
+version = "0.12.6"
 edition = "2021"
 license = "MPL-2.0"
 rust-version = "1.68"

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.12.5 
+humility 0.12.6 
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.12.5 
+humility 0.12.6 
 
 ```
 

--- a/humility-bin/tests/cmd/version.trycmd
+++ b/humility-bin/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.12.5 
+humility 0.12.6 
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.12.5 
+humility 0.12.6 
 
 ```


### PR DESCRIPTION
We shouldn't merge this until https://github.com/oxidecomputer/pmbus/pull/21 and https://github.com/oxidecomputer/pmbus/pull/22 go in, but this gives me something to point Eric to for testing.