### PR TITLE
Use `addr2line` for backtraces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "humility-bin"
-version = "0.12.7"
+version = "0.12.8"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,6 +2518,7 @@ version = "0.1.0"
 dependencies = [
  "humility-arch-arm",
  "humility-core",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator 0.3.0",
+ "gimli 0.32.0",
+ "memmap2",
+ "object 0.37.2",
+ "rustc-demangle",
+ "smallvec",
+ "typed-arena",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,7 +195,7 @@ version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
- "addr2line",
+ "addr2line 0.19.0",
  "cc",
  "cfg-if",
  "libc",
@@ -579,6 +595,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -2315,6 +2340,7 @@ dependencies = [
 name = "humility-core"
 version = "0.1.0"
 dependencies = [
+ "addr2line 0.25.0",
  "anyhow",
  "bitfield",
  "capstone",
@@ -2727,9 +2753,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libm"
@@ -2807,6 +2833,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2987,6 +3022,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e3d0a7419f081f4a808147e845310313a39f322d7ae1f996b7f001d6cbed04"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -3540,6 +3586,15 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -4163,6 +4218,18 @@ dependencies = [
  "snapbox",
  "toml_edit 0.14.4",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ cmd-vpd = { path = "./cmd/vpd", package = "humility-cmd-vpd" }
 cmd-writeword = { path = "./cmd/writeword", package = "humility-cmd-writeword" }
 
 # crates.io deps
+addr2line = "0.25"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 atty = "0.2"
 bitfield = "0.13.2"

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "humility-bin"
-version = "0.12.7"
+version = "0.12.8"
 edition = "2021"
 license = "MPL-2.0"
 

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.12.7 
+humility 0.12.8 
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.12.7 
+humility 0.12.8 
 
 ```
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kernel-panic.1.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kernel-panic.1.stdout
@@ -14,7 +14,7 @@
    SP = 0x24000288 <- kernel: 0x24000000+0x288
         |
         +--->  0x240002c0 0x080019ac kern::fail::die_impl
-               0x240002d0 0x080019d0 kern::fail::die
+               0x240002d0 0x080019d4 kern::fail::die
                0x240002d0 0x080019d4 rust_begin_unwind
                0x240002f0 0x080006da core::panicking::panic_fmt
                0x24000318 0x0800105a core::panicking::panic

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.4.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.4.stdout
@@ -14,11 +14,11 @@
    SP = 0x20002b70 <- i2c_driver: 0x20002800+0x370
         |
         +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
-               0x20002c00 0x080148e2 drv_stm32h7_i2c::I2cController::write_read
-               0x20002c00 0x08014658 drv_stm32h7_i2c_server::main::{{closure}}
-               0x20002c00 0x08014658 userlib::hl::recv_without_notification::{{closure}}
-               0x20002c00 0x080142d4 userlib::hl::recv
-               0x20002c00 0x080142d4 userlib::hl::recv_without_notification
+               0x20002c00 0x08014920 drv_stm32h7_i2c::I2cController::write_read
+               0x20002c00 0x08014920 drv_stm32h7_i2c_server::main::{{closure}}
+               0x20002c00 0x08014920 userlib::hl::recv_without_notification::{{closure}}
+               0x20002c00 0x08014920 userlib::hl::recv
+               0x20002c00 0x08014920 userlib::hl::recv_without_notification
                0x20002c00 0x08014920 main
                0x20002c00 0x0801404e _start
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.49.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.49.stdout
@@ -14,16 +14,16 @@
    SP = 0x20002ae0 <- i2c_driver: 0x20002800+0x2e0
         |
         +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-               0x20002b20 0x08015b9c drv_stm32h7_i2c::I2cController::write_read
-               0x20002b20 0x08015b9c drv_stm32h7_i2c::ltc4306::write_reg_u8
+               0x20002b20 0x08015bc0 drv_stm32h7_i2c::I2cController::write_read
+               0x20002b20 0x08015bc0 drv_stm32h7_i2c::ltc4306::write_reg_u8
                0x20002b20 0x08015bc0 <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-               0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-               0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-               0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-               0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-               0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-               0x20002c00 0x0801447a userlib::hl::recv
-               0x20002c00 0x0801447a userlib::hl::recv_without_notification
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+               0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+               0x20002c00 0x080148a8 userlib::hl::recv
+               0x20002c00 0x080148a8 userlib::hl::recv_without_notification
                0x20002c00 0x080148a8 main
                0x20002c00 0x0801404e _start
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.50.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.50.stdout
@@ -13,8 +13,8 @@
   R12 = 0x20002a48 <- i2c_driver: 0x20002800+0x248
    SP = 0x20000eb0 <- kernel: 0x20000000+0xeb0
         |
-        +--->  0x20000f58 0x08002090 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+        +--->  0x20000f58 0x08002094 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002094 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002094 syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.51.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.51.stdout
@@ -15,10 +15,10 @@
         |
         +--->  0x20000f58 0x080022ee <kern::arch::arm_m::SavedState as kern::task::ArchState>::arg1
                0x20000f58 0x080022ee kern::task::AsIrqArgs<&T>::control
-               0x20000f58 0x080022dc kern::syscalls::irq_control
-               0x20000f58 0x080020a0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080020a0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+               0x20000f58 0x080022ee kern::syscalls::irq_control
+               0x20000f58 0x080022ee kern::syscalls::safe_syscall_entry
+               0x20000f58 0x080022ee kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x080022ee kern::arch::arm_m::with_task_table
                0x20000f58 0x080022ee syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.52.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.52.stdout
@@ -14,12 +14,12 @@
    SP = 0x20000e80 <- kernel: 0x20000000+0xe80
         |
         +--->  0x20000e80 0x0800153c kern::umem::USlice<T>::last_byte_addr
-               0x20000eb0 0x080033b2 kern::umem::USlice<T>::aliases
+               0x20000eb0 0x080033bc kern::umem::USlice<T>::aliases
                0x20000eb0 0x080033bc kern::umem::safe_copy
-               0x20000f58 0x080021c0 kern::syscalls::borrow_read
-               0x20000f58 0x080020a0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080020a0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+               0x20000f58 0x08002244 kern::syscalls::borrow_read
+               0x20000f58 0x08002244 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x08002244 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002244 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002244 syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.53.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.53.stdout
@@ -13,10 +13,10 @@
   R12 = 0x20002a78 <- i2c_driver: 0x20002800+0x278
    SP = 0x20000f18 <- kernel: 0x20000000+0xf18
         |
-        +--->  0x20000f58 0x08003936 kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
-               0x20000f58 0x08003928 kern::arch::arm_m::with_irq_table
-               0x20000f58 0x08003928 kern::arch::arm_m::DefaultHandler::{{closure}}
-               0x20000f58 0x0800391c kern::arch::arm_m::with_task_table
+        +--->  0x20000f58 0x08003942 kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
+               0x20000f58 0x08003942 kern::arch::arm_m::with_irq_table
+               0x20000f58 0x08003942 kern::arch::arm_m::DefaultHandler::{{closure}}
+               0x20000f58 0x08003942 kern::arch::arm_m::with_task_table
                0x20000f58 0x08003942 DefaultHandler
 
    LR = 0x08003933 <- kernel: DefaultHandler+0x47

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.6.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.6.stdout
@@ -14,10 +14,10 @@
    SP = 0x20000f10 <- kernel: 0x20000000+0xf10
         |
         +--->  0x20000f18 0x0800383e kern::arch::arm_m::disable_irq
-               0x20000f58 0x08003b56 kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
-               0x20000f58 0x08003b48 kern::arch::arm_m::with_irq_table
-               0x20000f58 0x08003b48 kern::arch::arm_m::DefaultHandler::{{closure}}
-               0x20000f58 0x08003b3c kern::arch::arm_m::with_task_table
+               0x20000f58 0x08003b6e kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
+               0x20000f58 0x08003b6e kern::arch::arm_m::with_irq_table
+               0x20000f58 0x08003b6e kern::arch::arm_m::DefaultHandler::{{closure}}
+               0x20000f58 0x08003b6e kern::arch::arm_m::with_task_table
                0x20000f58 0x08003b6e DefaultHandler
 
    LR = 0x08003b6f <- kernel: DefaultHandler+0x63

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.8.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.8.stdout
@@ -16,9 +16,9 @@
         +--->  0x20000f58 0x08002914 <kern::arch::arm_m::SavedState as kern::task::ArchState>::arg2
                0x20000f58 0x08002914 kern::task::AsReplyArgs<&T>::message
                0x20000f58 0x08002914 kern::syscalls::reply
-               0x20000f58 0x080022c0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080022c0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002294 kern::arch::arm_m::with_task_table
+               0x20000f58 0x08002914 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x08002914 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002914 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002914 syscall_entry
                0x20000f58 0x0800397a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.kiowa.rick.0.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.kiowa.rick.0.stdout
@@ -14,16 +14,16 @@
    SP = 0x20001508 <- jefe: 0x20001000+0x508
         |
         +--->  0x200015c0 0x080081fa <core::result::Result<T,E> as core::ops::try::Try>::into_result
-               0x200015c0 0x080081f2 <&mut ssmarshal::Deserializer as serde::de::EnumAccess>::variant_seed
-               0x200015c0 0x080081f2 serde::de::EnumAccess::variant
-               0x200015c0 0x080081f2 <abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize::__Visitor as serde::de::Visitor>::visit_enum
-               0x200015c0 0x080081f2 <&mut ssmarshal::Deserializer as serde::de::Deserializer>::deserialize_enum
-               0x200015c0 0x080081f2 abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize
-               0x200015c0 0x080081ee ssmarshal::deserialize
-               0x200015c0 0x080081e6 userlib::kipc::read_task_status
+               0x200015c0 0x080081fa <&mut ssmarshal::Deserializer as serde::de::EnumAccess>::variant_seed
+               0x200015c0 0x080081fa serde::de::EnumAccess::variant
+               0x200015c0 0x080081fa <abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize::__Visitor as serde::de::Visitor>::visit_enum
+               0x200015c0 0x080081fa <&mut ssmarshal::Deserializer as serde::de::Deserializer>::deserialize_enum
+               0x200015c0 0x080081fa abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize
+               0x200015c0 0x080081fa ssmarshal::deserialize
+               0x200015c0 0x080081fa userlib::kipc::read_task_status
                0x200015c0 0x080081fa task_jefe::check_tasks
-               0x20001600 0x0800890a task_jefe::main::{{closure}}
-               0x20001600 0x0800889c userlib::hl::recv
+               0x20001600 0x08008916 task_jefe::main::{{closure}}
+               0x20001600 0x08008916 userlib::hl::recv
                0x20001600 0x08008916 main
                0x20001600 0x0800804e _start
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.35.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.35.stdout
@@ -15,18 +15,18 @@
         |
         +--->  0x20000e70 0x0000159e kern::umem::USlice<T>::last_byte_addr
                0x20000e98 0x0000199e core::num::<impl u32>::wrapping_add
-               0x20000e98 0x00001992 <abi::RegionDesc as kern::app::RegionDescExt>::covers
-               0x20000e98 0x0000198e kern::task::Task::can_access::{{closure}}
-               0x20000e98 0x0000198a <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::any
+               0x20000e98 0x0000199e <abi::RegionDesc as kern::app::RegionDescExt>::covers
+               0x20000e98 0x0000199e kern::task::Task::can_access::{{closure}}
+               0x20000e98 0x0000199e <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::any
                0x20000e98 0x0000199e kern::task::Task::can_access
                0x20000eb0 0x000017a2 kern::task::Task::can_write
-               0x20000f58 0x00002ac8 kern::kipc::serialize_response
-               0x20000f58 0x00002ac2 kern::kipc::read_task_status
-               0x20000f58 0x00002ac2 kern::kipc::handle_kernel_message
-               0x20000f58 0x00002ac2 kern::syscalls::send
-               0x20000f58 0x00002a2c kern::syscalls::safe_syscall_entry
-               0x20000f58 0x00002074 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x00002048 kern::arch::arm_m::with_task_table
+               0x20000f58 0x00002ad6 kern::kipc::serialize_response
+               0x20000f58 0x00002ad6 kern::kipc::read_task_status
+               0x20000f58 0x00002ad6 kern::kipc::handle_kernel_message
+               0x20000f58 0x00002ad6 kern::syscalls::send
+               0x20000f58 0x00002ad6 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x00002ad6 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x00002ad6 kern::arch::arm_m::with_task_table
                0x20000f58 0x00002ad6 syscall_entry
                0x20000f58 0x00003636 SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.36.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.36.stdout
@@ -15,8 +15,8 @@
         |
         +--->  0x20000eb0 0x00001e72 core::option::Option<T>::expect
                0x20000eb0 0x00001e72 kern::task::select
-               0x20000f58 0x00002074 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x00002048 kern::arch::arm_m::with_task_table
+               0x20000f58 0x00002dce kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x00002dce kern::arch::arm_m::with_task_table
                0x20000f58 0x00002dce syscall_entry
                0x20000f58 0x00003636 SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.37.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.37.stdout
@@ -13,8 +13,8 @@
   R12 = 0x00000018 <- kernel: __EXCEPTIONS+0x10
    SP = 0x20000e80 <- kernel: 0x20000000+0xe80
         |
-        +--->  0x20000ea0 0x00001eca <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::next
-               0x20000ea0 0x00001eca <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::next
+        +--->  0x20000ea0 0x00001ecc <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::next
+               0x20000ea0 0x00001ecc <core::iter::adapters::enumerate::Enumerate<I> as core::iter::traits::iterator::Iterator>::next
                0x20000ea0 0x00001ecc kern::arch::arm_m::apply_memory_protection
                0x20000eb0 0x0000355e kern::arch::arm_m::set_current_task
                0x20000eb0 0x0000355e kern::syscalls::switch_to

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.39.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.39.stdout
@@ -13,8 +13,8 @@
   R12 = 0x0000ff9c
    SP = 0x20001278 <- jefe: 0x20001000+0x278
         |
-        +--->  0x20001290 0x000115ae cortex_m::itm::write_words
-               0x20001290 0x000115aa cortex_m::itm::write_aligned
+        +--->  0x20001290 0x000115b6 cortex_m::itm::write_words
+               0x20001290 0x000115b6 cortex_m::itm::write_aligned
                0x20001290 0x000115b6 cortex_m::itm::write_all
                0x20001298 0x0001013e <&mut W as core::fmt::Write>::write_str
                0x200012f0 0x000110f0 core::fmt::write

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.40.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.40.stdout
@@ -16,17 +16,17 @@
         +--->  0x20000e90 0x0000129e ssmarshal::Serializer::write_u8
                0x20000eb0 0x000012b8 <core::result::Result<T,E> as core::ops::try::Try>::into_result
                0x20000eb0 0x000012b8 <&mut ssmarshal::Serializer as serde::ser::Serializer>::serialize_struct_variant
-               0x20000f58 0x00002c96 abi::_::<impl serde::ser::Serialize for abi::FaultInfo>::serialize
-               0x20000f58 0x00002c96 <&mut ssmarshal::Serializer as serde::ser::SerializeStructVariant>::serialize_field
-               0x20000f58 0x00002c96 abi::_::<impl serde::ser::Serialize for abi::TaskState>::serialize
-               0x20000f58 0x00002c96 ssmarshal::serialize
-               0x20000f58 0x00002c96 kern::kipc::serialize_response
-               0x20000f58 0x00002c96 kern::kipc::read_task_status
-               0x20000f58 0x00002c96 kern::kipc::handle_kernel_message
-               0x20000f58 0x00002c8e kern::syscalls::send
-               0x20000f58 0x00002a2c kern::syscalls::safe_syscall_entry
-               0x20000f58 0x00002074 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x00002048 kern::arch::arm_m::with_task_table
+               0x20000f58 0x00002ca0 abi::_::<impl serde::ser::Serialize for abi::FaultInfo>::serialize
+               0x20000f58 0x00002ca0 <&mut ssmarshal::Serializer as serde::ser::SerializeStructVariant>::serialize_field
+               0x20000f58 0x00002ca0 abi::_::<impl serde::ser::Serialize for abi::TaskState>::serialize
+               0x20000f58 0x00002ca0 ssmarshal::serialize
+               0x20000f58 0x00002ca0 kern::kipc::serialize_response
+               0x20000f58 0x00002ca0 kern::kipc::read_task_status
+               0x20000f58 0x00002ca0 kern::kipc::handle_kernel_message
+               0x20000f58 0x00002ca0 kern::syscalls::send
+               0x20000f58 0x00002ca0 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x00002ca0 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x00002ca0 kern::arch::arm_m::with_task_table
                0x20000f58 0x00002ca0 syscall_entry
                0x20000f58 0x00003636 SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.41.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.41.stdout
@@ -15,7 +15,7 @@
         |
         +--->  0x20001360 0x00011d80 __aeabi_memset4
                0x20001400 0x00010220 userlib::sys_send
-               0x20001400 0x0001021a userlib::kipc::read_task_status
+               0x20001400 0x00010220 userlib::kipc::read_task_status
                0x20001400 0x00010220 main
                0x20001400 0x0001004e _start
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.44.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.44.stdout
@@ -14,17 +14,17 @@
    SP = 0x20000e60 <- kernel: 0x20000000+0xe60
         |
         +--->  0x20000eb0 0x08003400 core::num::<impl u32>::wrapping_sub
-               0x20000eb0 0x080033fa <abi::RegionDesc as kern::app::RegionDescExt>::covers
-               0x20000eb0 0x080033f8 kern::task::Task::can_access::{{closure}}
-               0x20000eb0 0x080033e6 <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::any
-               0x20000eb0 0x080033d4 kern::task::Task::can_access
-               0x20000eb0 0x080033d4 kern::task::Task::can_read
+               0x20000eb0 0x08003400 <abi::RegionDesc as kern::app::RegionDescExt>::covers
+               0x20000eb0 0x08003400 kern::task::Task::can_access::{{closure}}
+               0x20000eb0 0x08003400 <core::slice::iter::Iter<T> as core::iter::traits::iterator::Iterator>::any
+               0x20000eb0 0x08003400 kern::task::Task::can_access
+               0x20000eb0 0x08003400 kern::task::Task::can_read
                0x20000eb0 0x08003400 kern::syscalls::borrow_lease
                0x20000f58 0x08002640 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-               0x20000f58 0x0800262c kern::syscalls::borrow_write
-               0x20000f58 0x0800201c kern::syscalls::safe_syscall_entry
-               0x20000f58 0x0800201c kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08001ff0 kern::arch::arm_m::with_task_table
+               0x20000f58 0x08002640 kern::syscalls::borrow_write
+               0x20000f58 0x08002640 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x08002640 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002640 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002640 syscall_entry
                0x20000f58 0x08003642 SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.45.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.45.stdout
@@ -15,10 +15,10 @@
         |
         +--->  0x20000eb0 0x080035b0 kern::syscalls::borrow_lease
                0x20000f58 0x080021e0 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-               0x20000f58 0x08002198 kern::syscalls::borrow_read
-               0x20000f58 0x08002078 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x08002078 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x0800204c kern::arch::arm_m::with_task_table
+               0x20000f58 0x080021e0 kern::syscalls::borrow_read
+               0x20000f58 0x080021e0 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x080021e0 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x080021e0 kern::arch::arm_m::with_task_table
                0x20000f58 0x080021e0 syscall_entry
                0x20000f58 0x0800375e SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.47.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.47.stdout
@@ -14,10 +14,10 @@
    SP = 0x20000e80 <- kernel: 0x20000000+0xe80
         |
         +--->  0x20000eb0 0x08003384 kern::umem::safe_copy
-               0x20000f58 0x080021c0 kern::syscalls::borrow_read
-               0x20000f58 0x080020a0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080020a0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+               0x20000f58 0x08002244 kern::syscalls::borrow_read
+               0x20000f58 0x08002244 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x08002244 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002244 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002244 syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.49.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.49.stdout
@@ -14,16 +14,16 @@
    SP = 0x20002ae0 <- i2c_driver: 0x20002800+0x2e0
         |
         +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-               0x20002b20 0x08015b9c drv_stm32h7_i2c::I2cController::write_read
-               0x20002b20 0x08015b9c drv_stm32h7_i2c::ltc4306::write_reg_u8
+               0x20002b20 0x08015bc0 drv_stm32h7_i2c::I2cController::write_read
+               0x20002b20 0x08015bc0 drv_stm32h7_i2c::ltc4306::write_reg_u8
                0x20002b20 0x08015bc0 <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-               0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-               0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-               0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-               0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-               0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-               0x20002c00 0x0801447a userlib::hl::recv
-               0x20002c00 0x0801447a userlib::hl::recv_without_notification
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+               0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+               0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+               0x20002c00 0x080148a8 userlib::hl::recv
+               0x20002c00 0x080148a8 userlib::hl::recv_without_notification
                0x20002c00 0x080148a8 main
                0x20002c00 0x0801404e _start
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.50.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.50.stdout
@@ -13,8 +13,8 @@
   R12 = 0x20002a48 <- i2c_driver: 0x20002800+0x248
    SP = 0x20000eb0 <- kernel: 0x20000000+0xeb0
         |
-        +--->  0x20000f58 0x08002090 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+        +--->  0x20000f58 0x08002094 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002094 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002094 syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.51.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.51.stdout
@@ -15,10 +15,10 @@
         |
         +--->  0x20000f58 0x080022ee <kern::arch::arm_m::SavedState as kern::task::ArchState>::arg1
                0x20000f58 0x080022ee kern::task::AsIrqArgs<&T>::control
-               0x20000f58 0x080022dc kern::syscalls::irq_control
-               0x20000f58 0x080020a0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080020a0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+               0x20000f58 0x080022ee kern::syscalls::irq_control
+               0x20000f58 0x080022ee kern::syscalls::safe_syscall_entry
+               0x20000f58 0x080022ee kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x080022ee kern::arch::arm_m::with_task_table
                0x20000f58 0x080022ee syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.52.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.52.stdout
@@ -14,12 +14,12 @@
    SP = 0x20000e80 <- kernel: 0x20000000+0xe80
         |
         +--->  0x20000e80 0x0800153c kern::umem::USlice<T>::last_byte_addr
-               0x20000eb0 0x080033b2 kern::umem::USlice<T>::aliases
+               0x20000eb0 0x080033bc kern::umem::USlice<T>::aliases
                0x20000eb0 0x080033bc kern::umem::safe_copy
-               0x20000f58 0x080021c0 kern::syscalls::borrow_read
-               0x20000f58 0x080020a0 kern::syscalls::safe_syscall_entry
-               0x20000f58 0x080020a0 kern::syscalls::syscall_entry::{{closure}}
-               0x20000f58 0x08002074 kern::arch::arm_m::with_task_table
+               0x20000f58 0x08002244 kern::syscalls::borrow_read
+               0x20000f58 0x08002244 kern::syscalls::safe_syscall_entry
+               0x20000f58 0x08002244 kern::syscalls::syscall_entry::{{closure}}
+               0x20000f58 0x08002244 kern::arch::arm_m::with_task_table
                0x20000f58 0x08002244 syscall_entry
                0x20000f58 0x0800375a SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.ouray.53.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.ouray.53.stdout
@@ -13,10 +13,10 @@
   R12 = 0x20002a78 <- i2c_driver: 0x20002800+0x278
    SP = 0x20000f18 <- kernel: 0x20000000+0xf18
         |
-        +--->  0x20000f58 0x08003936 kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
-               0x20000f58 0x08003928 kern::arch::arm_m::with_irq_table
-               0x20000f58 0x08003928 kern::arch::arm_m::DefaultHandler::{{closure}}
-               0x20000f58 0x0800391c kern::arch::arm_m::with_task_table
+        +--->  0x20000f58 0x08003942 kern::arch::arm_m::DefaultHandler::{{closure}}::{{closure}}
+               0x20000f58 0x08003942 kern::arch::arm_m::with_irq_table
+               0x20000f58 0x08003942 kern::arch::arm_m::DefaultHandler::{{closure}}
+               0x20000f58 0x08003942 kern::arch::arm_m::with_task_table
                0x20000f58 0x08003942 DefaultHandler
 
    LR = 0x08003933 <- kernel: DefaultHandler+0x47

--- a/humility-bin/tests/cmd/registers-s/registers-s.panic-on-boot.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.panic-on-boot.stdout
@@ -14,7 +14,7 @@
    SP = 0x240002a0 <- kernel: 0x24000000+0x2a0
         |
         +--->  0x240002d8 0x08001aec kern::fail::die_impl
-               0x240002e8 0x08001b10 kern::fail::die
+               0x240002e8 0x08001b14 kern::fail::die
                0x240002e8 0x08001b14 rust_begin_unwind
                0x24000308 0x080006fc core::panicking::panic_fmt
                0x24000378 0x08001124 core::panicking::assert_failed_inner

--- a/humility-bin/tests/cmd/registers-s/registers-s.static-tasks.0.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.static-tasks.0.stdout
@@ -19,10 +19,10 @@
                0x200002f0 0x08001516 kern::task::Task::set_healthy_state
                0x20000398 0x080020dc <kern::task::NextTask as core::cmp::PartialEq>::eq
                0x20000398 0x080020dc kern::task::NextTask::combine
-               0x20000398 0x080020ce kern::syscalls::send
-               0x20000398 0x08001ac6 kern::syscalls::safe_syscall_entry
-               0x20000398 0x08001ac6 kern::syscalls::syscall_entry::{{closure}}
-               0x20000398 0x08001ab0 kern::startup::with_task_table
+               0x20000398 0x080020dc kern::syscalls::send
+               0x20000398 0x080020dc kern::syscalls::safe_syscall_entry
+               0x20000398 0x080020dc kern::syscalls::syscall_entry::{{closure}}
+               0x20000398 0x080020dc kern::startup::with_task_table
                0x20000398 0x080020dc syscall_entry
                0x20000398 0x08003326 SVCall
 

--- a/humility-bin/tests/cmd/registers-s/registers-s.static-tasks.1.stdout
+++ b/humility-bin/tests/cmd/registers-s/registers-s.static-tasks.1.stdout
@@ -14,10 +14,10 @@
    SP = 0x200002a0 <- kernel: 0x20000000+0x2a0
         |
         +--->  0x200002b0 0x08001a6a <core::iter::adapters::chain::Chain<A,B> as core::iter::traits::iterator::Iterator>::next
-               0x200002f0 0x08001850 kern::task::priority_scan
+               0x200002f0 0x0800187e kern::task::priority_scan
                0x200002f0 0x0800187e kern::task::select
-               0x20000398 0x08001ac6 kern::syscalls::syscall_entry::{{closure}}
-               0x20000398 0x08001ab0 kern::startup::with_task_table
+               0x20000398 0x080026e0 kern::syscalls::syscall_entry::{{closure}}
+               0x20000398 0x080026e0 kern::startup::with_task_table
                0x20000398 0x080026e0 syscall_entry
                0x20000398 0x08003328 SVCall
 

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.chilly.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+66)
    |
    +--->  0x20017538 0x08065548 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20017600 0x080642b4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20017600 0x080642b4 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20017600 0x080642c6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20017600 0x080642c6 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20017600 0x080642c6 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08065bf4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200175dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   2 recv, notif: bit0(irq61) bit1(T+21)
    |
    +--->  0x200028a8 0x0802e7b4 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20002ed8 0x080257ee userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20002ed8 0x080257ee idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20002ed8 0x080257fe userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20002ed8 0x080257fe idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:250:20
    |      0x20002ed8 0x080257fe main
-   |                 @ /hubris//task/net/src/main.rs:99
+   |                 @ /hubris/task/net/src/main.rs:180:13
    |
    |
    +--->   R0 = 0x20002c98   R1 = 0x0000001c   R2 = 0x00000003   R3 = 0x20002d38
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2001a350 0x0806a5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x2001a380 0x0806a090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2001a380 0x0806a090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2001a380 0x0806a09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2001a380 0x0806a09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x2001a380 0x0806a09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x2001a358   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2001a360
@@ -189,13 +189,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20017ae8 0x08049c30 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20017b68 0x08048684 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20017b68 0x08048684 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20017b68 0x0804869e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20017b68 0x0804869e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20017b68 0x0804869e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20017b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20017b04
@@ -251,13 +251,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x200182e0 0x0804dd58 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20018368 0x0804c656 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20018368 0x0804c656 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20018368 0x0804c670 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20018368 0x0804c670 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20018368 0x0804c670 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20018302   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20018304
@@ -313,21 +313,21 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 notif: bit2(irq72/irq73)
    |
    +--->  0x20018a30 0x080520d0 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20018a50 0x08050064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
-   |      0x20018b80 0x08050a0e drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:443
-   |      0x20018b80 0x080509dc drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:178
-   |      0x20018b80 0x080509dc userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /hubris/sys/userlib/src/hl.rs:128
-   |      0x20018b80 0x0805068a userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20018b80 0x0805068a userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
+   |      0x20018b80 0x08050a8c drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:495:21
+   |      0x20018b80 0x08050a8c drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:237:23
+   |      0x20018b80 0x08050a8c userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:47
+   |      0x20018b80 0x08050a8c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:105:29
+   |      0x20018b80 0x08050a8c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20018b80 0x08050a8c main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:149
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:178:9
    |
    |
    +--->   R0 = 0x08052678   R1 = 0x00000000   R2 = 0x00000004   R3 = 0x20018a34
@@ -383,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x08055f02 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20004270 0x0805467c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x200042a8 0x08054444 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:739
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:901:17
    |      0x20004380 0x08054e4a main
-   |                 @ /hubris//task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:404:5
    |
    |
    +--->   R0 = 0x080565a8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20004254
@@ -445,17 +445,17 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20010498 0x0800a114 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:154
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
    |      0x200104f0 0x08009b20 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:287
-   |      0x20010560 0x08008190 drv_i2c_devices::max31790::read_reg16
-   |                 @ /hubris//drv/i2c-devices/src/max31790.rs:227
-   |      0x20010560 0x08008182 drv_i2c_devices::max31790::Max31790::fan_rpm
-   |                 @ /hubris//drv/i2c-devices/src/max31790.rs:278
-   |      0x20010560 0x08008182 task_thermal::FanControl::fan_rpm
-   |                 @ /hubris//task/thermal/src/main.rs:94
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:307:12
+   |      0x20010560 0x08008196 drv_i2c_devices::max31790::read_reg16
+   |                 @ /hubris/drv/i2c-devices/src/max31790.rs:231:5
+   |      0x20010560 0x08008196 drv_i2c_devices::max31790::Max31790::fan_rpm
+   |                 @ /hubris/drv/i2c-devices/src/max31790.rs:279:19
+   |      0x20010560 0x08008196 task_thermal::FanControl::fan_rpm
+   |                 @ /hubris/task/thermal/src/main.rs:96:34
    |      0x20010560 0x08008196 task_thermal::control::ThermalControl<B>::read_sensors
-   |                 @ /hubris//task/thermal/src/control.rs:99
+   |                 @ /hubris/task/thermal/src/control.rs:103:37
    |      0x20011198 0x08008cd0 <task_thermal::ServerImpl<B> as idol_runtime::NotificationHandler>::handle_notification
    |                 @ /hubris//task/thermal/src/main.rs:202
    |      0x20011198 0x08008c6e idol_runtime::dispatch_n
@@ -517,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 power                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x20014368 0x0805a220 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:154
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
    |      0x200143c0 0x080595c8 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:287
-   |      0x20014800 0x08058654 <drv_i2c_devices::tps546b24a::Tps546B24A as drv_i2c_devices::CurrentSensor<drv_i2c_devices::tps546b24a::Error>>::read_iout
-   |                 @ /hubris//drv/i2c-devices/src/tps546b24a.rs:80
-   |      0x20014800 0x08058654 task_power::read_current
-   |                 @ /hubris//task/power/src/main.rs:70
-   |      0x20014800 0x080585ae task_power::PowerController::read_iout
-   |                 @ /hubris//task/power/src/main.rs:111
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:307:12
+   |      0x20014800 0x0805865e <drv_i2c_devices::tps546b24a::Tps546B24A as drv_i2c_devices::CurrentSensor<drv_i2c_devices::tps546b24a::Error>>::read_iout
+   |                 @ /hubris/drv/i2c-devices/src/tps546b24a.rs:81:20
+   |      0x20014800 0x0805865e task_power::read_current
+   |                 @ /hubris/task/power/src/main.rs:76:11
+   |      0x20014800 0x0805865e task_power::PowerController::read_iout
+   |                 @ /hubris/task/power/src/main.rs:116:33
    |      0x20014800 0x0805865e main
-   |                 @ /hubris//task/power/src/main.rs:232
+   |                 @ /hubris/task/power/src/main.rs:266:19
    |
    |
    +--->   R0 = 0x20014394   R1 = 0x2001436c   R2 = 0x20014369   R3 = 0x00000000
@@ -583,19 +583,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 notif: bit31(T+6)
    |
    +--->  0x20008140 0x08043672 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20008180 0x080436e2 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20008180 0x080436bc userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20008180 0x080436e2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x080436e2 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x0804111c core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x0804111c core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x0804111c main
-   |                 @ /hubris//task/hiffy/src/main.rs:99
+   |                 @ /hubris/task/hiffy/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x0804477c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -651,13 +651,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200154f0 0x080135a2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015640 0x08010864 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015640 0x08010864 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015640 0x08010874 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015640 0x08010874 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20015640 0x08010874 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:58
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:302:9
    |
    |
    +--->   R0 = 0x20015517   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x20015530
@@ -713,13 +713,13 @@ ID TASK                       GEN PRI STATE
 11 hf                           0   3 recv
    |
    +--->  0x200195f8 0x0805d82c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20019780 0x0805c36e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20019780 0x0805c36e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20019780 0x0805c37e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20019780 0x0805c37e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20019780 0x0805c37e main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:145:9
    |
    |
    +--->   R0 = 0x20019630   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x20019760
@@ -775,13 +775,13 @@ ID TASK                       GEN PRI STATE
 12 sensor                       0   3 recv, notif: bit0(T+466)
    |
    +--->  0x20019a88 0x08066bca userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20019f80 0x080660ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20019f80 0x080660ac idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20019f80 0x080660ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20019f80 0x080660ba idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:250:20
    |      0x20019f80 0x080660ba main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20019f68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x20019d00
@@ -837,11 +837,11 @@ ID TASK                       GEN PRI STATE
 13 udpecho                      0   3 notif: bit0
    |
    +--->  0x20012e08 0x0806157e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20013000 0x080607e4 core::result::Result<T,E>::unwrap
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1296
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1297:9
    |      0x20013000 0x080607e4 main
-   |                 @ /hubris//task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:36:17
    |
    |
    +--->   R0 = 0x08061b2c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20012fdc
@@ -897,13 +897,13 @@ ID TASK                       GEN PRI STATE
 14 validate                     0   3 recv
    |
    +--->  0x20016398 0x0806957e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x200163e8 0x08068248 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x200163e8 0x08068248 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x200163e8 0x08068258 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x200163e8 0x08068258 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x200163e8 0x08068258 main
-   |                 @ /hubris//task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x200163b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200163b8
@@ -959,7 +959,7 @@ ID TASK                       GEN PRI STATE
 15 idle                         0   5 RUNNING
    |
    +--->  0x2001a500 0x0806a856 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2001a500   R1 = 0x2001a500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.control_plane_agent.overflow.0.stdout
@@ -5,26 +5,35 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x24030090 0x08027790 drv_lpc55_update_api::_::<impl serde::de::Deserialize for drv_lpc55_update_api::RotBootInfo>::deserialize
-   |                 @ /hubris/drv/lpc55-update-api/src/lib.rs:102
+   |                 @ /hubris/drv/lpc55-update-api/src/lib.rs:102:0
    |      0x24030198 0x0802883c <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
-   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/result.rs:1985
-   |      0x24030198 0x0802882e hubpack::de::deserialize
-   |                 @ /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hubpack-0.1.2/src/de.rs:22
+   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/result.rs:1986:15
+   |      0x24030198 0x0802883c hubpack::de::deserialize
+   |                 @ /home/ubuntu/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hubpack-0.1.2/src/de.rs:24:15
    |      0x24030198 0x0802883c drv_sprot_api::SpRot::rot_boot_info
-   |      0x24030890 0x0801c218 <task_control_plane_agent::mgs_handler::MgsHandler as gateway_messages::sp_impl::SpHandler>::sp_state
-   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:556
+   |                 @ /build/drv-sprot-api-d527bfef7e248efa/out/client_stub.rs:805:48
+   |      0x24030890 0x0801c2aa core::result::Result<T,E>::map
+   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/result.rs:770:15
+   |      0x24030890 0x0801c2aa task_control_plane_agent::mgs_common::MgsCommon::sp_state
+   |                 @ /hubris/task/control-plane-agent/src/mgs_common.rs:134:18
+   |      0x24030890 0x0801c2aa <task_control_plane_agent::mgs_handler::MgsHandler as gateway_messages::sp_impl::SpHandler>::sp_state
+   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:558:9
    |      0x24030890 0x0801c2aa gateway_messages::sp_impl::handle_mgs_request
-   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:684
+   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:769:32
    |      0x24031000 0x08023c8c <core::option::Option<T> as core::ops::try_trait::Try>::branch
-   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/option.rs:2476
-   |      0x24031000 0x08023628 gateway_messages::sp_impl::handle_message
-   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:402
-   |      0x24031000 0x08022b32 <task_control_plane_agent::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:253
-   |      0x24031000 0x080229f8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /rustc/c52c23b6f44cd19718721a5e3b2eeb169e9c96ff/library/core/src/option.rs:2477:15
+   |      0x24031000 0x08023c8c gateway_messages::sp_impl::handle_message
+   |                 @ /git/management-gateway-service-749acba834b73294/1885b52/gateway-messages/src/sp_impl.rs:413:58
+   |      0x24031000 0x08023c8c task_control_plane_agent::NetHandler::handle_received_packet
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:577:26
+   |      0x24031000 0x08023c8c task_control_plane_agent::NetHandler::run_until_blocked
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:544:21
+   |      0x24031000 0x08023c8c <task_control_plane_agent::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:266:13
+   |      0x24031000 0x08023c8c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:265:13
    |      0x24031000 0x08023c8c main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:216
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:222:9
    |
    |
    +-----------> 0x24001108 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.counters.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.counters.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+2)
    |
    +--->  0x2404c518 0x0806df78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404c600 0x0806d00a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404c600 0x0806d00a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404c600 0x0806d01a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404c600 0x0806d01a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404c600 0x0806d01a main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:80:9
    |
    |
    +--->   R0 = 0x2404c58c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2404c5c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+386)
    |
    +--->  0x240107e8 0x080171f8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240109c8 0x080084f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240109c8 0x08008504 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x240109c8 0x08008504 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24011798 0x08010508 main
-   |                 @ /hubris/task/net/src/main.rs:158
+   |                 @ /hubris/task/net/src/main.rs:261:13
    |
    |
    +--->   R0 = 0x240114e0   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010918
@@ -119,11 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2404e348 0x0805f60e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404e380 0x0805f17e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404e380 0x0805f18c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404e380 0x0805f18c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404e380 0x0805f18c main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2404e350   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2404e358
@@ -175,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240482a8 0x08092fc0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24048368 0x08091330 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24048368 0x08091328 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24048368 0x08091348 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24048368 0x08091348 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24048368 0x08091348 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:31
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x240482f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24048334
@@ -233,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x24049220 0x0804a7cc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24049380 0x0804892c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24049380 0x0804892c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x24049380 0x0804892c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24049380 0x0804892c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:123
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24049380 0x0804893c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24049380 0x0804893c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24049380 0x0804893c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x24049380 0x0804893c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:5
    |      0x24049380 0x0804893c main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:322
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x24049344   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24049358
@@ -295,19 +297,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x2404a280 0x080894d8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404a2a0 0x080882ac core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x2404a2f0 0x08087d58 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x2404a2f0 0x08087d58 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x2404a2f0 0x08087d58 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x2404a2f0 0x08087d58 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:847
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:896:17
    |      0x2404a380 0x08088502 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:261:5
    |
    |
    +--->   R0 = 0x08089994   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404a284
@@ -359,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042e0 0x0808b604 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x0808a312 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x0808a312 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x0808a320 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x0808a320 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24004380 0x0808a320 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -417,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+436)
    |
    +--->  0x240024b8 0x08066266 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x0806315e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x0806315e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x08063170 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x08063170 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24003770 0x08063170 main
-   |                 @ /hubris/task/thermal/src/main.rs:342
+   |                 @ /hubris/task/thermal/src/main.rs:379:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -475,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+551)
    |
    +--->  0x2403c500 0x0809a7de userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403c9c8 0x0809484e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403c9c8 0x0809484e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403c9c8 0x0809485e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403c9c8 0x0809485e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403c9c8 0x0809485e main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +--->   R0 = 0x2403c750   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x2403c980
@@ -533,19 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+31)
    |
    +--->  0x24008230 0x0807e438 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008278 0x0807e4b6 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008278 0x0807e47c userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008278 0x0807e4b6 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
    |      0x24008278 0x0807e4b6 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24008400 0x0807ba22 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x0807ba22 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x0807ba22 main
-   |                 @ /hubris/task/hiffy/src/main.rs:131
+   |                 @ /hubris/task/hiffy/src/main.rs:148:9
    |
    |
    +--->   R0 = 0x0807f988   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2400823c
@@ -597,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+2)
    |
    +--->  0x2403e438 0x0803cc62 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403e640 0x08039abc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403e640 0x08039abc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403e640 0x08039aca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403e640 0x08039aca idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403e640 0x08039aca main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:133
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:143:17
    |
    |
    +--->   R0 = 0x2403e614   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2403e4c0
@@ -655,13 +657,13 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2404ccd8 0x0808fbdc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404ce40 0x0808e43c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404ce40 0x0808e43c userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404ce40 0x0808e44c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404ce40 0x0808e44c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2404ce40 0x0808e44c main
-   |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
+   |                 @ /hubris/task/gimlet-inspector/src/main.rs:139:17
    |
    |
    +--->   R0 = 0x08090490   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404cdcc
@@ -713,13 +715,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24047540 0x0808d612 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24047800 0x0808c180 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24047800 0x0808c180 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24047800 0x0808c190 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24047800 0x0808c190 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24047800 0x0808c190 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x2404755c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240477d4
@@ -771,13 +773,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240469a0 0x08082788 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24046bb8 0x080804fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24046bb8 0x080804fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24046bb8 0x0808050c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24046bb8 0x0808050c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24046bb8 0x0808050c main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240469e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24046b78
@@ -829,13 +831,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24045378 0x0805b9a8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24045800 0x0805a1b4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24045800 0x0805a1b4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24045800 0x0805a1c4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24045800 0x0805a1c4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24045800 0x0805a1c4 main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:524
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:534:9
    |
    |
    +--->   R0 = 0x240453cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240453d0
@@ -887,13 +889,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv, notif: timer(T+608)
    |
    +--->  0x24042350 0x0805e9f0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24042400 0x0805d4e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24042400 0x0805d4e2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24042400 0x0805d4f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24042400 0x0805d4f0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24042400 0x0805d4f0 main
-   |                 @ /hubris/task/sensor/src/main.rs:284
+   |                 @ /hubris/task/sensor/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x240423ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x240423d8
@@ -945,13 +947,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
    |
    +--->  0x24020e18 0x08054086 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24021000 0x08050394 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24021000 0x08050394 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24021000 0x080503a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24021000 0x080503a4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24021000 0x080503a4 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:151
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x24020f10   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020f48
@@ -1003,13 +1005,13 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x24040ef0 0x080597c0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24041000 0x08058246 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24041000 0x08058246 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24041000 0x08058256 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24041000 0x08058256 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24041000 0x08058256 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x08059fe0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24040fd8
@@ -1061,15 +1063,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+161)
    |
    +--->  0x2404b6d8 0x0807963a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404b800 0x0807837a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x2404b800 0x0807833e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
-   |      0x2404b800 0x08078316 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x2404b800 0x0807837a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
+   |      0x2404b800 0x0807837a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x2404b800 0x0807837a main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x08079da4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2404b790
@@ -1121,21 +1123,21 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x240289a0 0x08031748 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24028df0 0x08020206 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24028df0 0x08020214 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x24028df0 0x08020214 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24029000 0x0802c0d0 core::option::Option<T>::as_ref
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/option.rs:629
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/option.rs:630:15
    |      0x24029000 0x0802c0d0 <task_control_plane_agent::update::host_flash::HostFlashUpdate as task_control_plane_agent::update::ComponentUpdater>::is_preparing
-   |                 @ /hubris/task/control-plane-agent/src/update/host_flash.rs:154
+   |                 @ /hubris/task/control-plane-agent/src/update/host_flash.rs:155:15
    |      0x24029000 0x0802c0d0 task_control_plane_agent::mgs_handler::MgsHandler::timer_deadline
-   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:169
+   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:175:12
    |      0x24029000 0x0802c0d0 task_control_plane_agent::ServerImpl::timer_deadline
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:237
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:238:9
    |      0x24029000 0x0802c0d0 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:212
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:217:23
    |
    |
    +--->   R0 = 0x24028fac   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028b78
@@ -1187,13 +1189,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x24033f68 0x08076324 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24034000 0x0806fb82 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24034000 0x0806fb82 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24034000 0x0806fb92 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24034000 0x0806fb92 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24034000 0x0806fb92 main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:173
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x24033f78   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24033fe4
@@ -1245,13 +1247,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240443b0 0x080615d6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240443e8 0x0805fa50 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240443e8 0x0805fa50 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240443e8 0x0805fa60 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240443e8 0x0805fa60 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x240443e8 0x0805fa60 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240443b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240443b8
@@ -1303,13 +1305,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2404da18 0x08057538 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404db20 0x08056174 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404db20 0x08056174 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404db20 0x08056184 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404db20 0x08056184 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404db20 0x08056184 main
-   |                 @ /hubris/task/vpd/src/main.rs:210
+   |                 @ /hubris/task/vpd/src/main.rs:215:9
    |
    |
    +--->   R0 = 0x2404da50   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404da54
@@ -1361,13 +1363,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2404df40 0x0805cf82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404df80 0x0805ccfe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404df80 0x0805ccfe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404df80 0x0805cd0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404df80 0x0805cd0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404df80 0x0805cd0e main
-   |                 @ /hubris/drv/user-leds/src/main.rs:185
+   |                 @ /hubris/drv/user-leds/src/main.rs:204:9
    |
    |
    +--->   R0 = 0x2404df50   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2404df58
@@ -1419,13 +1421,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24038590 0x0806b0e0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24038960 0x0806894e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24038960 0x0806894e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24038960 0x0806895e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24038960 0x0806895e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24038960 0x0806895e main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x24038620   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24038730
@@ -1477,13 +1479,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2404d250 0x0808714a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d320 0x0808632a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d320 0x0808632a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d320 0x0808633a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d320 0x0808633a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404d320 0x0808633a main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2404d2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2404d2f8
@@ -1535,7 +1537,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2404e500 0x08057b92 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2404e500   R1 = 0x2404e500   R2 = 0x00000000   R3 = 0x00000000
@@ -1587,13 +1589,13 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2403a710 0x0808556c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403b000 0x08083692 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403b000 0x08083692 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403b000 0x080836a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403b000 0x080836a4 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2403b000 0x080836a4 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x08085f7c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2403af90

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.duplicate_HostFlash_hash_REPLY.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.duplicate_HostFlash_hash_REPLY.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+47)
    |
    +--->  0x24026528 0x0807d620 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24026600 0x0807c2dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24026600 0x0807c2dc idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24026600 0x0807c2ea userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24026600 0x0807c2ea idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:269:20
    |      0x24026600 0x0807c2ea main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24026598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x240265dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: bit0(irq61) bit1(T+93)
    |
    +--->  0x24008788 0x0803095e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24009220 0x08026070 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24009220 0x0802605e idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24009220 0x08026074 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24009220 0x08026074 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:269:20
    |      0x24009220 0x08026074 main
-   |                 @ /hubris/task/net/src/main.rs:104
+   |                 @ /hubris/task/net/src/main.rs:184:13
    |
    |
    +--->   R0 = 0x24008f90   R1 = 0x00000020   R2 = 0x00000003   R3 = 0x24008d88
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x24029330 0x080866dc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24029380 0x080861a2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24029380 0x080861a2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24029380 0x080861b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24029380 0x080861b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24029380 0x080861b0 main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24029368   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x24029340
@@ -189,13 +189,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x24026b08 0x08051ffa userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24026b68 0x080505c4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24026b68 0x080505c4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24026b68 0x080505de userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24026b68 0x080505de idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24026b68 0x080505de main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x24026b1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24026b1c
@@ -251,13 +251,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x24027300 0x0805612e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24027368 0x08054590 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24027368 0x08054590 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24027368 0x080545aa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24027368 0x080545aa idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24027368 0x080545aa main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2402731a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2402731c
@@ -313,17 +313,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 recv
    |
    +--->  0x24027a50 0x0805a79e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24027b80 0x080587ec userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24027b80 0x080587ec userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:238
-   |      0x24027b80 0x080587ec userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24027b80 0x080587ec userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:119
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24027b80 0x080587fc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24027b80 0x080587fc userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:242:11
+   |      0x24027b80 0x080587fc userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x24027b80 0x080587fc userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:126:5
    |      0x24027b80 0x080587fc main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:200
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229:9
    |
    |
    +--->   R0 = 0x24027b44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24027b58
@@ -379,19 +379,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x24004258 0x0805e614 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24004278 0x0805c81c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248:5
    |      0x240042a8 0x0805c112 core::ptr::read_volatile
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1468
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1472:9
    |      0x240042a8 0x0805c112 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240042a8 0x0805c112 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240042a8 0x0805c112 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:774
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:823:17
    |      0x24004380 0x0805d03e main
-   |                 @ /hubris/task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:407:5
    |
    |
    +--->   R0 = 0x0805eda8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2400425c
@@ -447,13 +447,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: bit0(T+290)
    |
    +--->  0x240025b8 0x080627a0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24003198 0x08060dd8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24003198 0x08060dd8 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24003198 0x08060de6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24003198 0x08060de6 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:269:20
    |      0x24003198 0x08060de6 main
-   |                 @ /hubris/task/thermal/src/main.rs:221
+   |                 @ /hubris/task/thermal/src/main.rs:244:9
    |
    |
    +--->   R0 = 0x24003000   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x24003080
@@ -509,15 +509,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 notif: bit31(T+254)
    |
    +--->  0x240203c0 0x0806688c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24020800 0x080643fa userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x24020800 0x080643d4 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
-   |      0x24020800 0x080643a8 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:625
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x24020800 0x080643fa userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
+   |      0x24020800 0x080643fa userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x24020800 0x080643fa main
-   |                 @ /hubris/task/power/src/main.rs:305
+   |                 @ /hubris/task/power/src/main.rs:311:9
    |
    |
    +--->   R0 = 0x080671f8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240207d8
@@ -573,19 +573,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+109)
    |
    +--->  0x24010200 0x0800c3d8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24010240 0x0800c452 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x24010240 0x0800c42c userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x24010240 0x0800c452 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
    |      0x24010240 0x0800c452 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:625
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x24010400 0x08009846 core::sync::atomic::atomic_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3049
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3057:23
    |      0x24010400 0x08009846 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2397
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2399:26
    |      0x24010400 0x08009846 main
-   |                 @ /hubris/task/hiffy/src/main.rs:122
+   |                 @ /hubris/task/hiffy/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x0800d5e0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24010208
@@ -641,13 +641,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x240214d8 0x08013de0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24021640 0x08010a88 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24021640 0x08010a88 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24021640 0x08010a98 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24021640 0x08010a98 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:269:20
    |      0x24021640 0x08010a98 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:64
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:343:9
    |
    |
    +--->   R0 = 0x24021507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x24021520
@@ -703,13 +703,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x24022530 0x0806999c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24022800 0x08068250 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24022800 0x08068250 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24022800 0x08068260 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24022800 0x08068260 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24022800 0x08068260 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x24022550   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240227d4
@@ -765,13 +765,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x240285c8 0x0806e0ae userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24028780 0x0806c378 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24028780 0x0806c378 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24028780 0x0806c386 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24028780 0x0806c386 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24028780 0x0806c386 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x24028610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24028730
@@ -827,13 +827,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x240233b8 0x08071618 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24023800 0x0807019c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24023800 0x0807019c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24023800 0x080701aa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24023800 0x080701aa idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24023800 0x080701aa main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:384
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:394:9
    |
    |
    +--->   R0 = 0x240233dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240233e0
@@ -889,13 +889,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: bit0(T+847)
    |
    +--->  0x24028a88 0x0807f0ec userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24028f80 0x0807e0ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24028f80 0x0807e0ac idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24028f80 0x0807e0ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24028f80 0x0807e0ba idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:269:20
    |      0x24028f80 0x0807e0ba main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x24028f68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x24028d00
@@ -951,13 +951,13 @@ ID TASK                       GEN PRI STATE
 15 udpecho                      0   6 notif: bit0
    |
    +--->  0x2401ce00 0x080817bc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2401d000 0x0808015a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2401d000 0x0808015a userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:263
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2401d000 0x0808016c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2401d000 0x0808016c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:268:5
    |      0x2401d000 0x0808016c main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x08081e28   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2401cf9c
@@ -1013,13 +1013,15 @@ ID TASK                       GEN PRI STATE
 16 udpbroadcast                 0   6 notif: bit31(T+290)
    |
    +--->  0x24024768 0x08083672 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24024800 0x0808216c userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x24024800 0x08082146 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x24024800 0x0808216c userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
+   |      0x24024800 0x0808216c userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x24024800 0x0808216c main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:49:9
    |
    |
    +--->   R0 = 0x08083cc8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240247ac
@@ -1075,11 +1077,11 @@ ID TASK                       GEN PRI STATE
 17 udprpc                       0   6 notif: bit0
    |
    +--->  0x2401e630 0x08075e36 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x2401f000 0x08074538 task_net_api::Net::recv_packet
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/task-net-api-1c282d4194cd92fd/out/client_stub.rs:34
+   |                 @ /build/task-net-api-1c282d4194cd92fd/out/client_stub.rs:78:20
    |      0x2401f000 0x08074538 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:68:15
    |
    |
    +--->   R0 = 0x080765f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2401efbc
@@ -1135,13 +1137,13 @@ ID TASK                       GEN PRI STATE
 18 mgmt_gateway                 0   6 notif: bit0 bit1(irq37) bit2
    |
    +--->  0x240186e0 0x08046358 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24018800 0x080413b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24018800 0x080413b8 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:263
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24018800 0x080413ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24018800 0x080413ca userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:268:5
    |      0x24018800 0x080413ca main
-   |                 @ /hubris/task/mgmt-gateway/src/main.rs:109
+   |                 @ /hubris/task/mgmt-gateway/src/main.rs:116:20
    |
    |
    +--->   R0 = 0x08047cec   R1 = 0x00000000   R2 = 0x00000007   R3 = 0x240187c0
@@ -1197,13 +1199,13 @@ ID TASK                       GEN PRI STATE
 19 validate                     0   5 recv
    |
    +--->  0x240253b0 0x08079c80 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x240253e8 0x08078260 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x240253e8 0x08078260 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x240253e8 0x08078270 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x240253e8 0x08078270 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x240253e8 0x08078270 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x240253b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240253b8
@@ -1259,13 +1261,13 @@ ID TASK                       GEN PRI STATE
 20 vpd                          0   4 recv
    |
    +--->  0x24029608 0x08085690 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24029720 0x0808407c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24029720 0x0808407c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24029720 0x0808408a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24029720 0x0808408a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/7350b8a/runtime/src/lib.rs:193:20
    |      0x24029720 0x0808408a main
-   |                 @ /hubris/task/vpd/src/main.rs:119
+   |                 @ /hubris/task/vpd/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x24029640   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24029650
@@ -1321,7 +1323,7 @@ ID TASK                       GEN PRI STATE
 21 idle                         0   7 RUNNING
    |
    +--->  0x24029900 0x08086852 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x24029900   R1 = 0x24029900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.extern-regions.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.extern-regions.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 FAULT: panicked at 'MAC RX watchdog', task/net/src/main.rs:268:41 (was: ready)
    |
    +--->  0x24010b60 0x0802f49a userlib::sys_panic_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:990
-   |      0x24010b98 0x0802f4d0 userlib::sys_panic
-   |                 @ /hubris/sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x24010b98 0x0802f4d4 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x24010b98 0x0802f4d4 rust_begin_unwind
-   |                 @ /hubris/sys/userlib/src/lib.rs:1298
+   |                 @ /hubris/sys/userlib/src/lib.rs:1437:5
    |      0x24010bb8 0x0802886a core::panicking::panic_fmt
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:50
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:65:14
    |      0x24011798 0x08026dd6 main
    |                 @ /hubris/task/net/src/main.rs:153
    |

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+24)
    |
    +--->  0x2404c518 0x08065f78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404c600 0x0806500a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404c600 0x0806500a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404c600 0x0806501a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404c600 0x0806501a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404c600 0x0806501a main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:80:9
    |
    |
    +--->   R0 = 0x2404c58c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2404c5c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+11)
    |
    +--->  0x240107e8 0x0803eab4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240109c8 0x080304f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240109c8 0x08030504 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x240109c8 0x08030504 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24011798 0x080384b6 main
-   |                 @ /hubris/task/net/src/main.rs:158
+   |                 @ /hubris/task/net/src/main.rs:261:13
    |
    |
    +--->   R0 = 0x240114e0   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010918
@@ -119,11 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2404e348 0x0805760e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404e380 0x0805717e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404e380 0x0805718c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404e380 0x0805718c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404e380 0x0805718c main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2404e350   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2404e358
@@ -175,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240482a8 0x0808cfc0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24048368 0x0808b330 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24048368 0x0808b328 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24048368 0x0808b348 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24048368 0x0808b348 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24048368 0x0808b348 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:31
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x240482f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24048334
@@ -233,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x24049220 0x080467cc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24049380 0x0804492c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24049380 0x0804492c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x24049380 0x0804492c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24049380 0x0804492c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:123
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24049380 0x0804493c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24049380 0x0804493c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24049380 0x0804493c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x24049380 0x0804493c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:5
    |      0x24049380 0x0804493c main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:322
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x24049344   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24049358
@@ -295,19 +297,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x2404a280 0x080794d8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404a2a0 0x080782ac core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x2404a2f0 0x08077d58 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x2404a2f0 0x08077d58 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x2404a2f0 0x08077d58 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x2404a2f0 0x08077d58 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:847
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:896:17
    |      0x2404a380 0x08078502 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:261:5
    |
    |
    +--->   R0 = 0x08079994   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404a284
@@ -359,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042e0 0x08076e04 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x08075b12 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x08075b12 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x08075b20 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x08075b20 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24004380 0x08075b20 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -417,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+59)
    |
    +--->  0x240024b8 0x08060266 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x0805d146 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x0805d146 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x0805d158 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x0805d158 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24003770 0x0805d158 main
-   |                 @ /hubris/task/thermal/src/main.rs:342
+   |                 @ /hubris/task/thermal/src/main.rs:379:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -475,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+119)
    |
    +--->  0x2403c500 0x080977be userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403c9c8 0x0809182e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403c9c8 0x0809182e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403c9c8 0x0809183e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403c9c8 0x0809183e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403c9c8 0x0809183e main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +--->   R0 = 0x2403c750   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x2403c980
@@ -533,19 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+237)
    |
    +--->  0x24008230 0x0807e570 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008278 0x0807e5ee userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008278 0x0807e5b4 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008278 0x0807e5ee userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
    |      0x24008278 0x0807e5ee userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24008400 0x0807bb42 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x0807bb42 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x0807bb42 main
-   |                 @ /hubris/task/hiffy/src/main.rs:131
+   |                 @ /hubris/task/hiffy/src/main.rs:148:9
    |
    |
    +--->   R0 = 0x0807fa98   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2400823c
@@ -597,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+54)
    |
    +--->  0x2403e438 0x08024c92 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403e640 0x08021ac4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403e640 0x08021ac4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403e640 0x08021ad2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403e640 0x08021ad2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403e640 0x08021ad2 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:133
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:143:17
    |
    |
    +--->   R0 = 0x2403e614   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2403e4c0
@@ -655,13 +657,13 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2404ccd8 0x0808fbdc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404ce40 0x0808e42c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404ce40 0x0808e42c userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404ce40 0x0808e43c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404ce40 0x0808e43c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2404ce40 0x0808e43c main
-   |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
+   |                 @ /hubris/task/gimlet-inspector/src/main.rs:139:17
    |
    |
    +--->   R0 = 0x08090490   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404cdcc
@@ -713,13 +715,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24047540 0x08089732 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24047800 0x080882a0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24047800 0x080882a0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24047800 0x080882b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24047800 0x080882b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24047800 0x080882b0 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x2404755c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240477d4
@@ -771,13 +773,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240469a0 0x08084788 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24046bb8 0x080824fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24046bb8 0x080824fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24046bb8 0x0808250c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24046bb8 0x0808250c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24046bb8 0x0808250c main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240469e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24046b78
@@ -829,13 +831,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24045378 0x080539d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24045800 0x0805219c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24045800 0x0805219c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24045800 0x080521ac userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24045800 0x080521ac idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24045800 0x080521ac main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:524
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:534:9
    |
    |
    +--->   R0 = 0x240453cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240453d0
@@ -887,13 +889,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv, notif: timer(T+231)
    |
    +--->  0x24042350 0x080639f0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24042400 0x080624e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24042400 0x080624e2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24042400 0x080624f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24042400 0x080624f0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24042400 0x080624f0 main
-   |                 @ /hubris/task/sensor/src/main.rs:284
+   |                 @ /hubris/task/sensor/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x240423ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x240423d8
@@ -945,13 +947,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer(T+39) control-plane-agent
    |
    +--->  0x24020e18 0x080500be userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24021000 0x0804c394 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24021000 0x0804c394 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24021000 0x0804c3a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24021000 0x0804c3a4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24021000 0x0804c3a4 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:151
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x24020f10   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020f48
@@ -1003,13 +1005,13 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x24040ef0 0x080567c0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24041000 0x08055246 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24041000 0x08055246 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24041000 0x08055256 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24041000 0x08055256 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24041000 0x08055256 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x08056fe0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24040fd8
@@ -1061,15 +1063,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+105)
    |
    +--->  0x2404b6d8 0x08058e3a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404b800 0x08057b7a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x2404b800 0x08057b3e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
-   |      0x2404b800 0x08057b16 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x2404b800 0x08057b7a main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x080595a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2404b790
@@ -1121,13 +1123,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24028c40 0x08019874 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24029000 0x08012ca2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24029000 0x08012ca2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24029000 0x08012cb0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24029000 0x08012cb0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24029000 0x08012cb0 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:214
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:220:9
    |
    |
    +--->   R0 = 0x24028e70   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028ed8
@@ -1179,13 +1181,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x24033f68 0x0806e350 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24034000 0x08067bce userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24034000 0x08067bce idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24034000 0x08067bde userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24034000 0x08067bde idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24034000 0x08067bde main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:173
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x24033f78   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24033fe4
@@ -1237,13 +1239,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240443b0 0x0805b5d6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240443e8 0x08059a50 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240443e8 0x08059a50 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240443e8 0x08059a60 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240443e8 0x08059a60 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x240443e8 0x08059a60 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240443b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240443b8
@@ -1295,13 +1297,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2404da18 0x080819fc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404db20 0x080805f4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404db20 0x080805f4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404db20 0x08080604 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404db20 0x08080604 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404db20 0x08080604 main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2404da50   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404da54
@@ -1353,13 +1355,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2404df40 0x08061f82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404df80 0x08061cfe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404df80 0x08061cfe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404df80 0x08061d0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404df80 0x08061d0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404df80 0x08061d0e main
-   |                 @ /hubris/drv/user-leds/src/main.rs:185
+   |                 @ /hubris/drv/user-leds/src/main.rs:204:9
    |
    |
    +--->   R0 = 0x2404df50   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2404df58
@@ -1411,13 +1413,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24038598 0x08073404 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24038960 0x08070c4e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24038960 0x08070c4e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24038960 0x08070c5e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24038960 0x08070c5e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24038960 0x08070c5e main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x24038620   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24038730
@@ -1469,13 +1471,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2404d250 0x080754ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d320 0x080746ca userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d320 0x080746ca idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d320 0x080746da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d320 0x080746da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404d320 0x080746da main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2404d2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2404d2f8
@@ -1527,7 +1529,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2404e500 0x080620b2 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2404e500   R1 = 0x2404e500   R2 = 0x00000000   R3 = 0x00000000
@@ -1579,13 +1581,13 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2403a710 0x08087590 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403b000 0x08085692 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403b000 0x08085692 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403b000 0x080856a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403b000 0x080856a4 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2403b000 0x080856a4 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x08087f7c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2403af90

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+91)
    |
    +--->  0x2404c518 0x08065f78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404c600 0x0806500a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404c600 0x0806500a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404c600 0x0806501a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404c600 0x0806501a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404c600 0x0806501a main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:80:9
    |
    |
    +--->   R0 = 0x2404c58c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2404c5c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+348)
    |
    +--->  0x240107e8 0x0803eab4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240109c8 0x080304f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240109c8 0x08030504 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x240109c8 0x08030504 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24011798 0x080384b6 main
-   |                 @ /hubris/task/net/src/main.rs:158
+   |                 @ /hubris/task/net/src/main.rs:261:13
    |
    |
    +--->   R0 = 0x240114e0   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010918
@@ -119,11 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2404e348 0x0805760e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404e380 0x0805717e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404e380 0x0805718c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404e380 0x0805718c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404e380 0x0805718c main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2404e350   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2404e358
@@ -175,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240482a8 0x0808cfc0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24048368 0x0808b330 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24048368 0x0808b328 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24048368 0x0808b348 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24048368 0x0808b348 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24048368 0x0808b348 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:31
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x240482f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24048334
@@ -233,21 +235,21 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 notif: i2c2-irq(irq33/irq34)
    |
    +--->  0x24049200 0x080467cc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24049220 0x08044154 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
-   |      0x24049380 0x08044d3c drv_stm32xx_i2c::I2cController::write_read
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:534
-   |      0x24049380 0x0804498a drv_stm32xx_i2c_server::main::{{closure}}
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358
-   |      0x24049380 0x0804498a userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /hubris/sys/userlib/src/hl.rs:130
-   |      0x24049380 0x0804492c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24049380 0x0804492c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:123
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
+   |      0x24049380 0x08044e46 drv_stm32xx_i2c::I2cController::write_read
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:617:17
+   |      0x24049380 0x08044e46 drv_stm32xx_i2c_server::main::{{closure}}
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:437:27
+   |      0x24049380 0x08044e46 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:47
+   |      0x24049380 0x08044e46 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:105:29
+   |      0x24049380 0x08044e46 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:5
    |      0x24049380 0x08044e46 main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:322
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x08046d90   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24049204
@@ -299,19 +301,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x2404a280 0x080794d8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404a2a0 0x080782ac core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x2404a2f0 0x08077d58 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x2404a2f0 0x08077d58 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x2404a2f0 0x08077d58 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x2404a2f0 0x08077d58 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:847
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:896:17
    |      0x2404a380 0x08078502 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:261:5
    |
    |
    +--->   R0 = 0x08079994   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404a284
@@ -363,13 +365,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042e0 0x08076e04 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x08075b12 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x08075b12 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x08075b20 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x08075b20 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24004380 0x08075b20 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -421,13 +423,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+425)
    |
    +--->  0x240024b8 0x08060266 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x0805d146 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x0805d146 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x0805d158 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x0805d158 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24003770 0x0805d158 main
-   |                 @ /hubris/task/thermal/src/main.rs:342
+   |                 @ /hubris/task/thermal/src/main.rs:379:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -479,25 +481,25 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 wait: reply from i2c_driver/gen0
    |
    +--->  0x2403c480 0x080977da userlib::sys_send_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:154
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
    |      0x2403c4d8 0x08096700 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:158
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:178:9
    |      0x2403c500 0x08096b94 <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/result.rs:2091
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/result.rs:2092:15
    |      0x2403c500 0x08096b94 drv_i2c_devices::max5970::Max5970::peak_vout
-   |                 @ /hubris/drv/i2c-devices/src/max5970.rs:334
-   |      0x2403c9c8 0x080925a2 task_power::bsp::trace_max5970
-   |                 @ /hubris/task/power/src/bsp/gimlet_bcdef.rs:102
-   |      0x2403c9c8 0x0809251c task_power::bsp::State::handle_timer_fired
-   |                 @ /hubris/task/power/src/bsp/gimlet_bcdef.rs:223
-   |      0x2403c9c8 0x08091880 task_power::ServerImpl::handle_timer_fired
-   |                 @ /hubris/task/power/src/main.rs:439
-   |      0x2403c9c8 0x08091880 <task_power::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
-   |                 @ /hubris/task/power/src/main.rs:627
-   |      0x2403c9c8 0x0809182e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/drv/i2c-devices/src/max5970.rs:341:13
+   |      0x2403c9c8 0x080925ae task_power::bsp::trace_max5970
+   |                 @ /hubris/task/power/src/bsp/gimlet_bcdef.rs:108:26
+   |      0x2403c9c8 0x080925ae task_power::bsp::State::handle_timer_fired
+   |                 @ /hubris/task/power/src/bsp/gimlet_bcdef.rs:246:17
+   |      0x2403c9c8 0x080925ae task_power::ServerImpl::handle_timer_fired
+   |                 @ /hubris/task/power/src/main.rs:510:9
+   |      0x2403c9c8 0x080925ae <task_power::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/power/src/main.rs:628:9
+   |      0x2403c9c8 0x080925ae idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:245:13
    |      0x2403c9c8 0x080925ae main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +--->   R0 = 0x2403c4ac   R1 = 0x2403c484   R2 = 0x00000002   R3 = 0x00000001
@@ -549,19 +551,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+186)
    |
    +--->  0x24008230 0x0807e570 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008278 0x0807e5ee userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008278 0x0807e5b4 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008278 0x0807e5ee userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
    |      0x24008278 0x0807e5ee userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24008400 0x0807bb42 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x0807bb42 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x0807bb42 main
-   |                 @ /hubris/task/hiffy/src/main.rs:131
+   |                 @ /hubris/task/hiffy/src/main.rs:148:9
    |
    |
    +--->   R0 = 0x0807fa98   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2400823c
@@ -613,13 +615,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+6)
    |
    +--->  0x2403e438 0x08024c92 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403e640 0x08021ac4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403e640 0x08021ac4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403e640 0x08021ad2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403e640 0x08021ad2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403e640 0x08021ad2 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:133
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:143:17
    |
    |
    +--->   R0 = 0x2403e614   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2403e4c0
@@ -671,13 +673,13 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2404ccd8 0x0808fbdc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404ce40 0x0808e42c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404ce40 0x0808e42c userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404ce40 0x0808e43c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404ce40 0x0808e43c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2404ce40 0x0808e43c main
-   |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
+   |                 @ /hubris/task/gimlet-inspector/src/main.rs:139:17
    |
    |
    +--->   R0 = 0x08090490   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404cdcc
@@ -729,13 +731,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24047540 0x08089732 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24047800 0x080882a0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24047800 0x080882a0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24047800 0x080882b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24047800 0x080882b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24047800 0x080882b0 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x2404755c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240477d4
@@ -787,13 +789,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240469a0 0x08084788 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24046bb8 0x080824fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24046bb8 0x080824fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24046bb8 0x0808250c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24046bb8 0x0808250c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24046bb8 0x0808250c main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240469e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24046b78
@@ -845,13 +847,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24045378 0x080539d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24045800 0x0805219c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24045800 0x0805219c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24045800 0x080521ac userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24045800 0x080521ac idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24045800 0x080521ac main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:524
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:534:9
    |
    |
    +--->   R0 = 0x240453cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240453d0
@@ -903,13 +905,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv, notif: timer(T+598)
    |
    +--->  0x24042350 0x080639f0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24042400 0x080624e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24042400 0x080624e2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24042400 0x080624f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24042400 0x080624f0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24042400 0x080624f0 main
-   |                 @ /hubris/task/sensor/src/main.rs:284
+   |                 @ /hubris/task/sensor/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x240423ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x240423d8
@@ -961,13 +963,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
    |
    +--->  0x24020e18 0x080500be userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24021000 0x0804c394 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24021000 0x0804c394 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24021000 0x0804c3a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24021000 0x0804c3a4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24021000 0x0804c3a4 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:151
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x24020f10   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020f48
@@ -1019,13 +1021,13 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x24040ef0 0x080567c0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24041000 0x08055246 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24041000 0x08055246 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24041000 0x08055256 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24041000 0x08055256 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24041000 0x08055256 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x08056fe0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24040fd8
@@ -1077,15 +1079,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+409)
    |
    +--->  0x2404b6d8 0x08058e3a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404b800 0x08057b7a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x2404b800 0x08057b3e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
-   |      0x2404b800 0x08057b16 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x2404b800 0x08057b7a main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x080595a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2404b790
@@ -1137,13 +1139,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24028c40 0x08019874 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24029000 0x08012ca2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24029000 0x08012ca2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24029000 0x08012cb0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24029000 0x08012cb0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24029000 0x08012cb0 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:214
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:220:9
    |
    |
    +--->   R0 = 0x24028e70   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028ed8
@@ -1195,13 +1197,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x24033f68 0x0806e350 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24034000 0x08067bce userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24034000 0x08067bce idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24034000 0x08067bde userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24034000 0x08067bde idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24034000 0x08067bde main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:173
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x24033f78   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24033fe4
@@ -1253,13 +1255,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240443b0 0x0805b5d6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240443e8 0x08059a50 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240443e8 0x08059a50 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240443e8 0x08059a60 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240443e8 0x08059a60 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x240443e8 0x08059a60 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240443b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240443b8
@@ -1311,13 +1313,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2404da18 0x080819fc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404db20 0x080805f4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404db20 0x080805f4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404db20 0x08080604 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404db20 0x08080604 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404db20 0x08080604 main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2404da50   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404da54
@@ -1369,13 +1371,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2404df40 0x08061f82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404df80 0x08061cfe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404df80 0x08061cfe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404df80 0x08061d0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404df80 0x08061d0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404df80 0x08061d0e main
-   |                 @ /hubris/drv/user-leds/src/main.rs:185
+   |                 @ /hubris/drv/user-leds/src/main.rs:204:9
    |
    |
    +--->   R0 = 0x2404df50   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2404df58
@@ -1427,13 +1429,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24038598 0x08073404 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24038960 0x08070c4e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24038960 0x08070c4e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24038960 0x08070c5e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24038960 0x08070c5e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24038960 0x08070c5e main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x24038620   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24038730
@@ -1485,13 +1487,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2404d250 0x080754ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d320 0x080746ca userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d320 0x080746ca idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d320 0x080746da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d320 0x080746da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404d320 0x080746da main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2404d2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2404d2f8
@@ -1543,7 +1545,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2404e500 0x080620b2 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2404e500   R1 = 0x2404e500   R2 = 0x00000000   R3 = 0x00000000
@@ -1595,13 +1597,13 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2403a710 0x08087590 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403b000 0x08085692 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403b000 0x08085692 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403b000 0x080856a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403b000 0x080856a4 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2403b000 0x080856a4 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x08087f7c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2403af90

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.2.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.2.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+89)
    |
    +--->  0x2404c518 0x08065f78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404c600 0x0806500a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404c600 0x0806500a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404c600 0x0806501a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404c600 0x0806501a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404c600 0x0806501a main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:80:9
    |
    |
    +--->   R0 = 0x2404c58c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2404c5c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+475)
    |
    +--->  0x240107e8 0x0803eab4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240109c8 0x080304f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240109c8 0x08030504 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x240109c8 0x08030504 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24011798 0x080384b6 main
-   |                 @ /hubris/task/net/src/main.rs:158
+   |                 @ /hubris/task/net/src/main.rs:261:13
    |
    |
    +--->   R0 = 0x240114e0   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010918
@@ -119,11 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2404e348 0x0805760e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404e380 0x0805717e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404e380 0x0805718c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404e380 0x0805718c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404e380 0x0805718c main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2404e350   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2404e358
@@ -175,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240482a8 0x0808cfc0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24048368 0x0808b330 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24048368 0x0808b328 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24048368 0x0808b348 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24048368 0x0808b348 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24048368 0x0808b348 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:31
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x240482f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24048334
@@ -233,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x24049220 0x080467cc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24049380 0x0804492c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24049380 0x0804492c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x24049380 0x0804492c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24049380 0x0804492c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:123
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24049380 0x0804493c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24049380 0x0804493c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24049380 0x0804493c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x24049380 0x0804493c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:5
    |      0x24049380 0x0804493c main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:322
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x24049344   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24049358
@@ -295,19 +297,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x2404a280 0x080794d8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404a2a0 0x080782ac core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x2404a2f0 0x08077d58 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x2404a2f0 0x08077d58 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x2404a2f0 0x08077d58 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x2404a2f0 0x08077d58 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:847
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:896:17
    |      0x2404a380 0x08078502 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:261:5
    |
    |
    +--->   R0 = 0x08079994   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404a284
@@ -359,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042e0 0x08076e04 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x08075b12 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x08075b12 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x08075b20 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x08075b20 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24004380 0x08075b20 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -417,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+527)
    |
    +--->  0x240024b8 0x08060266 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x0805d146 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x0805d146 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x0805d158 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x0805d158 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24003770 0x0805d158 main
-   |                 @ /hubris/task/thermal/src/main.rs:342
+   |                 @ /hubris/task/thermal/src/main.rs:379:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -475,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+771)
    |
    +--->  0x2403c500 0x080977be userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403c9c8 0x0809182e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403c9c8 0x0809182e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403c9c8 0x0809183e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403c9c8 0x0809183e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403c9c8 0x0809183e main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +--->   R0 = 0x2403c750   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x2403c980
@@ -533,19 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+230)
    |
    +--->  0x24008230 0x0807e570 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008278 0x0807e5ee userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008278 0x0807e5b4 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008278 0x0807e5ee userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
    |      0x24008278 0x0807e5ee userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24008400 0x0807bb42 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x0807bb42 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x0807bb42 main
-   |                 @ /hubris/task/hiffy/src/main.rs:131
+   |                 @ /hubris/task/hiffy/src/main.rs:148:9
    |
    |
    +--->   R0 = 0x0807fa98   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2400823c
@@ -597,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+34)
    |
    +--->  0x2403e438 0x08024c92 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403e640 0x08021ac4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403e640 0x08021ac4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403e640 0x08021ad2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403e640 0x08021ad2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2403e640 0x08021ad2 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:133
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:143:17
    |
    |
    +--->   R0 = 0x2403e614   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2403e4c0
@@ -655,13 +657,13 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2404ccd8 0x0808fbdc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404ce40 0x0808e42c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404ce40 0x0808e42c userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404ce40 0x0808e43c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404ce40 0x0808e43c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2404ce40 0x0808e43c main
-   |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
+   |                 @ /hubris/task/gimlet-inspector/src/main.rs:139:17
    |
    |
    +--->   R0 = 0x08090490   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404cdcc
@@ -713,13 +715,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24047540 0x08089732 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24047800 0x080882a0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24047800 0x080882a0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24047800 0x080882b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24047800 0x080882b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24047800 0x080882b0 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x2404755c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240477d4
@@ -771,13 +773,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240469a0 0x08084788 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24046bb8 0x080824fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24046bb8 0x080824fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24046bb8 0x0808250c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24046bb8 0x0808250c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24046bb8 0x0808250c main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240469e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24046b78
@@ -829,13 +831,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24045378 0x080539d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24045800 0x0805219c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24045800 0x0805219c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24045800 0x080521ac userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24045800 0x080521ac idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24045800 0x080521ac main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:524
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:534:9
    |
    |
    +--->   R0 = 0x240453cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240453d0
@@ -887,13 +889,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv, notif: timer(T+696)
    |
    +--->  0x24042350 0x080639f0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24042400 0x080624e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24042400 0x080624e2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24042400 0x080624f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24042400 0x080624f0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24042400 0x080624f0 main
-   |                 @ /hubris/task/sensor/src/main.rs:284
+   |                 @ /hubris/task/sensor/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x240423ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x240423d8
@@ -945,13 +947,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer(T+156) control-plane-agent
    |
    +--->  0x24020e18 0x080500be userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24021000 0x0804c394 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24021000 0x0804c394 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24021000 0x0804c3a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24021000 0x0804c3a4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24021000 0x0804c3a4 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:151
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x24020f10   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020f48
@@ -1003,13 +1005,13 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x24040ef0 0x080567c0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24041000 0x08055246 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24041000 0x08055246 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24041000 0x08055256 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24041000 0x08055256 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24041000 0x08055256 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x08056fe0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24040fd8
@@ -1061,15 +1063,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+455)
    |
    +--->  0x2404b6d8 0x08058e3a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x2404b800 0x08057b7a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x2404b800 0x08057b3e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
-   |      0x2404b800 0x08057b16 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
+   |      0x2404b800 0x08057b7a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x2404b800 0x08057b7a main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x080595a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2404b790
@@ -1121,13 +1123,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24028c40 0x08019874 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24029000 0x08012ca2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24029000 0x08012ca2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24029000 0x08012cb0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24029000 0x08012cb0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24029000 0x08012cb0 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:214
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:220:9
    |
    |
    +--->   R0 = 0x24028e70   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028ed8
@@ -1179,13 +1181,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x24033f68 0x0806e350 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24034000 0x08067bce userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24034000 0x08067bce idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24034000 0x08067bde userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24034000 0x08067bde idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24034000 0x08067bde main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:173
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x24033f78   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24033fe4
@@ -1237,13 +1239,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240443b0 0x0805b5d6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240443e8 0x08059a50 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240443e8 0x08059a50 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240443e8 0x08059a60 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240443e8 0x08059a60 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x240443e8 0x08059a60 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240443b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240443b8
@@ -1295,13 +1297,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2404da18 0x080819fc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404db20 0x080805f4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404db20 0x080805f4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404db20 0x08080604 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404db20 0x08080604 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404db20 0x08080604 main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2404da50   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404da54
@@ -1353,13 +1355,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2404df40 0x08061f82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404df80 0x08061cfe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404df80 0x08061cfe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404df80 0x08061d0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404df80 0x08061d0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404df80 0x08061d0e main
-   |                 @ /hubris/drv/user-leds/src/main.rs:185
+   |                 @ /hubris/drv/user-leds/src/main.rs:204:9
    |
    |
    +--->   R0 = 0x2404df50   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2404df58
@@ -1411,13 +1413,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24038598 0x08073404 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24038960 0x08070c4e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24038960 0x08070c4e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24038960 0x08070c5e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24038960 0x08070c5e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x24038960 0x08070c5e main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x24038620   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24038730
@@ -1469,13 +1471,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2404d250 0x080754ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d320 0x080746ca userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d320 0x080746ca idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:218
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d320 0x080746da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d320 0x080746da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/86761da/runtime/src/lib.rs:226:20
    |      0x2404d320 0x080746da main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2404d2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2404d2f8
@@ -1527,7 +1529,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2404e500 0x080620b2 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2404e500   R1 = 0x2404e500   R2 = 0x00000000   R3 = 0x00000000
@@ -1579,13 +1581,13 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2403a710 0x08087590 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403b000 0x08085692 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403b000 0x08085692 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403b000 0x080856a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403b000 0x080856a4 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2403b000 0x080856a4 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x08087f7c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2403af90

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.3.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+79)
    |
    +--->  0x2405a4f0 0x08071a7c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405a600 0x08070bf4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405a600 0x08070bf4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405a600 0x08070c04 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405a600 0x08070c04 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405a600 0x08070c04 main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:79:9
    |
    |
    +--->   R0 = 0x2405a564   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2405a570
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+259)
    |
    +--->  0x24011030 0x0805e33e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24011f40 0x08056f02 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24011f40 0x08056f02 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24011f40 0x08056f14 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24011f40 0x08056f14 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24011f40 0x08056f14 main
-   |                 @ /hubris/task/net/src/main.rs:166
+   |                 @ /hubris/task/net/src/main.rs:271:13
    |
    |
    +--->   R0 = 0x24011b10   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24011c00
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv, notif: exti-wildcard-irq(irq6/irq7/irq8/irq9/irq10/irq23/irq40)
    |
    +--->  0x2405b338 0x0803092e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405b380 0x080302de userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405b380 0x080302de idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405b380 0x080302ee userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405b380 0x080302ee idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405b380 0x080302ee main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:377
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:538:9
    |
    |
    +--->   R0 = 0x2405b368   R1 = 0x00000005   R2 = 0x00000001   R3 = 0x2405b344
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x24056290 0x0806b126 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24056368 0x08069382 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24056368 0x0806937e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24056368 0x080693a6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24056368 0x080693a6 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24056368 0x080693a6 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:33
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:42:9
    |
    |
    +--->   R0 = 0x240562d6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24056300
@@ -235,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x240582b0 0x0800a9ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24058418 0x0800884c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24058418 0x0800884c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:239
-   |      0x24058418 0x0800884c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x24058418 0x0800884c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:122
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24058418 0x0800885c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:321:24
+   |      0x24058418 0x0800885c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24058418 0x0800885c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x24058418 0x0800885c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:129:5
    |      0x24058418 0x0800885c main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:364
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:417:9
    |
    |
    +--->   R0 = 0x240583c0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240583f0
@@ -297,12 +297,17 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x240591c8 0x0808f594 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x240591e8 0x0808e0c4 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250:5
    |      0x240592e8 0x0808db12 core::ptr::read_volatile
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1667
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1678:9
+   |      0x240592e8 0x0808db12 vcell::VolatileCell<T>::get
+   |                 @ /home/bmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/vcell-0.1.3/src/lib.rs:33:18
+   |      0x240592e8 0x0808db12 stm32h7::generic::Reg<REG>::modify
+   |                 @ /home/bmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240592e8 0x0808db12 drv_stm32xx_i2c::I2cController::operate_as_target
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:1001:17
    |      0x24059380 0x0808e2f4 main
    |                 @ /hubris/task/spd/src/main.rs:81
    |
@@ -356,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042b8 0x0806d59e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24004380 0x0806c256 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24004380 0x0806c256 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24004380 0x0806c266 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24004380 0x0806c266 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24004380 0x0806c266 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:118:9
    |
    |
    +--->   R0 = 0x240042d8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -414,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+657)
    |
    +--->  0x24002778 0x08014806 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24003770 0x080118a4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24003770 0x080118a4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24003770 0x080118b4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24003770 0x080118b4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24003770 0x080118b4 main
-   |                 @ /hubris/task/thermal/src/main.rs:346
+   |                 @ /hubris/task/thermal/src/main.rs:385:9
    |
    |
    +--->   R0 = 0x24002e8c   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x240031a0
@@ -472,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+66)
    |
    +--->  0x24044710 0x0809d8da userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24044ed8 0x08097efe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24044ed8 0x08097efe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24044ed8 0x08097f0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24044ed8 0x08097f0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24044ed8 0x08097f0e main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:424:9
    |
    |
    +--->   R0 = 0x24044ac0   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x24044ae8
@@ -530,17 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+128)
    |
    +--->  0x240082d0 0x0809468e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x24008318 0x0809471a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1108
-   |      0x24008318 0x080946ec userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:425
+   |                 @ /hubris/sys/userlib/src/lib.rs:1113:9
+   |      0x24008318 0x0809471a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:441:12
    |      0x24008318 0x0809471a userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:459
+   |                 @ /hubris/sys/userlib/src/hl.rs:472:5
    |      0x240084b0 0x080919c0 core::sync::atomic::atomic_sub
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:3347
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:3355:23
+   |      0x240084b0 0x080919c0 core::sync::atomic::AtomicU32::fetch_sub
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:2691:26
    |      0x240084b0 0x080919c0 main
-   |                 @ /hubris/task/hiffy/src/main.rs:139
+   |                 @ /hubris/task/hiffy/src/main.rs:156:9
    |
    |
    +--->   R0 = 0x08095a90   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240082dc
@@ -592,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+70) vcore
    |
    +--->  0x24048690 0x0807d606 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24048a28 0x08079d3e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24048a28 0x08079d3e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24048a28 0x08079d4e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24048a28 0x08079d4e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24048a28 0x08079d4e main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:145
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:155:17
    |
    |
    +--->   R0 = 0x2404873e   R1 = 0x00000001   R2 = 0x00000003   R3 = 0x24048740
@@ -650,7 +657,7 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2405ac98 0x080684b4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2405ae40 0x08066cf6 main
    |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
    |
@@ -704,13 +711,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24055520 0x08064822 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24055800 0x08063308 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24055800 0x08063308 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24055800 0x08063316 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24055800 0x08063316 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24055800 0x08063316 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x24055540   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240557d4
@@ -762,13 +769,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240549a0 0x08077464 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24054bb8 0x0807524e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24054bb8 0x0807524e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24054bb8 0x0807525e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24054bb8 0x0807525e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24054bb8 0x0807525e main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240549e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24054b78
@@ -820,13 +827,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24053378 0x08034e9a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24053800 0x080334d4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24053800 0x080334d4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24053800 0x080334e2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24053800 0x080334e2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24053800 0x080334e2 main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:543
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:568:9
    |
    |
    +--->   R0 = 0x240533d4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240533d8
@@ -878,13 +885,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv
    |
    +--->  0x24050380 0x0808cd5c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24050400 0x0808b2e4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24050400 0x0808b2e4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24050400 0x0808b2f2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24050400 0x0808b2f2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24050400 0x0808b2f2 main
-   |                 @ /hubris/task/sensor/src/main.rs:253
+   |                 @ /hubris/task/sensor/src/main.rs:289:9
    |
    |
    +--->   R0 = 0x240503b4   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x240503d0
@@ -936,13 +943,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer(T+92) control-plane-agent
    |
    +--->  0x240211d0 0x080420b6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x240213d8 0x0803f010 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x240213d8 0x0803f010 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x240213d8 0x0803f020 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x240213d8 0x0803f020 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x240213d8 0x0803f020 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:156
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:166:9
    |
    |
    +--->   R0 = 0x240212c0   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x240212f8
@@ -994,7 +1001,7 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x2404eee8 0x08032b70 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2404f000 0x080315a8 main
    |                 @ /hubris/task/udpecho/src/main.rs:14
    |
@@ -1048,15 +1055,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+1)
    |
    +--->  0x240576e8 0x0808a7f2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x24057800 0x08089218 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1108
-   |      0x24057800 0x08089208 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:425
-   |      0x24057800 0x08089208 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:459
+   |                 @ /hubris/sys/userlib/src/lib.rs:1113:9
+   |      0x24057800 0x08089218 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:441:12
+   |      0x24057800 0x08089218 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:472:5
    |      0x24057800 0x08089218 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x0808af6c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24057790
@@ -1108,13 +1115,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24030988 0x08029994 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24031000 0x08020568 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24031000 0x08020568 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24031000 0x08020578 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24031000 0x08020578 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24031000 0x08020578 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:217
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:223:9
    |
    |
    +--->   R0 = 0x24030c68   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24030ec8
@@ -1166,13 +1173,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x2403bf78 0x0804e35c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2403c000 0x080467aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2403c000 0x080467aa idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2403c000 0x080467ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2403c000 0x080467ba idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2403c000 0x080467ba main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:169
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:194:9
    |
    |
    +--->   R0 = 0x2403bf88   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2403bfe0
@@ -1224,13 +1231,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240523b8 0x080396f4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x240523e8 0x08037bf2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x240523e8 0x08037bf2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x240523e8 0x08037c02 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x240523e8 0x08037c02 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x240523e8 0x08037c02 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240523bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240523c0
@@ -1282,13 +1289,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2405c638 0x080374e6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405c720 0x0803618c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405c720 0x0803618c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405c720 0x0803619c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405c720 0x0803619c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405c720 0x0803619c main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2405c660   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2405c6b4
@@ -1340,13 +1347,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2405c340 0x080654c6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405c380 0x080651fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405c380 0x080651fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405c380 0x0806520c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405c380 0x0806520c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405c380 0x0806520c main
-   |                 @ /hubris/drv/user-leds/src/main.rs:179
+   |                 @ /hubris/drv/user-leds/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x2405c350   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2405c358
@@ -1398,13 +1405,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24040550 0x0800f8e0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24040960 0x0800c7d8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24040960 0x0800c7d8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24040960 0x0800c7e8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24040960 0x0800c7e8 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24040960 0x0800c7e8 main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x240405e8   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24040618
@@ -1456,13 +1463,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2405ba00 0x08066566 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405bb20 0x0806595c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405bb20 0x0806595c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405bb20 0x0806596c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405bb20 0x0806596c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405bb20 0x0806596c main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2405ba64   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2405baf8
@@ -1514,7 +1521,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2405c900 0x08037992 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:28:13
    |
    |
    +--->   R0 = 0x2405c900   R1 = 0x2405c900   R2 = 0x00000000   R3 = 0x00000000
@@ -1566,7 +1573,7 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2404c708 0x080741a8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2404d000 0x080727de main
    |                 @ /hubris/task/udprpc/src/main.rs:43
    |

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.host-panic.4.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+19)
    |
    +--->  0x2405a4f0 0x08071a7c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405a600 0x08070bf4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405a600 0x08070bf4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405a600 0x08070c04 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405a600 0x08070c04 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405a600 0x08070c04 main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:79:9
    |
    |
    +--->   R0 = 0x2405a564   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2405a570
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+106)
    |
    +--->  0x24011030 0x0805e33e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24011f40 0x08056f02 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24011f40 0x08056f02 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24011f40 0x08056f14 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24011f40 0x08056f14 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24011f40 0x08056f14 main
-   |                 @ /hubris/task/net/src/main.rs:166
+   |                 @ /hubris/task/net/src/main.rs:271:13
    |
    |
    +--->   R0 = 0x24011b10   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24011c00
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv, notif: exti-wildcard-irq(irq6/irq7/irq8/irq9/irq10/irq23/irq40)
    |
    +--->  0x2405b338 0x0803092e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405b380 0x080302de userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405b380 0x080302de idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405b380 0x080302ee userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405b380 0x080302ee idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405b380 0x080302ee main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:377
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:538:9
    |
    |
    +--->   R0 = 0x2405b368   R1 = 0x00000005   R2 = 0x00000001   R3 = 0x2405b344
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x24056290 0x0806b126 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24056368 0x08069382 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24056368 0x0806937e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24056368 0x080693a6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24056368 0x080693a6 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24056368 0x080693a6 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:33
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:42:9
    |
    |
    +--->   R0 = 0x240562d6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24056300
@@ -235,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x240582b0 0x0800a9ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24058418 0x0800884c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24058418 0x0800884c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:239
-   |      0x24058418 0x0800884c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x24058418 0x0800884c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:122
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24058418 0x0800885c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:321:24
+   |      0x24058418 0x0800885c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24058418 0x0800885c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x24058418 0x0800885c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:129:5
    |      0x24058418 0x0800885c main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:364
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:417:9
    |
    |
    +--->   R0 = 0x240583c0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240583f0
@@ -297,12 +297,17 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x240591c8 0x0808f594 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x240591e8 0x0808e0c4 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ops/function.rs:250:5
    |      0x240592e8 0x0808db12 core::ptr::read_volatile
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1667
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/ptr/mod.rs:1678:9
+   |      0x240592e8 0x0808db12 vcell::VolatileCell<T>::get
+   |                 @ /home/bmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/vcell-0.1.3/src/lib.rs:33:18
+   |      0x240592e8 0x0808db12 stm32h7::generic::Reg<REG>::modify
+   |                 @ /home/bmc/.cargo/registry/src/index.crates.io-6f17d22bba15001f/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240592e8 0x0808db12 drv_stm32xx_i2c::I2cController::operate_as_target
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:1001:17
    |      0x24059380 0x0808e2f4 main
    |                 @ /hubris/task/spd/src/main.rs:81
    |
@@ -356,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042b8 0x0806d59e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24004380 0x0806c256 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24004380 0x0806c256 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24004380 0x0806c266 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24004380 0x0806c266 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24004380 0x0806c266 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:118:9
    |
    |
    +--->   R0 = 0x240042d8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -414,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+156)
    |
    +--->  0x24002778 0x08014806 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24003770 0x080118a4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24003770 0x080118a4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24003770 0x080118b4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24003770 0x080118b4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24003770 0x080118b4 main
-   |                 @ /hubris/task/thermal/src/main.rs:346
+   |                 @ /hubris/task/thermal/src/main.rs:385:9
    |
    |
    +--->   R0 = 0x24002e8c   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x240031a0
@@ -472,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+444)
    |
    +--->  0x24044710 0x0809d8da userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24044ed8 0x08097efe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24044ed8 0x08097efe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24044ed8 0x08097f0e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24044ed8 0x08097f0e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24044ed8 0x08097f0e main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:424:9
    |
    |
    +--->   R0 = 0x24044ac0   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x24044ae8
@@ -530,17 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+111)
    |
    +--->  0x240082d0 0x0809468e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x24008318 0x0809471a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1108
-   |      0x24008318 0x080946ec userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:425
+   |                 @ /hubris/sys/userlib/src/lib.rs:1113:9
+   |      0x24008318 0x0809471a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:441:12
    |      0x24008318 0x0809471a userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:459
+   |                 @ /hubris/sys/userlib/src/hl.rs:472:5
    |      0x240084b0 0x080919c0 core::sync::atomic::atomic_sub
-   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:3347
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:3355:23
+   |      0x240084b0 0x080919c0 core::sync::atomic::AtomicU32::fetch_sub
+   |                 @ /rustc/4fd4797c2654977f545c9a91e2aa4e6cdbb38919/library/core/src/sync/atomic.rs:2691:26
    |      0x240084b0 0x080919c0 main
-   |                 @ /hubris/task/hiffy/src/main.rs:139
+   |                 @ /hubris/task/hiffy/src/main.rs:156:9
    |
    |
    +--->   R0 = 0x08095a90   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240082dc
@@ -592,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+5) vcore
    |
    +--->  0x24048690 0x0807d606 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24048a28 0x08079d3e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24048a28 0x08079d3e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24048a28 0x08079d4e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24048a28 0x08079d4e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24048a28 0x08079d4e main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:145
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:155:17
    |
    |
    +--->   R0 = 0x2404873e   R1 = 0x00000001   R2 = 0x00000003   R3 = 0x24048740
@@ -650,7 +657,7 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x2405ac98 0x080684b4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2405ae40 0x08066cf6 main
    |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
    |
@@ -704,13 +711,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24055520 0x08064822 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24055800 0x08063308 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24055800 0x08063308 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24055800 0x08063316 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24055800 0x08063316 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24055800 0x08063316 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x24055540   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240557d4
@@ -762,13 +769,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x240549a0 0x08077464 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24054bb8 0x0807524e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24054bb8 0x0807524e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24054bb8 0x0807525e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24054bb8 0x0807525e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24054bb8 0x0807525e main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240549e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24054b78
@@ -820,13 +827,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24053378 0x08034e9a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24053800 0x080334d4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24053800 0x080334d4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24053800 0x080334e2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24053800 0x080334e2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24053800 0x080334e2 main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:543
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:568:9
    |
    |
    +--->   R0 = 0x240533d4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240533d8
@@ -878,13 +885,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv
    |
    +--->  0x24050380 0x0808cd5c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24050400 0x0808b2e4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24050400 0x0808b2e4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24050400 0x0808b2f2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24050400 0x0808b2f2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24050400 0x0808b2f2 main
-   |                 @ /hubris/task/sensor/src/main.rs:253
+   |                 @ /hubris/task/sensor/src/main.rs:289:9
    |
    |
    +--->   R0 = 0x240503b4   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x240503d0
@@ -936,13 +943,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
    |
    +--->  0x240211d0 0x080420b6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x240213d8 0x0803f010 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x240213d8 0x0803f010 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x240213d8 0x0803f020 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x240213d8 0x0803f020 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x240213d8 0x0803f020 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:156
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:166:9
    |
    |
    +--->   R0 = 0x240212c0   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x240212f8
@@ -994,7 +1001,7 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x2404eee8 0x08032b70 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2404f000 0x080315a8 main
    |                 @ /hubris/task/udpecho/src/main.rs:14
    |
@@ -1048,15 +1055,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+59)
    |
    +--->  0x240576e8 0x0808a7f2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x24057800 0x08089218 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1108
-   |      0x24057800 0x08089208 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:425
-   |      0x24057800 0x08089208 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:459
+   |                 @ /hubris/sys/userlib/src/lib.rs:1113:9
+   |      0x24057800 0x08089218 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:441:12
+   |      0x24057800 0x08089218 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:472:5
    |      0x24057800 0x08089218 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x0808af6c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24057790
@@ -1108,13 +1115,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24030988 0x08029994 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24031000 0x08020568 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24031000 0x08020568 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24031000 0x08020578 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24031000 0x08020578 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24031000 0x08020578 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:217
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:223:9
    |
    |
    +--->   R0 = 0x24030c68   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24030ec8
@@ -1166,13 +1173,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x2403bf78 0x0804e35c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2403c000 0x080467aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2403c000 0x080467aa idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2403c000 0x080467ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2403c000 0x080467ba idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2403c000 0x080467ba main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:169
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:194:9
    |
    |
    +--->   R0 = 0x2403bf88   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2403bfe0
@@ -1224,13 +1231,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240523b8 0x080396f4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x240523e8 0x08037bf2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x240523e8 0x08037bf2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x240523e8 0x08037c02 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x240523e8 0x08037c02 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x240523e8 0x08037c02 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240523bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240523c0
@@ -1282,13 +1289,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2405c638 0x080374e6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405c720 0x0803618c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405c720 0x0803618c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405c720 0x0803619c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405c720 0x0803619c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405c720 0x0803619c main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2405c660   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2405c6b4
@@ -1340,13 +1347,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2405c340 0x080654c6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405c380 0x080651fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405c380 0x080651fc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405c380 0x0806520c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405c380 0x0806520c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405c380 0x0806520c main
-   |                 @ /hubris/drv/user-leds/src/main.rs:179
+   |                 @ /hubris/drv/user-leds/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x2405c350   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2405c358
@@ -1398,13 +1405,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24040550 0x0800f8e0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x24040960 0x0800c7d8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x24040960 0x0800c7d8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x24040960 0x0800c7e8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x24040960 0x0800c7e8 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x24040960 0x0800c7e8 main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x240405e8   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24040618
@@ -1456,13 +1463,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2405ba00 0x08066566 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
-   |      0x2405bb20 0x0806595c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:296
-   |      0x2405bb20 0x0806595c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:228
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
+   |      0x2405bb20 0x0806596c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:323:8
+   |      0x2405bb20 0x0806596c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/52c3758/runtime/src/lib.rs:237:20
    |      0x2405bb20 0x0806596c main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2405ba64   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2405baf8
@@ -1514,7 +1521,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2405c900 0x08037992 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:28:13
    |
    |
    +--->   R0 = 0x2405c900   R1 = 0x2405c900   R2 = 0x00000000   R3 = 0x00000000
@@ -1566,7 +1573,7 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x2404c708 0x080741a8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:368
+   |                 @ /hubris/sys/userlib/src/lib.rs:423:13
    |      0x2404d000 0x080727de main
    |                 @ /hubris/task/udprpc/src/main.rs:43
    |

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.idol-returns-an-enum.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.idol-returns-an-enum.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+65)
    |
    +--->  0x2404b4e0 0x08082ce4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404b600 0x080812a6 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404b600 0x080812a6 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404b600 0x080812b6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404b600 0x080812b6 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x2404b600 0x080812b6 main
-   |                 @ /hubris/task/jefe/src/main.rs:121
+   |                 @ /hubris/task/jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x2404b58c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x2404b5c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+244)
    |
    +--->  0x240109e0 0x0802f2c4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24010bc0 0x080201fc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24010bc0 0x08020210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x24010bc0 0x08020210 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x24011798 0x0802853c main
-   |                 @ /hubris/task/net/src/main.rs:153
+   |                 @ /hubris/task/net/src/main.rs:272:13
    |
    |
    +--->   R0 = 0x240114f8   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010b10
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2404cb48 0x080b6696 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404cb80 0x080b618c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404cb80 0x080b618c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404cb80 0x080b619c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404cb80 0x080b619c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x2404cb80 0x080b619c main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2404cb50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2404cb58
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240442a8 0x080863ec userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24044368 0x0808467a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24044368 0x08084672 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24044368 0x08084692 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24044368 0x08084692 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24044368 0x08084692 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:30
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:39:9
    |
    |
    +--->   R0 = 0x240442f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24044334
@@ -235,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x2404ba38 0x0808a998 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404bb80 0x08088998 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404bb80 0x08088998 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x2404bb80 0x08088998 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x2404bb80 0x08088998 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404bb80 0x080889a8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404bb80 0x080889a8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x2404bb80 0x080889a8 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x2404bb80 0x080889a8 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x2404bb80 0x080889a8 main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:214
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:243:9
    |
    |
    +--->   R0 = 0x2404bb44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404bb58
@@ -297,19 +297,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x24045278 0x0808db4c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24045298 0x0808c7f8 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x240452f0 0x0808c154 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x240452f0 0x0808c154 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240452f0 0x0808c154 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240452f0 0x0808c154 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:796
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:845:17
    |      0x24045380 0x0808cb74 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:262:5
    |
    |
    +--->   R0 = 0x0808e044   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404527c
@@ -361,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042d8 0x080ad53e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x080ac31e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x080ac31e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x080ac32c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x080ac32c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24004380 0x080ac32c main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -419,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+288)
    |
    +--->  0x24002550 0x0800bda6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x08008eec userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x08008eec idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x08008efa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x08008efa idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x24003770 0x08008efa main
-   |                 @ /hubris/task/thermal/src/main.rs:321
+   |                 @ /hubris/task/thermal/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -477,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+363)
    |
    +--->  0x240382e8 0x080646c6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24038598 0x0806025e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24038598 0x0806026c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x24038598 0x0806026c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x240385e0 0x080622d6 main
-   |                 @ /hubris/task/power/src/main.rs:405
+   |                 @ /hubris/task/power/src/main.rs:421:5
    |
    |
    +--->   R0 = 0x240385a4   R1 = 0x00000007   R2 = 0x00000001   R3 = 0x24038468
@@ -535,19 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+161)
    |
    +--->  0x24008228 0x0806cd52 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008270 0x0806cdcc userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008270 0x0806cd92 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008270 0x0806cdcc userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24008270 0x0806cdcc userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24008400 0x08069dde core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x08069dde core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x08069dde main
-   |                 @ /hubris/task/hiffy/src/main.rs:126
+   |                 @ /hubris/task/hiffy/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x0806e5c8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24008234
@@ -599,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer
    |
    +--->  0x2403a448 0x08014f02 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403a640 0x080117cc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403a640 0x080117cc idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403a640 0x080117da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403a640 0x080117da idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x2403a640 0x080117da main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:106
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x2403a5c0   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2403a4c0
@@ -657,13 +657,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x24046540 0x080917b2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24046800 0x080902d4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24046800 0x080902d4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24046800 0x080902e4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24046800 0x080902e4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24046800 0x080902e4 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:36
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:49:9
    |
    |
    +--->   R0 = 0x2404655c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240467d4
@@ -715,13 +715,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x240479a0 0x08096744 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24047bb8 0x08094500 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24047bb8 0x08094500 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24047bb8 0x08094510 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24047bb8 0x08094510 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24047bb8 0x08094510 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:86
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:181:9
    |
    |
    +--->   R0 = 0x240479e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24047b78
@@ -773,13 +773,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x24048378 0x08099bc8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24048800 0x080981bc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24048800 0x080981bc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24048800 0x080981cc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24048800 0x080981cc idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24048800 0x080981cc main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:553
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:563:9
    |
    |
    +--->   R0 = 0x240483cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240483d0
@@ -831,13 +831,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: timer(T+466)
    |
    +--->  0x2403c378 0x080af134 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403c400 0x080ae19e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403c400 0x080ae19e idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403c400 0x080ae1ae userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403c400 0x080ae1ae idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x2403c400 0x080ae1ae main
-   |                 @ /hubris/task/sensor/src/main.rs:158
+   |                 @ /hubris/task/sensor/src/main.rs:188:9
    |
    |
    +--->   R0 = 0x2403c3b8   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2403c3d8
@@ -889,13 +889,13 @@ ID TASK                       GEN PRI STATE
 15 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer(T+66) control-plane-agent
    |
    +--->  0x24020628 0x08073b14 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24020800 0x08070cd8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24020800 0x08070cd8 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24020800 0x08070ce8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24020800 0x08070ce8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x24020800 0x08070ce8 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:130
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:140:9
    |
    |
    +--->   R0 = 0x24020710   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020748
@@ -947,13 +947,13 @@ ID TASK                       GEN PRI STATE
 16 udpecho                      0   6 notif: socket
    |
    +--->  0x2403eef0 0x0809db44 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403f000 0x0809c5d0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403f000 0x0809c5d0 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403f000 0x0809c5e0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403f000 0x0809c5e0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2403f000 0x0809c5e0 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x0809e360   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2403efd8
@@ -1005,15 +1005,15 @@ ID TASK                       GEN PRI STATE
 17 udpbroadcast                 0   6 notif: bit31(T+257)
    |
    +--->  0x240496d0 0x080b164c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24049800 0x080b0380 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24049800 0x080b0340 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
-   |      0x24049800 0x080b031a userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24049800 0x080b0380 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24049800 0x080b0380 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24049800 0x080b0380 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x080b1df4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24049790
@@ -1065,13 +1065,13 @@ ID TASK                       GEN PRI STATE
 18 udprpc                       0   6 notif: socket
    |
    +--->  0x24040718 0x080a20fa userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24041000 0x080a07c6 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24041000 0x080a07c6 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24041000 0x080a07d6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24041000 0x080a07d6 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24041000 0x080a07d6 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x080a2aec   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24040f90
@@ -1123,21 +1123,21 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24028950 0x0804e9dc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24028e00 0x08040112 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24028e00 0x08040126 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x24028e00 0x08040126 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x24029000 0x08049ece core::option::Option<T>::as_ref
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/option.rs:629
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/option.rs:630:15
    |      0x24029000 0x08049ece <task_control_plane_agent::update::host_flash::HostFlashUpdate as task_control_plane_agent::update::ComponentUpdater>::is_preparing
-   |                 @ /hubris/task/control-plane-agent/src/update/host_flash.rs:154
+   |                 @ /hubris/task/control-plane-agent/src/update/host_flash.rs:155:15
    |      0x24029000 0x08049ece task_control_plane_agent::mgs_handler::MgsHandler::timer_deadline
-   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:168
+   |                 @ /hubris/task/control-plane-agent/src/mgs_gimlet.rs:174:12
    |      0x24029000 0x08049ece task_control_plane_agent::ServerImpl::timer_deadline
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:181
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:182:9
    |      0x24029000 0x08049ece main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:156
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:161:23
    |
    |
    +--->   R0 = 0x24028fac   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028c18
@@ -1189,13 +1189,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x24033d30 0x0807d9ce userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24034000 0x0807907c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24034000 0x0807907c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24034000 0x0807908c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24034000 0x0807908c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x24034000 0x0807908c main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:165
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x24033d74   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24033e78
@@ -1247,13 +1247,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x2404a3a0 0x080a5f76 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404a3e8 0x080a425a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404a3e8 0x080a425a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404a3e8 0x080a426a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404a3e8 0x080a426a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x2404a3e8 0x080a426a main
-   |                 @ /hubris/task/validate/src/main.rs:85
+   |                 @ /hubris/task/validate/src/main.rs:90:9
    |
    |
    +--->   R0 = 0x2404a3a8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404a3b8
@@ -1305,13 +1305,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   5 recv
    |
    +--->  0x2404ce10 0x080b31f4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404cf20 0x080b207c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404cf20 0x080b207c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404cf20 0x080b208a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404cf20 0x080b208a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x2404cf20 0x080b208a main
-   |                 @ /hubris/task/vpd/src/main.rs:126
+   |                 @ /hubris/task/vpd/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x2404ce44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404ce54
@@ -1363,13 +1363,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv
    |
    +--->  0x2404d348 0x080b6a84 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d380 0x080b68f4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d380 0x080b68f4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d380 0x080b6904 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d380 0x080b6904 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x2404d380 0x080b6904 main
-   |                 @ /hubris/drv/user-leds/src/main.rs:123
+   |                 @ /hubris/drv/user-leds/src/main.rs:130:9
    |
    |
    +--->   R0 = 0x2404d34c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2404d358
@@ -1421,13 +1421,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24042590 0x080aaf7c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24042960 0x080a8b5a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24042960 0x080a8b5a idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:271
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24042960 0x080a8b68 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24042960 0x080a8b68 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:279:20
    |      0x24042960 0x080a8b68 main
-   |                 @ /hubris/task/dump-agent/src/main.rs:253
+   |                 @ /hubris/task/dump-agent/src/main.rs:270:13
    |
    |
    +--->   R0 = 0x24042614   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24042728
@@ -1479,13 +1479,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2404c250 0x080b53aa userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404c320 0x080b436c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404c320 0x080b436c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:198
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404c320 0x080b437c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404c320 0x080b437c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f239689/runtime/src/lib.rs:203:20
    |      0x2404c320 0x080b437c main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:144
+   |                 @ /hubris/drv/sbrmi/src/main.rs:153:9
    |
    |
    +--->   R0 = 0x2404c2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2404c2f8
@@ -1537,7 +1537,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2404d500 0x080b6c52 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2404d500   R1 = 0x2404d500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.igor.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.igor.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+82)
    |
    +--->  0x2402b528 0x0808967e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402b600 0x080882dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402b600 0x080882dc idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402b600 0x080882ea userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402b600 0x080882ea idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:269:20
    |      0x2402b600 0x080882ea main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2402b598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x2402b5bc
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: bit0(irq61) bit2(T+174)
    |
    +--->  0x240087b0 0x08030ccc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24009220 0x0802648e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24009220 0x08026488 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24009220 0x080264a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24009220 0x080264a0 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:269:20
    |      0x24009220 0x080264a0 main
-   |                 @ /hubris/task/net/src/main.rs:125
+   |                 @ /hubris/task/net/src/main.rs:248:13
    |
    |
    +--->   R0 = 0x24008fe8   R1 = 0x00000020   R2 = 0x00000005   R3 = 0x24008e30
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2402db30 0x080926dc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402db80 0x080921a2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402db80 0x080921a2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402db80 0x080921b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402db80 0x080921b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402db80 0x080921b0 main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2402db68   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2402db40
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x2402bb08 0x08061ffa userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402bb68 0x080605c4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402bb68 0x080605c4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402bb68 0x080605de userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402bb68 0x080605de idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402bb68 0x080605de main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2402bb1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2402bb1c
@@ -235,13 +235,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x2402c300 0x0806612e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402c368 0x08064590 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402c368 0x08064590 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402c368 0x080645aa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402c368 0x080645aa idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402c368 0x080645aa main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2402c31a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2402c31c
@@ -293,21 +293,21 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 notif: bit3(irq95/irq96)
    |
    +--->  0x2402ca30 0x0806a7f4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x2402ca50 0x08068064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248
-   |      0x2402cb80 0x08068a9a drv_stm32xx_i2c::I2cController::write_read
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:478
-   |      0x2402cb80 0x08068a9a drv_stm32xx_i2c_server::main::{{closure}}
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229
-   |      0x2402cb80 0x08068a9a userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /hubris/sys/userlib/src/hl.rs:125
-   |      0x2402cb80 0x080687ec userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x2402cb80 0x080687ec userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248:5
+   |      0x2402cb80 0x08068b4a drv_stm32xx_i2c::I2cController::write_read
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:530:21
+   |      0x2402cb80 0x08068b4a drv_stm32xx_i2c_server::main::{{closure}}
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:289:23
+   |      0x2402cb80 0x08068b4a userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:47
+   |      0x2402cb80 0x08068b4a userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:103:25
+   |      0x2402cb80 0x08068b4a userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x2402cb80 0x08068b4a main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:200
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229:9
    |
    |
    +--->   R0 = 0x0806ae58   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x2402ca34
@@ -359,19 +359,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x240042a0 0x0806e5d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x240042c0 0x0806c81c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248:5
    |      0x240042f0 0x0806c112 core::ptr::read_volatile
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1468
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1472:9
    |      0x240042f0 0x0806c112 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240042f0 0x0806c112 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240042f0 0x0806c112 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:774
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:823:17
    |      0x24004380 0x0806d046 main
-   |                 @ /hubris/task/spd/src/main.rs:203
+   |                 @ /hubris/task/spd/src/main.rs:420:5
    |
    |
    +--->   R0 = 0x0806ed50   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x240042a4
@@ -423,25 +423,25 @@ ID TASK                       GEN PRI STATE
  7 thermal                      2   5 wait: reply from i2c_driver/gen0
    |
    +--->  0x24002670 0x0800b47e userlib::sys_send_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:156
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:13
    |      0x240026c8 0x0800af22 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:290
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:310:12
    |      0x24002738 0x08008852 <core::result::Result<T,E> as core::ops::try_trait::Try>::branch
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/result.rs:2117
-   |      0x24002738 0x08008840 drv_i2c_devices::max31790::Max31790::fan_rpm
-   |                 @ /hubris/drv/i2c-devices/src/max31790.rs:283
-   |      0x24002738 0x08008840 task_thermal::control::FanControl::fan_rpm
-   |                 @ /hubris/task/thermal/src/control.rs:178
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/result.rs:2118:15
+   |      0x24002738 0x08008852 drv_i2c_devices::max31790::Max31790::fan_rpm
+   |                 @ /hubris/drv/i2c-devices/src/max31790.rs:284:19
+   |      0x24002738 0x08008852 task_thermal::control::FanControl::fan_rpm
+   |                 @ /hubris/task/thermal/src/control.rs:180:39
    |      0x24002738 0x08008852 task_thermal::control::ThermalControl::read_sensors
-   |                 @ /hubris/task/thermal/src/control.rs:529
-   |      0x24003198 0x08009190 task_thermal::control::ThermalControl::run_control
-   |                 @ /hubris/task/thermal/src/control.rs:633
-   |      0x24003198 0x08009160 <task_thermal::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
-   |                 @ /hubris/task/thermal/src/main.rs:245
-   |      0x24003198 0x080090e6 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/task/thermal/src/control.rs:533:23
+   |      0x24003198 0x0800919a task_thermal::control::ThermalControl::run_control
+   |                 @ /hubris/task/thermal/src/control.rs:636:36
+   |      0x24003198 0x0800919a <task_thermal::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/thermal/src/main.rs:256:37
+   |      0x24003198 0x0800919a idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:278:9
    |      0x24003198 0x0800919a main
-   |                 @ /hubris/task/thermal/src/main.rs:277
+   |                 @ /hubris/task/thermal/src/main.rs:303:9
    |
    |
    +--->   R0 = 0x2400269c   R1 = 0x24002674   R2 = 0x24002671   R3 = 0x00000000
@@ -493,15 +493,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 wait: send to i2c_driver/gen0
    |
    +--->  0x24024330 0x08052d2e userlib::sys_send_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:156
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:13
    |      0x24024388 0x08051ef2 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:290
-   |      0x240243e8 0x08050352 <drv_i2c_devices::bmr491::Bmr491 as drv_i2c_devices::TempSensor<drv_i2c_devices::bmr491::Error>>::read_temperature
-   |                 @ /hubris/drv/i2c-devices/src/bmr491.rs:78
-   |      0x240243e8 0x08050352 task_power::Device::read_temperature
-   |                 @ /hubris/task/power/src/main.rs:76
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:310:12
+   |      0x240243e8 0x08050360 <drv_i2c_devices::bmr491::Bmr491 as drv_i2c_devices::TempSensor<drv_i2c_devices::bmr491::Error>>::read_temperature
+   |                 @ /hubris/drv/i2c-devices/src/bmr491.rs:79:20
+   |      0x240243e8 0x08050360 task_power::Device::read_temperature
+   |                 @ /hubris/task/power/src/main.rs:78:36
    |      0x240243e8 0x08050360 main
-   |                 @ /hubris/task/power/src/main.rs:380
+   |                 @ /hubris/task/power/src/main.rs:407:23
    |
    |
    +--->   R0 = 0x2402435c   R1 = 0x24024334   R2 = 0x24024331   R3 = 0x00000000
@@ -553,19 +553,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+84)
    |
    +--->  0x240101f8 0x0805c3ee userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24010240 0x0805c466 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x24010240 0x0805c42e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x24010240 0x0805c466 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24010240 0x0805c466 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24010400 0x08059846 core::sync::atomic::atomic_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3049
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3057:23
    |      0x24010400 0x08059846 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2397
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2399:26
    |      0x24010400 0x08059846 main
-   |                 @ /hubris/task/hiffy/src/main.rs:122
+   |                 @ /hubris/task/hiffy/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x0805d610   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24010204
@@ -617,13 +617,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0(T+5)
    |
    +--->  0x240254d8 0x08013e3e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24025640 0x08010a8c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24025640 0x08010a8c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24025640 0x08010a9c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24025640 0x08010a9c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:269:20
    |      0x24025640 0x08010a9c main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:66
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:345:9
    |
    |
    +--->   R0 = 0x24025507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x24025520
@@ -675,13 +675,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x24026530 0x080719b2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24026800 0x08070250 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24026800 0x08070250 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24026800 0x08070260 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24026800 0x08070260 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x24026800 0x08070260 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x24026550   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240267d4
@@ -733,13 +733,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x2402d5c8 0x080760c4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402d780 0x08074378 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402d780 0x08074378 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402d780 0x08074386 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402d780 0x08074386 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402d780 0x08074386 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:78
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x2402d610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2402d730
@@ -791,13 +791,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x240273b8 0x0807962c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24027800 0x0807819a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24027800 0x0807819a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24027800 0x080781a8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24027800 0x080781a8 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x24027800 0x080781a8 main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:394
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:404:9
    |
    |
    +--->   R0 = 0x240273dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240273e0
@@ -849,13 +849,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: bit0(T+482)
    |
    +--->  0x24028660 0x0808b10a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24028ed8 0x0808a0ae userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24028ed8 0x0808a0ae idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24028ed8 0x0808a0bc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24028ed8 0x0808a0bc idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:269:20
    |      0x24028ed8 0x0808a0bc main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x24028ec0   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x24028a98
@@ -907,13 +907,13 @@ ID TASK                       GEN PRI STATE
 15 host_sp_comms                0   5 recv, notif: bit0(irq82) bit1 bit2
    |
    +--->  0x240186a8 0x0807eb68 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24018800 0x0807c9ba userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24018800 0x0807c9ba idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24018800 0x0807c9c8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24018800 0x0807c9c8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:269:20
    |      0x24018800 0x0807c9c8 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:94
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:104:9
    |
    |
    +--->   R0 = 0x24018778   R1 = 0x00000008   R2 = 0x00000007   R3 = 0x24018780
@@ -965,13 +965,13 @@ ID TASK                       GEN PRI STATE
 16 udpecho                      0   6 notif: bit0
    |
    +--->  0x24020e00 0x0808d7bc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x24021000 0x0808c15a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x24021000 0x0808c15a userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:263
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x24021000 0x0808c16c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x24021000 0x0808c16c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:268:5
    |      0x24021000 0x0808c16c main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x0808de28   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24020f9c
@@ -1023,13 +1023,15 @@ ID TASK                       GEN PRI STATE
 17 udpbroadcast                 0   6 notif: bit31(T+33)
    |
    +--->  0x24029758 0x0808f6b0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24029800 0x0808e182 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x24029800 0x0808e146 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x24029800 0x0808e182 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24029800 0x0808e182 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24029800 0x0808e182 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:49:9
    |
    |
    +--->   R0 = 0x0808fce8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240297ac
@@ -1081,11 +1083,11 @@ ID TASK                       GEN PRI STATE
 18 udprpc                       0   6 notif: bit0
    |
    +--->  0x24022630 0x08081e36 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x24023000 0x08080538 task_net_api::Net::recv_packet
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/task-net-api-93a5fca30cf2b9fd/out/client_stub.rs:37
+   |                 @ /build/task-net-api-93a5fca30cf2b9fd/out/client_stub.rs:81:20
    |      0x24023000 0x08080538 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:68:15
    |
    |
    +--->   R0 = 0x080825f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24022fbc
@@ -1137,13 +1139,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 notif: bit0 bit1(irq37) bit2
    |
    +--->  0x2401c3e8 0x08047402 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2401c800 0x08043cea userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2401c800 0x08043cea userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:263
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2401c800 0x08043cfa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2401c800 0x08043cfa userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:268:5
    |      0x2401c800 0x08043cfa main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:109
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:116:20
    |
    |
    +--->   R0 = 0x08049d38   R1 = 0x00000000   R2 = 0x00000007   R3 = 0x2401c618
@@ -1195,13 +1197,13 @@ ID TASK                       GEN PRI STATE
 20 validate                     0   5 recv
    |
    +--->  0x2402a3b0 0x08085ed8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402a3e8 0x08084260 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402a3e8 0x08084260 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402a3e8 0x08084270 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402a3e8 0x08084270 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402a3e8 0x08084270 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x2402a3b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2402a3b8
@@ -1253,13 +1255,13 @@ ID TASK                       GEN PRI STATE
 21 vpd                          0   4 recv
    |
    +--->  0x2402de08 0x080916a6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2402df20 0x0809007c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2402df20 0x0809007c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2402df20 0x0809008a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2402df20 0x0809008a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4f32654/runtime/src/lib.rs:193:20
    |      0x2402df20 0x0809008a main
-   |                 @ /hubris/task/vpd/src/main.rs:115
+   |                 @ /hubris/task/vpd/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x2402de40   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2402de50
@@ -1311,7 +1313,7 @@ ID TASK                       GEN PRI STATE
 22 idle                         0   7 RUNNING
    |
    +--->  0x2402e100 0x08092852 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2402e100   R1 = 0x2402e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.in_bootloader.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+12)
    |
    +--->  0x2001b530 0x0806561c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001b600 0x080642dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001b600 0x080642dc idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:259
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001b600 0x080642ea userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001b600 0x080642ea idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:267:20
    |      0x2001b600 0x080642ea main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2001b598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x2001b5dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: bit0(irq61) bit1(T+18)
    |
    +--->  0x20004b58 0x08030666 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x20005220 0x08025db6 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x20005220 0x08025db2 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:259
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x20005220 0x08025dc8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x20005220 0x08025dc8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:267:20
    |      0x20005220 0x08025dc8 main
-   |                 @ /hubris/task/net/src/main.rs:104
+   |                 @ /hubris/task/net/src/main.rs:184:13
    |
    |
    +--->   R0 = 0x20004fb0   R1 = 0x00000020   R2 = 0x00000003   R3 = 0x200050f8
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2001e330 0x0806c6dc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001e380 0x0806c1a2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001e380 0x0806c1a2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001e380 0x0806c1b0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001e380 0x0806c1b0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x2001e380 0x0806c1b0 main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:77
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:140:9
    |
    |
    +--->   R0 = 0x2001e368   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2001e340
@@ -189,13 +189,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x2001bb08 0x08041ff2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001bb68 0x080405c4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001bb68 0x080405c4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001bb68 0x080405de userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001bb68 0x080405de idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x2001bb68 0x080405de main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2001bb1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2001bb1c
@@ -251,13 +251,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x2001c300 0x08046126 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001c368 0x08044590 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001c368 0x08044590 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001c368 0x080445aa userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001c368 0x080445aa idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x2001c368 0x080445aa main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2001c31a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2001c31c
@@ -313,17 +313,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 recv
    |
    +--->  0x2001ca48 0x0804a5ca userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001cb80 0x0804866c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001cb80 0x0804866c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:238
-   |      0x2001cb80 0x0804866c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x2001cb80 0x0804866c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:119
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001cb80 0x0804867c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001cb80 0x0804867c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:242:11
+   |      0x2001cb80 0x0804867c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x2001cb80 0x0804867c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:126:5
    |      0x2001cb80 0x0804867c main
-   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:146
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:175:9
    |
    |
    +--->   R0 = 0x2001cb44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2001cb58
@@ -379,19 +379,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20010258 0x0804e610 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x20010278 0x0804c814 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ops/function.rs:248:5
    |      0x200102a8 0x0804c112 core::ptr::read_volatile
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1468
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/ptr/mod.rs:1472:9
    |      0x200102a8 0x0804c112 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x200102a8 0x0804c112 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x200102a8 0x0804c112 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:791:17
    |      0x20010380 0x0804d03a main
-   |                 @ /hubris/task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:407:5
    |
    |
    +--->   R0 = 0x0804eda8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2001025c
@@ -447,13 +447,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: bit0(T+879)
    |
    +--->  0x200025b8 0x0805279c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x20003198 0x08050dd8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x20003198 0x08050dd8 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:259
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x20003198 0x08050de6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x20003198 0x08050de6 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:267:20
    |      0x20003198 0x08050de6 main
-   |                 @ /hubris/task/thermal/src/main.rs:221
+   |                 @ /hubris/task/thermal/src/main.rs:244:9
    |
    |
    +--->   R0 = 0x20003000   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20003080
@@ -509,15 +509,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 notif: bit31(T+174)
    |
    +--->  0x200163c0 0x08056844 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x20016800 0x080543fa userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x20016800 0x080543d4 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
-   |      0x20016800 0x080543a8 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:625
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x20016800 0x080543fa userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
+   |      0x20016800 0x080543fa userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x20016800 0x080543fa main
-   |                 @ /hubris/task/power/src/main.rs:305
+   |                 @ /hubris/task/power/src/main.rs:311:9
    |
    |
    +--->   R0 = 0x080571a8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200167d8
@@ -573,19 +573,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+143)
    |
    +--->  0x20008200 0x0800bfd0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x20008240 0x0800c04a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x20008240 0x0800c024 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x20008240 0x0800c04a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
    |      0x20008240 0x0800c04a userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:625
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x20008400 0x08009432 core::sync::atomic::atomic_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3049
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:3057:23
    |      0x20008400 0x08009432 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2397
+   |                 @ /rustc/4d6d601c8a83284d6b23c253a3e2a060fd197316/library/core/src/sync/atomic.rs:2399:26
    |      0x20008400 0x08009432 main
-   |                 @ /hubris/task/hiffy/src/main.rs:110
+   |                 @ /hubris/task/hiffy/src/main.rs:127:9
    |
    |
    +--->   R0 = 0x0800d0d0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008208
@@ -641,13 +641,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x200174d8 0x08013de0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x20017640 0x08010a88 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x20017640 0x08010a88 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:259
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x20017640 0x08010a98 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x20017640 0x08010a98 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:267:20
    |      0x20017640 0x08010a98 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:64
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:343:9
    |
    |
    +--->   R0 = 0x20017507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x20017520
@@ -703,13 +703,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x20018530 0x08059994 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x20018800 0x08058250 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x20018800 0x08058250 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x20018800 0x08058260 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x20018800 0x08058260 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x20018800 0x08058260 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x20018550   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200187d4
@@ -765,13 +765,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x2001d5d8 0x0805df82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001d780 0x0805c366 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001d780 0x0805c366 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001d780 0x0805c374 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001d780 0x0805c374 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x2001d780 0x0805c374 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:145:9
    |
    |
    +--->   R0 = 0x2001d610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2001d730
@@ -827,13 +827,13 @@ ID TASK                       GEN PRI STATE
 13 sensor                       0   4 recv, notif: bit0(T+12)
    |
    +--->  0x2001da88 0x080670ec userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001df80 0x080660ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001df80 0x080660ac idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:259
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001df80 0x080660ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001df80 0x080660ba idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:267:20
    |      0x2001df80 0x080660ba main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x2001df68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x2001dd00
@@ -889,13 +889,13 @@ ID TASK                       GEN PRI STATE
 14 udpecho                      0   6 notif: bit0
    |
    +--->  0x20014e00 0x080697a0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x20015000 0x0806815a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x20015000 0x0806815a userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:263
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x20015000 0x0806816c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x20015000 0x0806816c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:268:5
    |      0x20015000 0x0806816c main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x08069e0c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20014f9c
@@ -951,13 +951,15 @@ ID TASK                       GEN PRI STATE
 15 udpbroadcast                 0   6 notif: bit31(T+454)
    |
    +--->  0x20019770 0x0806b20c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
    |      0x20019800 0x0806a0f8 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1057
-   |      0x20019800 0x0806a0d2 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:600
+   |                 @ /hubris/sys/userlib/src/lib.rs:1062:9
+   |      0x20019800 0x0806a0f8 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:615:12
+   |      0x20019800 0x0806a0f8 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:637:5
    |      0x20019800 0x0806a0f8 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:14
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:38:9
    |
    |
    +--->   R0 = 0x0806b784   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200197ac
@@ -1013,13 +1015,13 @@ ID TASK                       GEN PRI STATE
 16 validate                     0   5 recv
    |
    +--->  0x2001a3b0 0x08061a78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:334
-   |      0x2001a3e8 0x08060260 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:282
-   |      0x2001a3e8 0x08060260 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:186
+   |                 @ /hubris/sys/userlib/src/lib.rs:389:13
+   |      0x2001a3e8 0x08060270 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:308:8
+   |      0x2001a3e8 0x08060270 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/285d928/runtime/src/lib.rs:191:20
    |      0x2001a3e8 0x08060270 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x2001a3b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2001a3b8
@@ -1075,11 +1077,11 @@ ID TASK                       GEN PRI STATE
 17 idle                         0   7 RUNNING
    |
    +--->  0x2001e500 0x0806c850 cortex_m::asm::inline::__nop
-   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:118
+   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:122:5
    |      0x2001e500 0x0806c850 cortex_m::asm::nop
-   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:34
+   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:35:5
    |      0x2001e500 0x0806c850 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:24:13
    |
    |
    +--->   R0 = 0x2001e500   R1 = 0x2001e500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.inheritance.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.inheritance.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+14)
    |
    +--->  0x20000ab8 0x08003ba0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x20000b60 0x080031f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x20000b60 0x080031f0 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:342:13
+   |      0x20000b60 0x08003204 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x20000b60 0x08003204 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x20000b60 0x08003204 main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x20000b00   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x20000b38
@@ -45,11 +45,11 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 RUNNING
    |
    +--->  0x20000840 0x08002f40 cortex_m::asm::inline::__wfi
-   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:190
+   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:191:5
    |      0x20000840 0x08002f40 cortex_m::asm::wfi
-   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:54
+   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:55:5
    |      0x20000840 0x08002f40 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:28:13
    |
    |
    +--->   R0 = 0x20000840   R1 = 0x20000840   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ipc-counts.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ipc-counts.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: fault timer(T+100)
    |
    +--->  0x24059518 0x08059f78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24059600 0x0805900a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24059600 0x0805900a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24059600 0x0805901a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24059600 0x0805901a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24059600 0x0805901a main
-   |                 @ /hubris/task/jefe/src/main.rs:57
+   |                 @ /hubris/task/jefe/src/main.rs:80:9
    |
    |
    +--->   R0 = 0x2405958c   R1 = 0x0000000c   R2 = 0x00000003   R3 = 0x240595c8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 recv, notif: eth-irq(irq61) wake-timer(T+285)
    |
    +--->  0x240107e8 0x0802acd4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240109c8 0x0801c4f0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240109c8 0x0801c504 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
    |      0x240109c8 0x0801c504 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24011798 0x080244e8 main
-   |                 @ /hubris/task/net/src/main.rs:158
+   |                 @ /hubris/task/net/src/main.rs:261:13
    |
    |
    +--->   R0 = 0x240114e0   R1 = 0x0000001a   R2 = 0x00000005   R3 = 0x24010918
@@ -119,11 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x24059b48 0x0806c622 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24059b80 0x0806c190 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24059b80 0x0806c19e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24059b80 0x0806c19e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24059b80 0x0806c19e main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24059b50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x24059b58
@@ -175,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   3 recv
    |
    +--->  0x240552a8 0x08052384 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24055368 0x080506ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24055368 0x080506a4 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24055368 0x080506c4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24055368 0x080506c4 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24055368 0x080506c4 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:31
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x240552f6   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24055334
@@ -233,17 +235,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   3 recv
    |
    +--->  0x24056220 0x0801a8ac userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24056380 0x0801896e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24056380 0x0801896e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x24056380 0x0801896e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x24056380 0x0801896e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:123
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24056380 0x0801897e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24056380 0x0801897e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x24056380 0x0801897e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x24056380 0x0801897e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:130:5
    |      0x24056380 0x0801897e main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:322
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:358:9
    |
    |
    +--->   R0 = 0x24056344   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24056358
@@ -295,19 +297,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: i2c1-irq(irq31/irq32)
    |
    +--->  0x24057280 0x0806b4d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x240572a0 0x0806a13c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x240572f0 0x08069bd8 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x240572f0 0x08069bd8 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240572f0 0x08069bd8 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240572f0 0x08069bd8 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:847
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:896:17
    |      0x24057380 0x0806a3b0 main
-   |                 @ /hubris/task/spd/src/main.rs:81
+   |                 @ /hubris/task/spd/src/main.rs:261:5
    |
    |
    +--->   R0 = 0x0806b984   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24057284
@@ -359,13 +361,13 @@ ID TASK                       GEN PRI STATE
  6 packrat                      0   1 recv
    |
    +--->  0x240042e0 0x08068e04 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24004380 0x08067b12 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24004380 0x08067b12 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24004380 0x08067b20 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24004380 0x08067b20 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24004380 0x08067b20 main
-   |                 @ /hubris/task/packrat/src/main.rs:86
+   |                 @ /hubris/task/packrat/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x240042f8   R1 = 0x0000001a   R2 = 0x00000000   R3 = 0x24004350
@@ -417,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: timer(T+834)
    |
    +--->  0x240024b8 0x080345c2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24003770 0x0803118e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24003770 0x0803118e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24003770 0x080311a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24003770 0x080311a0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24003770 0x080311a0 main
-   |                 @ /hubris/task/thermal/src/main.rs:342
+   |                 @ /hubris/task/thermal/src/main.rs:379:9
    |
    |
    +--->   R0 = 0x24002be0   R1 = 0x00000014   R2 = 0x00000001   R3 = 0x24002c00
@@ -475,13 +477,13 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 recv, notif: timer(T+94)
    |
    +--->  0x24044240 0x0806169e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240449c8 0x0805b486 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240449c8 0x0805b486 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240449c8 0x0805b496 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240449c8 0x0805b496 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x240449c8 0x0805b496 main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +--->   R0 = 0x240445f0   R1 = 0x00000027   R2 = 0x00000001   R3 = 0x24044618
@@ -533,19 +535,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+100)
    |
    +--->  0x24008230 0x0803c410 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24008278 0x0803c48e userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24008278 0x0803c454 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24008278 0x0803c48e userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
    |      0x24008278 0x0803c48e userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24008400 0x080397f2 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24008400 0x080397f2 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24008400 0x080397f2 main
-   |                 @ /hubris/task/hiffy/src/main.rs:130
+   |                 @ /hubris/task/hiffy/src/main.rs:147:9
    |
    |
    +--->   R0 = 0x0803d938   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2400823c
@@ -597,13 +599,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: timer(T+90)
    |
    +--->  0x2404a428 0x0800cfd2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404a640 0x08009c46 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404a640 0x08009c46 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404a640 0x08009c54 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404a640 0x08009c54 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2404a640 0x08009c54 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:127
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:137:17
    |
    |
    +--->   R0 = 0x2404a614   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2404a4c0
@@ -655,13 +657,13 @@ ID TASK                       GEN PRI STATE
 11 gimlet_inspector             0   6 notif: socket
    |
    +--->  0x240544d8 0x0804272c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24054640 0x08040baa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24054640 0x08040baa userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24054640 0x08040bba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24054640 0x08040bba userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24054640 0x08040bba main
-   |                 @ /hubris/task/gimlet-inspector/src/main.rs:35
+   |                 @ /hubris/task/gimlet-inspector/src/main.rs:139:17
    |
    |
    +--->   R0 = 0x08042fe0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x240545cc
@@ -713,13 +715,13 @@ ID TASK                       GEN PRI STATE
 12 hash_driver                  0   2 recv
    |
    +--->  0x24053540 0x08071616 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24053800 0x080700f8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24053800 0x080700f8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24053800 0x08070108 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24053800 0x08070108 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24053800 0x08070108 main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:38
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:51:9
    |
    |
    +--->   R0 = 0x2405355c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240537d4
@@ -771,13 +773,13 @@ ID TASK                       GEN PRI STATE
 13 hf                           0   3 recv
    |
    +--->  0x24052998 0x080668fc userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24052bb8 0x08064548 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24052bb8 0x08064548 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24052bb8 0x08064558 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24052bb8 0x08064558 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24052bb8 0x08064558 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:90
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:185:9
    |
    |
    +--->   R0 = 0x240529e8   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24052b78
@@ -829,13 +831,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x24051378 0x080449d0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24051800 0x0804319c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24051800 0x0804319c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24051800 0x080431ac userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24051800 0x080431ac idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24051800 0x080431ac main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:524
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:534:9
    |
    |
    +--->   R0 = 0x240513cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240513d0
@@ -887,13 +889,13 @@ ID TASK                       GEN PRI STATE
 15 sensor                       0   4 recv, notif: timer(T+7)
    |
    +--->  0x2404e350 0x0806e070 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404e400 0x0806cb62 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404e400 0x0806cb62 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404e400 0x0806cb70 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404e400 0x0806cb70 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2404e400 0x0806cb70 main
-   |                 @ /hubris/task/sensor/src/main.rs:284
+   |                 @ /hubris/task/sensor/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x2404e3ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2404e3d8
@@ -945,13 +947,13 @@ ID TASK                       GEN PRI STATE
 16 host_sp_comms                0   7 recv, notif: jefe-state-change usart-irq(irq82) multitimer control-plane-agent
    |
    +--->  0x24020e18 0x0804e072 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24021000 0x08049f44 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24021000 0x08049f44 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24021000 0x08049f54 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24021000 0x08049f54 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24021000 0x08049f54 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:151
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x24020f10   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020f48
@@ -1003,13 +1005,13 @@ ID TASK                       GEN PRI STATE
 17 udpecho                      0   6 notif: socket
    |
    +--->  0x2404cef0 0x08073d78 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2404d000 0x08072160 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2404d000 0x08072160 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2404d000 0x08072172 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2404d000 0x08072172 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x2404d000 0x08072172 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:59:17
    |
    |
    +--->   R0 = 0x080745a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2404cfd8
@@ -1061,15 +1063,15 @@ ID TASK                       GEN PRI STATE
 18 udpbroadcast                 0   6 notif: bit31(T+167)
    |
    +--->  0x240586d8 0x080767de userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x24058800 0x080752b4 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1055
-   |      0x24058800 0x08075278 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:426
-   |      0x24058800 0x08075250 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:456
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x24058800 0x080752b4 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:442:12
+   |      0x24058800 0x080752b4 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:473:5
    |      0x24058800 0x080752b4 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:55
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:105:9
    |
    |
    +--->   R0 = 0x08076f54   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24058790
@@ -1121,13 +1123,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: usart-irq(irq37) socket timer
    |
    +--->  0x24030c40 0x08089d3c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24031000 0x08082374 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24031000 0x08082374 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24031000 0x08082384 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24031000 0x08082384 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24031000 0x08082384 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:214
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:220:9
    |
    |
    +--->   R0 = 0x24030e70   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24030ed8
@@ -1179,13 +1181,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x2403bf68 0x08097da0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2403c000 0x0809155c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2403c000 0x0809155c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2403c000 0x0809156c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2403c000 0x0809156c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2403c000 0x0809156c main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:173
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:195:9
    |
    |
    +--->   R0 = 0x2403bf78   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2403bfe4
@@ -1237,13 +1239,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240503b0 0x0803fd96 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x240503e8 0x0803e210 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x240503e8 0x0803e210 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x240503e8 0x0803e220 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x240503e8 0x0803e220 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x240503e8 0x0803e220 main
-   |                 @ /hubris/task/validate/src/main.rs:68
+   |                 @ /hubris/task/validate/src/main.rs:73:9
    |
    |
    +--->   R0 = 0x240503b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240503b8
@@ -1295,13 +1297,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2405ae18 0x0803757c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2405af20 0x08036174 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2405af20 0x08036174 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2405af20 0x08036184 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2405af20 0x08036184 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2405af20 0x08036184 main
-   |                 @ /hubris/task/vpd/src/main.rs:217
+   |                 @ /hubris/task/vpd/src/main.rs:222:9
    |
    |
    +--->   R0 = 0x2405ae50   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2405ae54
@@ -1353,13 +1355,13 @@ ID TASK                       GEN PRI STATE
 23 user_leds                    0   2 recv, notif: timer
    |
    +--->  0x2405ab40 0x0805aa42 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2405ab80 0x0805a70a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2405ab80 0x0805a70a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2405ab80 0x0805a71a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2405ab80 0x0805a71a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2405ab80 0x0805a71a main
-   |                 @ /hubris/drv/user-leds/src/main.rs:185
+   |                 @ /hubris/drv/user-leds/src/main.rs:204:9
    |
    |
    +--->   R0 = 0x2405ab50   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x2405ab58
@@ -1411,13 +1413,13 @@ ID TASK                       GEN PRI STATE
 24 dump_agent                   0   6 recv, notif: socket
    |
    +--->  0x24040598 0x08056f60 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24040960 0x080540d2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24040960 0x080540d2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24040960 0x080540e2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24040960 0x080540e2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x24040960 0x080540e2 main
-   |                 @ /hubris/task/dump-agent/src/main.rs:285
+   |                 @ /hubris/task/dump-agent/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x24040620   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x24040730
@@ -1469,13 +1471,13 @@ ID TASK                       GEN PRI STATE
 25 sbrmi                        0   4 recv
    |
    +--->  0x2405a250 0x0806f94a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x2405a320 0x0806eb2a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x2405a320 0x0806eb2a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:233
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x2405a320 0x0806eb3a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x2405a320 0x0806eb3a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/dee8a5f/runtime/src/lib.rs:241:20
    |      0x2405a320 0x0806eb3a main
-   |                 @ /hubris/drv/sbrmi/src/main.rs:155
+   |                 @ /hubris/drv/sbrmi/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x2405a2ac   R1 = 0x00000009   R2 = 0x00000000   R3 = 0x2405a2f8
@@ -1527,7 +1529,7 @@ ID TASK                       GEN PRI STATE
 26 idle                         0   8 RUNNING
    |
    +--->  0x2405b100 0x08069572 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2405b100   R1 = 0x2405b100   R2 = 0x00000000   R3 = 0x00000000
@@ -1579,13 +1581,13 @@ ID TASK                       GEN PRI STATE
 27 udprpc                       0   6 notif: socket
    |
    +--->  0x24048710 0x0809c100 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:332
-   |      0x24049000 0x0809a1f4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x24049000 0x0809a1f4 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x24049000 0x0809a206 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x24049000 0x0809a206 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x24049000 0x0809a206 main
-   |                 @ /hubris/task/udprpc/src/main.rs:43
+   |                 @ /hubris/task/udprpc/src/main.rs:185:17
    |
    |
    +--->   R0 = 0x0809caec   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24048f90

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+99)
    |
    +--->  0x20001d38 0x0800754c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20001e00 0x080062b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20001e00 0x080062b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20001e00 0x080062ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20001e00 0x080062ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20001e00 0x080062ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08007bf4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20001ddc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20001750 0x0804a5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20001780 0x0804a090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20001780 0x0804a090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20001780 0x0804a09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20001780 0x0804a09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20001780 0x0804a09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20001758   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001760
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 i2c_driver                   0   2 recv
    |
    +--->  0x200102f0 0x080197e8 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20010380 0x0801841a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20010380 0x0801841a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20010380 0x0801841a userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20010380 0x0801841a userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20010380 0x0801842a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20010380 0x0801842a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x20010380 0x0801842a userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20010380 0x0801842a userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20010380 0x0801842a main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:149
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:178:9
    |
    |
    +--->   R0 = 0x20010354   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20010358
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi_driver                   0   2 recv
    |
    +--->  0x20010af0 0x0801dc30 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20010b70 0x0801c682 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20010b70 0x0801c682 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20010b70 0x0801c69c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20010b70 0x0801c69c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20010b70 0x0801c69c main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20010b0a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20010b0c
@@ -255,13 +255,13 @@ ID TASK                       GEN PRI STATE
  4 net                          0   2 recv, notif: bit0(irq61) bit1
    |
    +--->  0x20002908 0x08029cac userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20002ed8 0x08021af2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20002ed8 0x08021af2 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20002ed8 0x08021b04 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20002ed8 0x08021b04 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:250:20
    |      0x20002ed8 0x08021b04 main
-   |                 @ /hubris//task/net/src/main.rs:99
+   |                 @ /hubris/task/net/src/main.rs:180:13
    |
    |
    +--->   R0 = 0x20002c78   R1 = 0x0000001c   R2 = 0x00000003   R3 = 0x20002d40
@@ -317,13 +317,13 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x20011348 0x0804ab50 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20011380 0x0804a91c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20011380 0x0804a91c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20011380 0x0804a92c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20011380 0x0804a92c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20011380 0x0804a92c main
-   |                 @ /hubris//drv/user-leds/src/main.rs:111
+   |                 @ /hubris/drv/user-leds/src/main.rs:118:9
    |
    |
    +--->   R0 = 0x2001134c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011358
@@ -379,9 +379,9 @@ ID TASK                       GEN PRI STATE
  6 ping                     10301   4 wait: reply from pong/gen0
    |
    +--->  0x20011740 0x08044a90 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:154
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
    |      0x20011780 0x080440c6 main
-   |                 @ /hubris//task/ping/src/main.rs:37
+   |                 @ /hubris/task/ping/src/main.rs:54:12
    |
    |
    +--->   R0 = 0x2001175c   R1 = 0x0000002d   R2 = 0x00000000   R3 = 0x00000000
@@ -437,13 +437,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 RUNNING
    |
    +--->  0x20011b38 0x08005d98 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20011b80 0x08005caa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20011b80 0x08005caa userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20011b80 0x08005cb8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20011b80 0x08005cb8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20011b80 0x08005cb8 main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x20011b44   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20011b58
@@ -499,11 +499,11 @@ ID TASK                       GEN PRI STATE
  8 udpecho                      0   3 notif: bit0
    |
    +--->  0x20004e08 0x0800957e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20005000 0x080087e4 core::result::Result<T,E>::unwrap
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1296
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1297:9
    |      0x20005000 0x080087e4 main
-   |                 @ /hubris//task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:36:17
    |
    |
    +--->   R0 = 0x08009b2c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20004fdc
@@ -559,7 +559,7 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 ready
    |
    +--->  0x20008800 0x08010001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -615,15 +615,15 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   4 notif: bit31(T+22)
    |
    +--->  0x20006608 0x08041b80 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20006648 0x08041bfa userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20006648 0x08041bd4 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20006648 0x08041bfa userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20006648 0x08041bfa userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:647:5
    |      0x20006800 0x080402ba main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:126:9
    |
    |
    +--->   R0 = 0x0804228c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20006610
@@ -679,13 +679,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   3 recv
    |
    +--->  0x20007528 0x080475c2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20007800 0x0804637c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20007800 0x0804637c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20007800 0x0804638c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20007800 0x0804638c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20007800 0x0804638c main
-   |                 @ /hubris//drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x20007540   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200077d4
@@ -741,7 +741,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   6 ready
    |
    +--->  0x20011f00 0x08005a01 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -797,13 +797,13 @@ ID TASK                       GEN PRI STATE
 13 rng_driver                   0   3 recv
    |
    +--->  0x20011cc0 0x08048e7e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20011d00 0x080481dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20011d00 0x080481dc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20011d00 0x080481ea userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20011d00 0x080481ea idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20011d00 0x080481ea main
-   |                 @ /hubris//drv/stm32h7-rng/src/main.rs:136
+   |                 @ /hubris/drv/stm32h7-rng/src/main.rs:144:9
    |
    |
    +--->   R0 = 0x20011cf7   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20011cd8

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kernel-panic.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+73)
    |
    +--->  0x240384f8 0x080a574a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24038600 0x080a4316 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24038600 0x080a4316 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24038600 0x080a4324 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24038600 0x080a4324 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24038600 0x080a4324 main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:148:9
    |
    |
    +--->   R0 = 0x24038598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x240385b8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 RUNNING
    |
    +--->  0x24008cd8 0x080309a2 userlib::sys_panic_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:991
-   |      0x24008d10 0x080309d8 userlib::sys_panic
-   |                 @ /hubris/sys/userlib/src/lib.rs:983
+   |                 @ /hubris/sys/userlib/src/lib.rs:1018:13
+   |      0x24008d10 0x080309dc userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:984:14
    |      0x24008d10 0x080309dc rust_begin_unwind
-   |                 @ /hubris/sys/userlib/src/lib.rs:1299
+   |                 @ /hubris/sys/userlib/src/lib.rs:1438:5
    |      0x24008d30 0x08028d6a core::panicking::panic_fmt
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:50
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:65:14
    |      0x24009798 0x080271d2 main
    |                 @ /hubris/task/net/src/main.rs:151
    |
@@ -121,13 +121,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x2403ab48 0x080ae632 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403ab80 0x080ae18c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403ab80 0x080ae18c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403ab80 0x080ae19a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403ab80 0x080ae19a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x2403ab80 0x080ae19a main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2403ab50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x2403ab58
@@ -179,13 +179,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x24038b00 0x08081d6e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24038b68 0x080805fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24038b68 0x080805fe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24038b68 0x08080618 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24038b68 0x08080618 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24038b68 0x08080618 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x24038b1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24038b1c
@@ -237,13 +237,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x24039300 0x08085eb2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039368 0x080845c0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039368 0x080845c0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039368 0x080845da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039368 0x080845da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24039368 0x080845da main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403931a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403931c
@@ -295,17 +295,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 recv
    |
    +--->  0x24039a50 0x0808a6f8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039b80 0x08088760 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039b80 0x08088760 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:237
-   |      0x24039b80 0x08088760 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x24039b80 0x08088760 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039b80 0x0808876e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039b80 0x0808876e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:241:11
+   |      0x24039b80 0x0808876e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x24039b80 0x0808876e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x24039b80 0x0808876e main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:202
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:231:9
    |
    |
    +--->   R0 = 0x24039b44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24039b58
@@ -357,19 +357,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x24004290 0x0808e37c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x240042b0 0x0808c7f4 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x240042e8 0x0808c118 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x240042e8 0x0808c118 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240042e8 0x0808c118 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240042e8 0x0808c118 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:774
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:823:17
    |      0x24004380 0x0808d074 main
-   |                 @ /hubris/task/spd/src/main.rs:203
+   |                 @ /hubris/task/spd/src/main.rs:420:5
    |
    |
    +--->   R0 = 0x0808eab8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24004294
@@ -421,13 +421,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: bit0(T+251)
    |
    +--->  0x24002700 0x0800b5ca userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24003198 0x0800915c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24003198 0x0800915c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24003198 0x0800916c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24003198 0x0800916c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24003198 0x0800916c main
-   |                 @ /hubris/task/thermal/src/main.rs:315
+   |                 @ /hubris/task/thermal/src/main.rs:352:9
    |
    |
    +--->   R0 = 0x24002bac   R1 = 0x00000020   R2 = 0x00000001   R3 = 0x24002bd8
@@ -479,15 +479,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 notif: bit31(T+616)
    |
    +--->  0x24032380 0x08062d8a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x240323e8 0x08060272 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x240323e8 0x0806023a userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
-   |      0x240323e8 0x08060210 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x240323e8 0x08060272 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x240323e8 0x08060272 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x240323e8 0x08060272 main
-   |                 @ /hubris/task/power/src/main.rs:419
+   |                 @ /hubris/task/power/src/main.rs:429:9
    |
    |
    +--->   R0 = 0x08063fe8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240323c0
@@ -539,19 +539,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+204)
    |
    +--->  0x24010228 0x0806d754 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24010270 0x0806d7d0 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24010270 0x0806d796 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24010270 0x0806d7d0 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24010270 0x0806d7d0 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24010400 0x0806a6c6 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24010400 0x0806a6c6 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24010400 0x0806a6c6 main
-   |                 @ /hubris/task/hiffy/src/main.rs:125
+   |                 @ /hubris/task/hiffy/src/main.rs:142:9
    |
    |
    +--->   R0 = 0x0806f1a8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24010234
@@ -603,13 +603,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x240334d8 0x080132ea userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24033640 0x08010a70 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24033640 0x08010a70 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24033640 0x08010a82 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24033640 0x08010a82 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24033640 0x08010a82 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:354:9
    |
    |
    +--->   R0 = 0x24033507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x24033520
@@ -661,13 +661,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x24034540 0x080917ba userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24034800 0x080902dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24034800 0x080902dc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24034800 0x080902ec userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24034800 0x080902ec idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24034800 0x080902ec main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x2403455c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240347d4
@@ -719,13 +719,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x2403a5c8 0x08095eac userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403a780 0x08094376 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403a780 0x08094376 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403a780 0x08094386 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403a780 0x08094386 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x2403a780 0x08094386 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:78
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x2403a610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x2403a730
@@ -777,13 +777,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x240353b8 0x080994b2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24035800 0x080981be userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24035800 0x080981be idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24035800 0x080981ce userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24035800 0x080981ce idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24035800 0x080981ce main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:395
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:405:9
    |
    |
    +--->   R0 = 0x240353dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240353e0
@@ -835,13 +835,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: bit0(T+73)
    |
    +--->  0x2402c378 0x080a7134 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402c400 0x080a619e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402c400 0x080a619e idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402c400 0x080a61ae userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402c400 0x080a61ae idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x2402c400 0x080a61ae main
-   |                 @ /hubris/task/sensor/src/main.rs:159
+   |                 @ /hubris/task/sensor/src/main.rs:189:9
    |
    |
    +--->   R0 = 0x2402c3b8   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2402c3d8
@@ -893,13 +893,13 @@ ID TASK                       GEN PRI STATE
 15 host_sp_comms                0   7 recv, notif: bit0(irq82) bit1 bit2(T+58) bit3
    |
    +--->  0x24018620 0x08073624 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24018800 0x08070c70 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24018800 0x08070c70 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24018800 0x08070c80 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24018800 0x08070c80 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24018800 0x08070c80 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:136
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x24018710   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24018748
@@ -951,13 +951,13 @@ ID TASK                       GEN PRI STATE
 16 udpecho                      0   6 notif: bit0
    |
    +--->  0x2402ee40 0x080a9724 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402f000 0x080a85e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402f000 0x080a85e2 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402f000 0x080a85f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402f000 0x080a85f0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x2402f000 0x080a85f0 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x080a9dac   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2402ef90
@@ -1009,13 +1009,15 @@ ID TASK                       GEN PRI STATE
 17 udpbroadcast                 0   6 notif: bit31(T+120)
    |
    +--->  0x24036750 0x080ab3fe userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24036800 0x080aa1b2 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24036800 0x080aa174 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24036800 0x080aa1b2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24036800 0x080aa1b2 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24036800 0x080aa1b2 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:47:9
    |
    |
    +--->   R0 = 0x080aba14   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240367ac
@@ -1067,13 +1069,13 @@ ID TASK                       GEN PRI STATE
 18 udprpc                       0   6 notif: bit0
    |
    +--->  0x24030668 0x0809de18 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24031000 0x0809c236 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24031000 0x0809c236 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24031000 0x0809c246 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24031000 0x0809c246 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x24031000 0x0809c246 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:149:17
    |
    |
    +--->   R0 = 0x0809e640   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24030fb0
@@ -1125,13 +1127,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: bit0 bit1(irq37) bit2
    |
    +--->  0x24028bf0 0x0804b384 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24029000 0x080462ba userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24029000 0x080462ba idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24029000 0x080462c8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24029000 0x080462c8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24029000 0x080462c8 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:148
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x24028dfc   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028e28
@@ -1183,13 +1185,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x240236d0 0x0807b274 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24024000 0x08078434 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24024000 0x08078434 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24024000 0x08078444 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24024000 0x08078444 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24024000 0x08078444 main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:151
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:168:9
    |
    |
    +--->   R0 = 0x24023718   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24023fb0
@@ -1241,13 +1243,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240373b0 0x080a1d0e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x240373e8 0x080a0248 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x240373e8 0x080a0248 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x240373e8 0x080a0258 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x240373e8 0x080a0258 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x240373e8 0x080a0258 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x240373b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240373c0
@@ -1299,13 +1301,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x2403ae08 0x080ad400 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403af20 0x080ac07a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403af20 0x080ac07a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403af20 0x080ac088 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403af20 0x080ac088 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x2403af20 0x080ac088 main
-   |                 @ /hubris/task/vpd/src/main.rs:115
+   |                 @ /hubris/task/vpd/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x2403ae40   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2403ae50
@@ -1357,7 +1359,7 @@ ID TASK                       GEN PRI STATE
 23 idle                         0   8 ready
    |
    +--->  0x2403b100 0x080ae852 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2403b100   R1 = 0x2403b100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.0.stdout
@@ -36,19 +36,19 @@ ID TASK                       GEN PRI STATE
  1 suite                       51   2 recv
    |
    +--->  0x20002f58 0x08015170 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002ff8 0x080121ec userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002ff8 0x080121ec userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002ff8 0x080121ec userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002ff8 0x080121ec userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002ff8 0x080121fc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002ff8 0x080121fc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002ff8 0x080121fc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002ff8 0x080121fc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002ff8 0x080121fc main
-   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:642
+   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:666:9
    |      0x20003000 0x08010026 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:805
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:827:5
    |
    |
    +--->   R0 = 0x20002f5c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002fa0
@@ -88,19 +88,19 @@ ID TASK                       GEN PRI STATE
  2 assist                       2   1 recv
    |
    +--->  0x20003f40 0x0801951e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003ff8 0x08018244 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003ff8 0x08018244 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003ff8 0x08018244 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003ff8 0x08018244 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003ff8 0x08018252 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003ff8 0x08018252 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003ff8 0x08018252 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003ff8 0x08018252 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003ff8 0x08018252 main
-   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:122
+   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:144:9
    |      0x20004000 0x08018026 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:805
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:827:5
    |
    |
    +--->   R0 = 0x20003f44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20003fd4
@@ -139,10 +139,10 @@ ID TASK                       GEN PRI STATE
 
  3 idle                         0   3 ready
    |
-   +--->  0x20004100 0x0801a01e main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   +--->  0x20004100 0x0801a020 main
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |      0x20004100 0x0801a020 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:805
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:827:5
    |
    |
    +--->   R0 = 0x20004000   R1 = 0x0801a038   R2 = 0x20004000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -231,17 +233,17 @@ Caused by:
  5 user_leds                    0   2 recv
    |
    +--->  0x200027c8 0x08018e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002800 0x080180d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002800 0x080180d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002800 0x080180d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x080180d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002800 0x080180e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002800 0x080180e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002800 0x080180e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x080180e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002800 0x080180e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:57
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:64:9
    |
    |
    +--->   R0 = 0x200027cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027d8
@@ -281,13 +283,13 @@ Caused by:
  6 pong                         0   3 ready
    |
    +--->  0x20002bb8 0x0801aebe userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002c00 0x0801a0b4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002c00 0x0801a0b4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002c00 0x0801a0c2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002c00 0x0801a0c2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20002c00 0x0801a0c2 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:19:23
    |
    |
    +--->   R0 = 0x20002bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002bd8
@@ -327,11 +329,11 @@ Caused by:
  7 ping                        17   4 ready
    |
    +--->  0x20002da0 0x0801d120 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20002e00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:81
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20002e00 0x0801c0b0 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:87:5
    |      0x20002e00 0x0801c0b0 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:50:9
    |
    |
    +--->   R0 = 0x20002ddc   R1 = 0x0000002c   R2 = 0x00000001   R3 = 0x00000000
@@ -371,13 +373,13 @@ Caused by:
  8 adt7420                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000ffb0 0x0801f532 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20010000 0x0801e190 drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:63
-   |      0x20010000 0x0801e190 task_adt7420::validate
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:33
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20010000 0x0801e1c6 drv_i2c_api::I2c::read_reg
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:77:9
+   |      0x20010000 0x0801e1c6 task_adt7420::validate
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:34:11
    |      0x20010000 0x0801e1c6 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:144
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:163:17
    |
    |
    +--->   R0 = 0x2000ffb0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff78
@@ -417,7 +419,7 @@ Caused by:
  9 idle                         0   5 ready
    |
    +--->  0x20010100 0x08020052 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20010000   R1 = 0x20010000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.10.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bc8 0x08048d6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014c00 0x08048074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014c00 0x08048074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014c00 0x08048082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014c00 0x08048082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:138:20
    |      0x20014c00 0x08048082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20014bd0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20014be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x0804a194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x0804a194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20015000 0x0804a194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20015000 0x0804a194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x0804a1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x0804a1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20015000 0x0804a1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20015000 0x0804a1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20015000 0x0804a1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20014fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20014fd8
@@ -193,21 +193,21 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  8   2 FAULT: in syscall: bad caller lease index (was: ready)
    |
    +--->  0x20001338 0x080358d0 userlib::sys_borrow_info_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:608
-   |      0x20001360 0x080340a0 userlib::sys_borrow_info
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:569
-   |      0x20001360 0x080340a0 idol_runtime::Leased<A,[T]>::check_slice
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:361
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:613:5
+   |      0x20001360 0x080340ac userlib::sys_borrow_info
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:577:24
+   |      0x20001360 0x080340ac idol_runtime::Leased<A,[T]>::check_slice
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:367:20
    |      0x20001360 0x080340ac idol_runtime::Leased<idol_runtime::W,[T]>::write_only_slice
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:459
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:464:19
    |      0x200013e8 0x0803458c core::option::Option<T>::ok_or
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/option.rs:914
-   |      0x200013e8 0x0803457a drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
-   |                 @ /home/bmc/hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32h7-spi-server-4358bfb526497907/out/server_stub.rs:174
-   |      0x200013e8 0x0803451c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:131
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/option.rs:915:15
+   |      0x200013e8 0x0803458c drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
+   |                 @ /home/bmc/build/drv-stm32h7-spi-server-4358bfb526497907/out/server_stub.rs:189:21
+   |      0x200013e8 0x0803458c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:163:11
    |      0x200013e8 0x0803458c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000000   R2 = 0x2000133c   R3 = 0x20001384
@@ -266,7 +266,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20012360 0x080399f8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200123e8 0x080384e2 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200123e8 0x080384e2 idol_runtime::dispatch
@@ -328,17 +328,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -394,13 +394,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200042f0 0x08040674 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x20004328 0x080400e8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:773:17
    |      0x20004400 0x08040e4c main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:197
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:418:5
    |
    |
    +--->   R0 = 0x08042788   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200042d4
@@ -456,15 +456,15 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 notif: bit31(T+708)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002760 0x08013d02 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002760 0x08013cdc userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002760 0x08013d02 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002760 0x08013d02 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x080107ec main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:144
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:180:9
    |
    |
    +--->   R0 = 0x08014fb4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002728
@@ -520,15 +520,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 wait: reply from spi4_driver/gen8
    |
    +--->  0x20008110 0x0800b6ba userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
    |      0x20008180 0x08008660 task_hiffy::common::send
-   |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:58
+   |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:154:8
    |      0x20008400 0x08009468 hif::execute::function
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:297
-   |      0x20008400 0x080091c4 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:259
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:303:13
+   |      0x20008400 0x08009468 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:465:38
    |      0x20008400 0x08009468 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x20008140   R1 = 0x00000000   R2 = 0x0800c87c   R3 = 0x20008158
@@ -584,15 +584,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 notif: bit31(T+8)
    |
    +--->  0x20010288 0x08023222 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200102c8 0x08023292 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x200102c8 0x0802326c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x200102c8 0x08023292 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x200102c8 0x08023292 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20010400 0x08020926 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:45
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:314:5
    |
    |
    +--->   R0 = 0x0802a04c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20010290
@@ -648,13 +648,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20014690 0x08045680 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014800 0x08044270 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014800 0x08044270 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014800 0x08044280 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014800 0x08044280 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/1f782a4/runtime/src/lib.rs:138:20
    |      0x20014800 0x08044280 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:316:9
    |
    |
    +--->   R0 = 0x200146b8   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200147e0
@@ -710,7 +710,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20015100 0x0804c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20015100   R1 = 0x20015100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.11.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+40)
    |
    +--->  0x20004540 0x0801147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004600 0x080102b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004600 0x080102b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004600 0x080102c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004600 0x080102c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20004600 0x080102c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08011a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200045dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005400 0x08020074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005400 0x08020074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005400 0x08020082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005400 0x08020082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20005400 0x08020082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x200053d0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x200053e0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005800 0x08022194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005800 0x08022194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005800 0x08022194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20005800 0x08022194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005800 0x080221a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005800 0x080221a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005800 0x080221a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20005800 0x080221a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20005800 0x080221a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x200057d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200057d8
@@ -193,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005c00 0x08024174 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005c00 0x08024174 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005c00 0x08024174 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005c00 0x08024182 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005c00 0x08024182 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005c00 0x08024182 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
    |      0x20005c00 0x08024182 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:97:9
    |
    |
    +--->   R0 = 0x08025404   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20005bd8
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004c00 0x08014430 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004c00 0x08014430 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20004c00 0x08014430 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20004c00 0x08014430 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004c00 0x08014440 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004c00 0x08014440 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20004c00 0x08014440 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20004c00 0x08014440 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20004c00 0x08014440 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20004bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -323,13 +323,13 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20001360 0x08019960 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0801851a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0801851a idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08018532 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08018532 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08018532 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x2000137c   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001384
@@ -385,13 +385,13 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006000 0x08026128 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20006000 0x08026128 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006000 0x08026136 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006000 0x08026136 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20006000 0x08026136 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:110
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x20005fc8   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20005fd8
@@ -447,11 +447,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006400 0x080280ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006400 0x080280ba userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006400 0x080280ba userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20006400 0x080280ba main
-   |                 @ /home/bmc/hubris/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x200063c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200063d8
@@ -510,9 +512,9 @@ ID TASK                       GEN PRI STATE
  8 ping                     14190   4 wait: send to pong/gen0
    |
    +--->  0x200065b0 0x0802ae84 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
    |      0x20006600 0x0802a0e0 main
-   |                 @ /home/bmc/hubris/task/ping/src/main.rs:35
+   |                 @ /home/bmc/hubris/task/ping/src/main.rs:49:12
    |
    |
    +--->   R0 = 0x200065dc   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -568,19 +570,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 notif: bit31(T+140)
    |
    +--->  0x20008540 0x0800b2e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008580 0x0800b352 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008580 0x0800b32c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008580 0x0800b352 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x0800b352 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008800 0x08008e68 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x08008e68 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x08008e68 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c42c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -636,15 +638,15 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 notif: bit31(T+151)
    |
    +--->  0x20002648 0x0801d718 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002688 0x0801d786 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002688 0x0801d760 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002688 0x0801d786 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002688 0x0801d786 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x0801c230 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:305:13
    |
    |
    +--->   R0 = 0x0801ddd8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002650
@@ -700,7 +702,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20006700 0x0802c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20006700   R1 = 0x20006700   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.12.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+38)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bd8 0x08048d72 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014c00 0x0804806e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014c00 0x0804806e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014c00 0x0804807c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014c00 0x0804807c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20014c00 0x0804807c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20014bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x0804a194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x0804a194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20015000 0x0804a194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20015000 0x0804a194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x0804a1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x0804a1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20015000 0x0804a1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20015000 0x0804a1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20015000 0x0804a1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20014fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20014fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,9 +255,9 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 RUNNING
    |
    +--->  0x200122d8 0x080381c4 ringbuf::Ringbuf<T,_>::entry
-   |                 @ /home/bmc/hubris/lib/ringbuf/src/lib.rs:249
+   |                 @ /home/bmc/hubris/lib/ringbuf/src/lib.rs:255:20
    |      0x20012368 0x08038a4e drv_stm32h7_spi_server::ServerImpl::ready_writey
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:247
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:383:21
    |      0x200123e8 0x0803868e drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
    |                 @ /home/bmc/hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32h7-spi-server-659dc873b0f8b67e/out/server_stub.rs:197
    |      0x200123e8 0x080384e4 idol_runtime::dispatch
@@ -319,17 +319,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -385,13 +385,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200042f0 0x08040674 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x20004328 0x080400e8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:773:17
    |      0x20004400 0x08040e4c main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:234
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:451:5
    |
    |
    +--->   R0 = 0x08042788   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200042d4
@@ -447,15 +447,15 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 notif: bit31(T+444)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002760 0x08013d02 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002760 0x08013cdc userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002760 0x08013d02 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002760 0x08013d02 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x080107ec main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:144
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:178:9
    |
    |
    +--->   R0 = 0x08014fb4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002728
@@ -511,15 +511,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 wait: reply from gimlet_seq/gen0
    |
    +--->  0x20008110 0x0800b696 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
    |      0x20008180 0x08008660 task_hiffy::common::send
-   |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:58
+   |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:154:8
    |      0x20008400 0x0800944c hif::execute::function
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:297
-   |      0x20008400 0x080091a8 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:259
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:303:13
+   |      0x20008400 0x0800944c hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:465:38
    |      0x20008400 0x0800944c main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x20008140   R1 = 0x00000000   R2 = 0x0800c85c   R3 = 0x20008158
@@ -575,23 +575,23 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20010220 0x08023636 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
-   |      0x20010278 0x08022d6e drv_spi_api::Spi::exchange
-   |                 @ /home/bmc/hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:147
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
+   |      0x20010278 0x08022da8 drv_spi_api::Spi::exchange
+   |                 @ /home/bmc/build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:191:12
    |      0x20010278 0x08022da8 drv_spi_api::SpiDevice::exchange
-   |                 @ /home/bmc/hubris/drv/spi-api/src/lib.rs:119
-   |      0x200102b8 0x0802026e drv_gimlet_seq_server::seq_spi::SequencerFpga::raw_spi_read
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/seq_spi.rs:92
+   |                 @ /home/bmc/hubris/drv/spi-api/src/lib.rs:124:9
+   |      0x200102b8 0x080202a8 drv_gimlet_seq_server::seq_spi::SequencerFpga::raw_spi_read
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/seq_spi.rs:109:9
    |      0x200102b8 0x080202a8 drv_gimlet_seq_server::seq_spi::SequencerFpga::read_bytes
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/seq_spi.rs:51
-   |      0x20010400 0x080209ec <drv_gimlet_seq_server::ServerImpl as drv_gimlet_seq_server::idl::InOrderSequencerImpl>::set_state
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:310
-   |      0x20010400 0x080209ec drv_gimlet_seq_server::idl::<impl idol_runtime::Server<drv_gimlet_seq_server::idl::SequencerOperation> for (core::marker::PhantomData<drv_gimlet_seq_server::idl::SequencerOperation>,&mut S)>::handle
-   |                 @ /home/bmc/hubris/target/thumbv7em-none-eabihf/release/build/drv-gimlet-seq-server-06e94541a4f6139a/out/server_stub.rs:103
-   |      0x20010400 0x080208e0 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/seq_spi.rs:56:9
+   |      0x20010400 0x08020a42 <drv_gimlet_seq_server::ServerImpl as drv_gimlet_seq_server::idl::InOrderSequencerImpl>::set_state
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:337:21
+   |      0x20010400 0x08020a42 drv_gimlet_seq_server::idl::<impl idol_runtime::Server<drv_gimlet_seq_server::idl::SequencerOperation> for (core::marker::PhantomData<drv_gimlet_seq_server::idl::SequencerOperation>,&mut S)>::handle
+   |                 @ /home/bmc/build/drv-gimlet-seq-server-06e94541a4f6139a/out/server_stub.rs:130:25
+   |      0x20010400 0x08020a42 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:172:11
    |      0x20010400 0x08020a42 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:51
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:292:9
    |
    |
    +--->   R0 = 0x20010240   R1 = 0x2001025f   R2 = 0x00000002   R3 = 0x2001027c
@@ -647,13 +647,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20014698 0x080456fc userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014800 0x08044274 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014800 0x08044274 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014800 0x08044284 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014800 0x08044284 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20014800 0x08044284 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x200146bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200147e0
@@ -709,7 +709,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 ready
    |
    +--->  0x20015100 0x0804c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20015100   R1 = 0x20015100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.13.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bd8 0x08048d72 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014c00 0x0804806e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014c00 0x0804806e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014c00 0x0804807c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014c00 0x0804807c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20014c00 0x0804807c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20014bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x0804a194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x0804a194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20015000 0x0804a194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20015000 0x0804a194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x0804a1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x0804a1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20015000 0x0804a1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20015000 0x0804a1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20015000 0x0804a1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20014fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20014fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200123e8 0x080384e4 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200123e8 0x080384e4 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -383,11 +383,11 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:652:5
    |      0x20004328 0x0804044a drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:904:17
    |      0x20004400 0x08040e4a main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:197
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x200042d4
@@ -443,13 +443,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 ready
    |
    +--->  0x200026f0 0x08013522 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20002800 0x08010470 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20002800 0x08010470 idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002800 0x08010480 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002800 0x08010480 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x20002800 0x08010480 main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:175
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:215:9
    |
    |
    +--->   R0 = 0x200027c8   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x20002790
@@ -505,19 +505,19 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009124 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009124 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009124 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c85c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -573,13 +573,13 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x08023576 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20010400 0x080208da userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20010400 0x080208da idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010400 0x080208e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010400 0x080208e2 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20010400 0x080208e2 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:51
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:291:9
    |
    |
    +--->   R0 = 0x200102d7   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200102f0
@@ -635,13 +635,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20014698 0x080456fc userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014800 0x08044274 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014800 0x08044274 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014800 0x08044284 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014800 0x08044284 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20014800 0x08044284 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x200146bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200147e0
@@ -697,7 +697,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 ready
    |
    +--->  0x20015100 0x0804c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20015100   R1 = 0x20015100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.14.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+69)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302be userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302be userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302d0 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302d0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302d0 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a64   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015c00 0x0804c06e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015c00 0x0804c06e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015c00 0x0804c07c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015c00 0x0804c07c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015c00 0x0804c07c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20015bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20015be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20016000 0x0804e194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20016000 0x0804e194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20016000 0x0804e194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20016000 0x0804e194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20016000 0x0804e1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20016000 0x0804e1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20016000 0x0804e1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20016000 0x0804e1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20016000 0x0804e1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20015fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20015fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200123e8 0x080384e4 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200123e8 0x080384e4 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -383,11 +383,11 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:652:5
    |      0x20004328 0x0804044a drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:904:17
    |      0x20004400 0x08040e4a main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:197
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x200042d4
@@ -443,13 +443,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x080136f2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20002800 0x080104a8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20002800 0x080104a8 idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002800 0x080104b6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002800 0x080104b6 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x20002800 0x080104b6 main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:211
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:252:9
    |
    |
    +--->   R0 = 0x200027c8   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x20002790
@@ -505,15 +505,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   3 ready
    |
    +--->  0x20014400 0x080511ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200144b0 0x08050140 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x200144b0 0x0805011e userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
-   |      0x200144b0 0x08050100 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x200144b0 0x08050140 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
+   |      0x200144b0 0x08050140 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x200144b0 0x08050140 main
-   |                 @ /home/bmc/hubris/task/power/src/main.rs:114
+   |                 @ /home/bmc/hubris/task/power/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x08051a2c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2001448c
@@ -569,19 +569,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009124 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009124 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009124 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c85c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -637,13 +637,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x08023576 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20010400 0x080208da userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20010400 0x080208da idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010400 0x080208e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010400 0x080208e2 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20010400 0x080208e2 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:51
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:291:9
    |
    |
    +--->   R0 = 0x200102d7   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200102f0
@@ -699,13 +699,13 @@ ID TASK                       GEN PRI STATE
 11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x08044274 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x08044274 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x08044284 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x08044284 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015000 0x08044284 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x20014ebc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014fe0
@@ -761,13 +761,13 @@ ID TASK                       GEN PRI STATE
 12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c52 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200157d0 0x080480a8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200157d0 0x080480a8 idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200157d0 0x080480b6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200157d0 0x080480b6 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x200157d0 0x080480b6 main
-   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:82
+   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:98:9
    |
    |
    +--->   R0 = 0x200157b8   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x200156a8
@@ -823,7 +823,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20016100   R1 = 0x20016100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.15.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302be userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302be userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302d0 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302d0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302d0 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a64   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015c00 0x0804c06e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015c00 0x0804c06e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015c00 0x0804c07c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015c00 0x0804c07c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015c00 0x0804c07c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20015bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20015be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20016000 0x0804e194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20016000 0x0804e194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20016000 0x0804e194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20016000 0x0804e194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20016000 0x0804e1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20016000 0x0804e1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20016000 0x0804e1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20016000 0x0804e1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20016000 0x0804e1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20015fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20015fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200123e8 0x080384e4 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200123e8 0x080384e4 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -383,11 +383,11 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 RUNNING
    |
    +--->  0x200042f0 0x0804202e userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:652:5
    |      0x20004328 0x0804044a drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:904:17
    |      0x20004400 0x08040e4a main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:197
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x200042d4
@@ -443,13 +443,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x08013796 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20002800 0x080104c6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20002800 0x080104c6 idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002800 0x080104d6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002800 0x080104d6 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x20002800 0x080104d6 main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:223
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:264:9
    |
    |
    +--->   R0 = 0x200027c8   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x20002790
@@ -505,15 +505,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   3 ready
    |
    +--->  0x20014400 0x08051302 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200144b0 0x08050162 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x200144b0 0x08050140 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
-   |      0x200144b0 0x08050122 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x200144b0 0x08050162 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
+   |      0x200144b0 0x08050162 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x200144b0 0x08050162 main
-   |                 @ /home/bmc/hubris/task/power/src/main.rs:116
+   |                 @ /home/bmc/hubris/task/power/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x08051bdc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2001448c
@@ -569,19 +569,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009124 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009124 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009124 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c85c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -637,13 +637,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x080235ce userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20010400 0x080208e2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20010400 0x080208e2 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010400 0x080208ea userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010400 0x080208ea idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20010400 0x080208ea main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:51
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:291:9
    |
    |
    +--->   R0 = 0x200102d7   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200102f0
@@ -699,13 +699,13 @@ ID TASK                       GEN PRI STATE
 11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x08044274 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x08044274 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x08044284 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x08044284 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015000 0x08044284 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x20014ebc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014fe0
@@ -761,13 +761,13 @@ ID TASK                       GEN PRI STATE
 12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c6a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200157d0 0x080480aa userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200157d0 0x080480aa idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200157d0 0x080480b8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200157d0 0x080480b8 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x200157d0 0x080480b8 main
-   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:99
+   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:115:9
    |
    |
    +--->   R0 = 0x200157b8   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x200156a8
@@ -823,7 +823,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20016100   R1 = 0x20016100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.16.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+79)
    |
    +--->  0x20013538 0x08031484 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302be userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302be userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302d0 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302d0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302d0 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a64   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20015bd8 0x0804cd72 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015c00 0x0804c06e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015c00 0x0804c06e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015c00 0x0804c07c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015c00 0x0804c07c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015c00 0x0804c07c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20015bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20015be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20015fc8 0x0804ef8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20016000 0x0804e194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20016000 0x0804e194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20016000 0x0804e194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20016000 0x0804e194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20016000 0x0804e1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20016000 0x0804e1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20016000 0x0804e1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20016000 0x0804e1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20016000 0x0804e1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20015fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20015fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080359c4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20012368 0x08039ac8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200123e8 0x080384e4 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200123e8 0x080384e4 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -381,7 +381,7 @@ ID TASK                       GEN PRI STATE
                 }
 
  6 spd                          0   2 RUNNING
-   stack unwind failed: failed to read cfa 0x9, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200042d0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 8041f8a, goff: Some(HubrisGoff { object: 7, goff: 13d7c }) }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 200042e8, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042d0, LR: 8040675, PC: 8041f9e, PSR: 41000000}, inlined: Some([]) }, HubrisStackFrame { cfa: 200042f0, sym: Some(HubrisStackSymbol { name: "core::ops::function::FnOnce::call_once", addr: 8040660, goff: Some(HubrisGoff { object: 7, goff: ecf }) }), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 1, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042f0, LR: 804044b, PC: 8040674, PSR: 41000000}, inlined: Some([]) }]
+   stack unwind failed: failed to read cfa 0x9, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200042d0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 8041f8a, goff: Some(HubrisGoff { object: 7, goff: 13d7c }) }), pos: Some([HubrisSrcPosition { file: "/home/bmc/hubris/sys/userlib/src/lib.rs", func: "userlib::sys_recv_stub", line: 127, col: 5 }]), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 200042e8, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042d0, LR: 8040675, PC: 8041f9e, PSR: 41000000}, inlined: Some([]) }, HubrisStackFrame { cfa: 200042f0, sym: Some(HubrisStackSymbol { name: "core::ops::function::FnOnce::call_once", addr: 8040660, goff: Some(HubrisGoff { object: 7, goff: ecf }) }), pos: Some([HubrisSrcPosition { file: "/rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs", func: "core::ops::function::FnOnce::call_once", line: e3, col: 5 }]), registers: {R0: 8042778, R1: 0, R2: 1, R3: 200042d4, R4: 200043a8, R5: 0, R6: 1e00, R7: 1, R8: 40005400, R9: 0, R10: 2000450c, R11: 1, R12: 0, SP: 200042f0, LR: 804044b, PC: 8040674, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
     address (0x5) below range (HubrisRegion { daddr: Some(800766c), base: 20004000, size: 4000, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(6)] })
@@ -439,13 +439,13 @@ Caused by:
  7 thermal                      0   3 ready
    |
    +--->  0x200026c0 0x08013796 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20002800 0x080104c6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20002800 0x080104c6 idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002800 0x080104d6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002800 0x080104d6 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x20002800 0x080104d6 main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:223
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:264:9
    |
    |
    +--->   R0 = 0x200027c8   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x20002790
@@ -499,7 +499,7 @@ Caused by:
                 }
 
  8 power                        0   3 ready
-   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200143e0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 80512fa, goff: Some(HubrisGoff { object: 9, goff: 1c35b }) }), registers: {R0: 8051bdc, R1: 0, R2: 80000000, R3: 2001448c, R4: 0, R5: ffff, R6: 80000000, R7: 0, R8: 0, R9: 0, R10: 8051bdc, R11: 1, R12: 0, SP: 200143e0, LR: 8050163, PC: 8051302, PSR: 41000000}, inlined: Some([]) }]
+   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200143e0, sym: Some(HubrisStackSymbol { name: "userlib::sys_recv_stub", addr: 80512fa, goff: Some(HubrisGoff { object: 9, goff: 1c35b }) }), pos: Some([HubrisSrcPosition { file: "/home/bmc/hubris/sys/userlib/src/lib.rs", func: "userlib::sys_recv_stub", line: 127, col: 5 }]), registers: {R0: 8051bdc, R1: 0, R2: 80000000, R3: 2001448c, R4: 0, R5: ffff, R6: 80000000, R7: 0, R8: 0, R9: 0, R10: 8051bdc, R11: 1, R12: 0, SP: 200143e0, LR: 8050163, PC: 8051302, PSR: 41000000}, inlined: Some([]) }]
 
 Caused by:
     address (0x4) below range (HubrisRegion { daddr: Some(80076ac), base: 20014000, size: 800, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(8)] })
@@ -557,19 +557,19 @@ Caused by:
  9 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009124 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009124 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009124 main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c85c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -625,13 +625,13 @@ Caused by:
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200102b8 0x080235ce userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20010400 0x080208e2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20010400 0x080208e2 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010400 0x080208ea userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010400 0x080208ea idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20010400 0x080208ea main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:51
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:291:9
    |
    |
    +--->   R0 = 0x200102d7   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200102f0
@@ -687,13 +687,13 @@ Caused by:
 11 hf                           0   3 recv
    |
    +--->  0x20014e98 0x080456fc userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x08044274 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x08044274 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x08044284 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x08044284 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20015000 0x08044284 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x20014ebc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014fe0
@@ -749,13 +749,13 @@ Caused by:
 12 sensor                       0   3 ready
    |
    +--->  0x20015588 0x08048c6a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200157d0 0x080480aa userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200157d0 0x080480aa idol_runtime::dispatch_n
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:201
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200157d0 0x080480b8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200157d0 0x080480b8 idol_runtime::dispatch_n
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:209:20
    |      0x200157d0 0x080480b8 main
-   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/sensor/src/main.rs:114:9
    |
    |
    +--->   R0 = 0x200157b8   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x200156a8
@@ -811,7 +811,7 @@ Caused by:
 13 idle                         0   5 ready
    |
    +--->  0x20016100 0x08052056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20016100   R1 = 0x20016100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.17.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+18)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200015b8 0x080100b0 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200015b8 0x080100b0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200015b8 0x080100c0 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200015b8 0x080100c0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x200015b8 0x080100c0 main
-   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:124:23
    |      0x200015b8 0x08010030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x080109a4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20001594
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001bb8 0x0801405e userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001bb8 0x0801405e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001bb8 0x0801406e userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001bb8 0x0801406e idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20001bb8 0x0801406e main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001bb8 0x08014030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001b8c   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20001b9c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001fb8 0x0801618c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001fb8 0x0801618c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
-   |      0x20001fb8 0x0801618c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
-   |      0x20001fb8 0x0801618c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001fb8 0x0801619a userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001fb8 0x0801619a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
+   |      0x20001fb8 0x0801619a userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:93:14
+   |      0x20001fb8 0x0801619a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:128:5
    |      0x20001fb8 0x0801619a main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001fb8 0x08016030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001f88   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001f90
@@ -199,19 +199,19 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018ec6 userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:668
-   |      0x200023b8 0x080181c0 userlib::hl::Borrow::read_at
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:374
-   |      0x200023b8 0x080181b2 drv_stm32g0_usart::step_transmit
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:204
-   |      0x200023b8 0x080181a4 drv_stm32g0_usart::main::{{closure}}
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:108
-   |      0x200023b8 0x0801816c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:669:5
+   |      0x200023b8 0x080181d4 userlib::hl::Borrow::read_at
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:383:12
+   |      0x200023b8 0x080181d4 drv_stm32g0_usart::step_transmit
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:224:25
+   |      0x200023b8 0x080181d4 drv_stm32g0_usart::main::{{closure}}
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:123:25
+   |      0x200023b8 0x080181d4 userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:96:9
    |      0x200023b8 0x080181d4 main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:100:9
    |      0x200023b8 0x08018030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002390   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20002390
@@ -267,15 +267,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200027b8 0x0801a11c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200027b8 0x0801a11c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200027b8 0x0801a12c userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200027b8 0x0801a12c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200027b8 0x0801a12c main
-   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:117
+   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:124:9
    |      0x200027b8 0x0801a030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002780   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20002790
@@ -331,13 +331,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+218)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20002bb8 0x0801c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x20002bb8 0x0801c0a4 main
-   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:26:23
    |      0x20002bb8 0x0801c030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002b7c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002b90
@@ -393,13 +395,13 @@ ID TASK                       GEN PRI STATE
  6 ping                      2834   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
-   |      0x20002db8 0x0801e06c task_ping::uart_send
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:65
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:155:5
+   |      0x20002db8 0x0801e098 task_ping::uart_send
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:69:10
    |      0x20002db8 0x0801e098 main
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:37
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:49:9
    |      0x20002db8 0x0801e030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002d94   R1 = 0x20002d88   R2 = 0x0000002f   R3 = 0x0000000b

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.18.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+91)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200015b8 0x080100b0 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200015b8 0x080100b0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200015b8 0x080100c0 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200015b8 0x080100c0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x200015b8 0x080100c0 main
-   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:124:23
    |      0x200015b8 0x08010030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x080109a4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20001594
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001bb8 0x0801405e userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001bb8 0x0801405e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001bb8 0x0801406e userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001bb8 0x0801406e idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20001bb8 0x0801406e main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001bb8 0x08014030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001b8c   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20001b9c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001fb8 0x0801618c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001fb8 0x0801618c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
-   |      0x20001fb8 0x0801618c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
-   |      0x20001fb8 0x0801618c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001fb8 0x0801619a userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001fb8 0x0801619a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
+   |      0x20001fb8 0x0801619a userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:93:14
+   |      0x20001fb8 0x0801619a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:128:5
    |      0x20001fb8 0x0801619a main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001fb8 0x08016030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001f88   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001f90
@@ -199,17 +199,17 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018fda userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:972
-   |      0x200023b8 0x08018216 userlib::sys_irq_control
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:961
-   |      0x200023b8 0x080181a4 drv_stm32g0_usart::main::{{closure}}
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:108
-   |      0x200023b8 0x0801816c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:973:5
+   |      0x200023b8 0x0801821c userlib::sys_irq_control
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:963:9
+   |      0x200023b8 0x0801821c drv_stm32g0_usart::main::{{closure}}
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:126:21
+   |      0x200023b8 0x0801821c userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:96:9
    |      0x200023b8 0x0801821c main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:100:9
    |      0x200023b8 0x08018030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x20002390
@@ -265,15 +265,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200027b8 0x0801a11c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200027b8 0x0801a11c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200027b8 0x0801a12c userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200027b8 0x0801a12c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200027b8 0x0801a12c main
-   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:117
+   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:124:9
    |      0x200027b8 0x0801a030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002780   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20002790
@@ -329,13 +329,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+191)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20002bb8 0x0801c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x20002bb8 0x0801c0a4 main
-   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:26:23
    |      0x20002bb8 0x0801c030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002b7c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002b90
@@ -391,13 +393,13 @@ ID TASK                       GEN PRI STATE
  6 ping                      2834   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
-   |      0x20002db8 0x0801e06c task_ping::uart_send
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:65
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:155:5
+   |      0x20002db8 0x0801e098 task_ping::uart_send
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:69:10
    |      0x20002db8 0x0801e098 main
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:37
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:49:9
    |      0x20002db8 0x0801e030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002d94   R1 = 0x20002d88   R2 = 0x0000003b   R3 = 0x0000000b
@@ -453,19 +455,19 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   3 notif: bit31(T+16)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20004128 0x080097f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20004128 0x080097f2 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:263
-   |      0x20004128 0x080097e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20004128 0x08009800 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:295:9
+   |      0x20004128 0x08009800 userlib::sys_recv_closed
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:268:5
+   |      0x20004128 0x08009800 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:613:17
    |      0x20004128 0x08009800 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:636:5
    |      0x200043b8 0x080082f6 main
-   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:110
+   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:128:9
    |      0x200043b8 0x08008030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x08009fb0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200040fc

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.19.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+32)
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200015b8 0x080100b0 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200015b8 0x080100b0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200015b8 0x080100c0 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200015b8 0x080100c0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x200015b8 0x080100c0 main
-   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:124:23
    |      0x200015b8 0x08010030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x080109a4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20001594
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001bb8 0x0801405e userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001bb8 0x0801405e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001bb8 0x0801406e userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001bb8 0x0801406e idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20001bb8 0x0801406e main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001bb8 0x08014030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001b8c   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20001b9c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001fb8 0x0801618c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001fb8 0x0801618c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
-   |      0x20001fb8 0x0801618c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
-   |      0x20001fb8 0x0801618c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001fb8 0x0801619a userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001fb8 0x0801619a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
+   |      0x20001fb8 0x0801619a userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:93:14
+   |      0x20001fb8 0x0801619a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:128:5
    |      0x20001fb8 0x0801619a main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001fb8 0x08016030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001f88   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001f90
@@ -199,17 +199,17 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20002368 0x08018ef8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200023b8 0x0801816c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200023b8 0x0801816c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
-   |      0x200023b8 0x0801816c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200023b8 0x0801817e userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200023b8 0x0801817e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
+   |      0x200023b8 0x0801817e userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:93:14
    |      0x200023b8 0x0801817e main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:100:9
    |      0x200023b8 0x08018030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x08019624   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20002390
@@ -265,15 +265,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200027b8 0x0801a11c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200027b8 0x0801a11c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200027b8 0x0801a12c userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200027b8 0x0801a12c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200027b8 0x0801a12c main
-   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:117
+   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:124:9
    |      0x200027b8 0x0801a030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002780   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20002790
@@ -329,13 +329,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+232)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20002bb8 0x0801c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x20002bb8 0x0801c0a4 main
-   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:26:23
    |      0x20002bb8 0x0801c030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002b7c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002b90
@@ -391,13 +393,13 @@ ID TASK                       GEN PRI STATE
  6 ping                       180   4 ready
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
-   |      0x20002db8 0x0801e06c task_ping::uart_send
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:65
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:155:5
+   |      0x20002db8 0x0801e098 task_ping::uart_send
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:69:10
    |      0x20002db8 0x0801e098 main
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:37
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:49:9
    |      0x20002db8 0x0801e030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002d94   R1 = 0x20002d88   R2 = 0x00000041   R3 = 0x00000007
@@ -453,19 +455,19 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   3 notif: bit31(T+63)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20004128 0x080097f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20004128 0x080097f2 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:263
-   |      0x20004128 0x080097e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20004128 0x08009800 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:295:9
+   |      0x20004128 0x08009800 userlib::sys_recv_closed
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:268:5
+   |      0x20004128 0x08009800 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:613:17
    |      0x20004128 0x08009800 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:636:5
    |      0x200043b8 0x080082f6 main
-   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:110
+   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:128:9
    |      0x200043b8 0x08008030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x08009fb0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200040fc

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.2.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -231,17 +233,17 @@ Caused by:
  5 user_leds                    0   2 recv
    |
    +--->  0x200027c8 0x08018eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002800 0x080180d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002800 0x080180d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002800 0x080180d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x080180d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002800 0x080180e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002800 0x080180e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002800 0x080180e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x080180e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002800 0x080180e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200027cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027d8
@@ -281,11 +283,13 @@ Caused by:
  6 pong                         0   3 ready
    |
    +--->  0x20002bb8 0x0801ad36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002c00 0x0801a08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20002c00 0x0801a098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20002bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002bd8
@@ -325,13 +329,13 @@ Caused by:
  7 i2c_debug                    0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x20005f68 0x0801d604 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
    |      0x20005fb0 0x0801c0a0 drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:85
-   |      0x20006000 0x0801c3fa task_i2c::scan_bus
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:32
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:99:9
+   |      0x20006000 0x0801c430 task_i2c::scan_bus
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:42:13
    |      0x20006000 0x0801c430 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:66
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:112:13
    |
    |
    +--->   R0 = 0x20005f84   R1 = 0x20005f6a   R2 = 0x0801db64   R3 = 0x00000000
@@ -371,7 +375,7 @@ Caused by:
  8 idle                         0   5 ready
    |
    +--->  0x20006100 0x08020052 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20006000   R1 = 0x20006000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.20.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+73)
    |
    +--->  0x20014538 0x08031554 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20014600 0x080302b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20014600 0x080302b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014600 0x080302ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014600 0x080302ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
    |      0x20014600 0x080302ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08031be4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200145dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200163d8 0x08050c86 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20016400 0x0805006e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20016400 0x0805006e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20016400 0x0805007c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20016400 0x0805007c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20016400 0x0805007c main
-   |                 @ /hubris//drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x200163dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200163e0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x200167c8 0x08052ee6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20016800 0x08052194 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20016800 0x08052194 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20016800 0x08052194 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20016800 0x08052194 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20016800 0x080521a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20016800 0x080521a4 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20016800 0x080521a4 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20016800 0x080521a4 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20016800 0x080521a4 main
-   |                 @ /hubris//drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x200167d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200167d8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001368 0x080358d8 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034536 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034536 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08034536 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 RUNNING
    |
    +--->  0x200122d8 0x080399a2 userlib::sys_borrow_read_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:471
+   |                 @ /hubris/sys/userlib/src/lib.rs:472:5
    |      0x20012368 0x080389f6 userlib::sys_borrow_read
    |                 @ /hubris/sys/userlib/src/lib.rs:451
    |      0x20012368 0x080389e6 idol_runtime::Leased<A,[T]>::read_at
@@ -323,17 +323,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20014ad8 0x0803e0ac userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20014c00 0x0803c68e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20014c00 0x0803c68e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20014c00 0x0803c68e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20014c00 0x0803c68e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014c00 0x0803c69e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014c00 0x0803c69e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20014c00 0x0803c69e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20014c00 0x0803c69e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20014c00 0x0803c69e main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20014bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20014bd8
@@ -389,13 +389,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041ef2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
    |      0x200042f0 0x08040674 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x20004328 0x080400e8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:741
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:772:17
    |      0x20004400 0x08040e46 main
-   |                 @ /hubris//task/spd/src/main.rs:197
+   |                 @ /hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x08042670   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200042d4
@@ -451,13 +451,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 recv, notif: bit0(T+284)
    |
    +--->  0x20002740 0x08011526 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20002800 0x080101fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20002800 0x080101fe idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:201
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002800 0x08010210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002800 0x08010210 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:209:20
    |      0x20002800 0x08010210 main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:242:9
    |
    |
    +--->   R0 = 0x200027de   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x200027e0
@@ -513,11 +513,11 @@ ID TASK                       GEN PRI STATE
  8 power                       32   3 wait: send to gimlet_seq/gen41
    |
    +--->  0x20013518 0x080460c0 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20013800 0x08044284 drv_gimlet_seq_api::Sequencer::get_state
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-gimlet-seq-api-e95ac81bcbfbed91/out/client_stub.rs:25
+   |                 @ /hubris/sys/userlib/src/lib.rs:154:5
+   |      0x20013800 0x080442ac drv_gimlet_seq_api::Sequencer::get_state
+   |                 @ /build/drv-gimlet-seq-api-e95ac81bcbfbed91/out/client_stub.rs:56:12
    |      0x20013800 0x080442ac main
-   |                 @ /hubris//task/power/src/main.rs:183
+   |                 @ /hubris/task/power/src/main.rs:192:21
    |
    |
    +--->   R0 = 0x200137d8   R1 = 0x200137d7   R2 = 0x80000000   R3 = 0x200137d8
@@ -573,19 +573,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 notif: bit31(T+23)
    |
    +--->  0x20008140 0x0800b576 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008180 0x0800b5e6 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:723
-   |      0x20008180 0x0800b5c0 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008180 0x0800b5e6 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b5e6 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009124 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009124 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009124 main
-   |                 @ /hubris//task/hiffy/src/main.rs:84
+   |                 @ /hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c68c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -641,15 +641,15 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                  41   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20010668 0x080268da userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200106b0 0x080260f6 drv_spi_api::Spi::write
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:86
+   |                 @ /hubris/sys/userlib/src/lib.rs:154:5
+   |      0x200106b0 0x08026126 drv_spi_api::Spi::write
+   |                 @ /build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:125:12
    |      0x200106b0 0x08026126 drv_spi_api::SpiDevice::write
-   |                 @ /hubris//drv/spi-api/src/lib.rs:131
-   |      0x20010800 0x080236c6 drv_gimlet_seq_server::reprogram_fpga
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:464
+   |                 @ /hubris/drv/spi-api/src/lib.rs:132:9
+   |      0x20010800 0x08023806 drv_gimlet_seq_server::reprogram_fpga
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:480:9
    |      0x20010800 0x08023806 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:61
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:250:19
    |
    |
    +--->   R0 = 0x20010678   R1 = 0x20010697   R2 = 0x00000100   R3 = 0x0802cdcb
@@ -705,13 +705,13 @@ ID TASK                       GEN PRI STATE
 11 hf                           0   3 recv
    |
    +--->  0x20015698 0x08049654 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20015800 0x08048274 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20015800 0x08048274 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015800 0x08048284 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015800 0x08048284 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20015800 0x08048284 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x200156bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200157e0
@@ -767,13 +767,13 @@ ID TASK                       GEN PRI STATE
 12 sensor                       0   3 recv, notif: bit0(T+273)
    |
    +--->  0x20015c38 0x0804cbca userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20015fd0 0x0804c0aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20015fd0 0x0804c0aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:201
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015fd0 0x0804c0b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015fd0 0x0804c0b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:209:20
    |      0x20015fd0 0x0804c0b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20015fb8   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x20015e00
@@ -829,7 +829,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x20016900 0x08054056 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20016900   R1 = 0x20016900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.21.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001530 0x0801070c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200015b8 0x080100b0 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200015b8 0x080100b0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200015b8 0x080100c0 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200015b8 0x080100c0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x200015b8 0x080100c0 main
-   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris-m0/task/jefe/src/main.rs:124:23
    |      0x200015b8 0x08010030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x080109a4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20001594
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001b80 0x08014cc0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001bb8 0x0801405e userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001bb8 0x0801405e idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001bb8 0x0801406e userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001bb8 0x0801406e idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20001bb8 0x0801406e main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001bb8 0x08014030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001b8c   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20001b9c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001f60 0x080174d0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20001fb8 0x0801618c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20001fb8 0x0801618c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:238
-   |      0x20001fb8 0x0801618c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
-   |      0x20001fb8 0x0801618c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20001fb8 0x0801619a userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20001fb8 0x0801619a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
+   |      0x20001fb8 0x0801619a userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:93:14
+   |      0x20001fb8 0x0801619a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:128:5
    |      0x20001fb8 0x0801619a main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001fb8 0x08016030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20001f88   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001f90
@@ -199,19 +199,19 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 ready
    |
    +--->  0x20002368 0x08018ec6 userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:668
-   |      0x200023b8 0x080181c0 userlib::hl::Borrow::read_at
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:374
-   |      0x200023b8 0x080181b2 drv_stm32g0_usart::step_transmit
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:204
-   |      0x200023b8 0x080181a4 drv_stm32g0_usart::main::{{closure}}
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:108
-   |      0x200023b8 0x0801816c userlib::hl::recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:669:5
+   |      0x200023b8 0x080181d4 userlib::hl::Borrow::read_at
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:383:12
+   |      0x200023b8 0x080181d4 drv_stm32g0_usart::step_transmit
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:224:25
+   |      0x200023b8 0x080181d4 drv_stm32g0_usart::main::{{closure}}
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:123:25
+   |      0x200023b8 0x080181d4 userlib::hl::recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:96:9
    |      0x200023b8 0x080181d4 main
-   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris-m0/drv/stm32g0-usart/src/main.rs:100:9
    |      0x200023b8 0x08018030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002390   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20002390
@@ -267,15 +267,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20002768 0x0801ae38 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x200027b8 0x0801a11c userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x200027b8 0x0801a11c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x200027b8 0x0801a12c userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x200027b8 0x0801a12c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200027b8 0x0801a12c main
-   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:117
+   |                 @ /home/bmc/hubris-m0/drv/user-leds/src/main.rs:124:9
    |      0x200027b8 0x0801a030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002780   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20002790
@@ -331,13 +331,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+100)
    |
    +--->  0x20002b68 0x0801cc34 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20002bb8 0x0801c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:308:8
+   |      0x20002bb8 0x0801c0a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:242:11
    |      0x20002bb8 0x0801c0a4 main
-   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris-m0/task/pong/src/main.rs:26:23
    |      0x20002bb8 0x0801c030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002b7c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002b90
@@ -393,13 +395,13 @@ ID TASK                       GEN PRI STATE
  6 ping                       181   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002d70 0x0801ee32 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:154
-   |      0x20002db8 0x0801e06c task_ping::uart_send
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:65
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:155:5
+   |      0x20002db8 0x0801e098 task_ping::uart_send
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:69:10
    |      0x20002db8 0x0801e098 main
-   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:37
+   |                 @ /home/bmc/hubris-m0/task/ping/src/main.rs:49:9
    |      0x20002db8 0x0801e030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x20002d94   R1 = 0x20002d88   R2 = 0x00000017   R3 = 0x00000007
@@ -455,19 +457,19 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   3 notif: bit31(T+182)
    |
    +--->  0x200040f8 0x08009774 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:335
-   |      0x20004128 0x080097f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:282
-   |      0x20004128 0x080097f2 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:263
-   |      0x20004128 0x080097e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:342:5
+   |      0x20004128 0x08009800 userlib::sys_recv
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:295:9
+   |      0x20004128 0x08009800 userlib::sys_recv_closed
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:268:5
+   |      0x20004128 0x08009800 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:613:17
    |      0x20004128 0x08009800 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/hl.rs:636:5
    |      0x200043b8 0x080082f6 main
-   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:110
+   |                 @ /home/bmc/hubris-m0/task/hiffy/src/main.rs:128:9
    |      0x200043b8 0x08008030 _start
-   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1224
+   |                 @ /home/bmc/hubris-m0/sys/userlib/src/lib.rs:1230:5
    |
    |
    +--->   R0 = 0x08009fb0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200040fc

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.22.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+84)
    |
    +--->  0x20002540 0x08011480 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20002600 0x080102ba userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20002600 0x080102ba userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002600 0x080102cc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002600 0x080102cc userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
    |      0x20002600 0x080102cc main
-   |                 @ /hubris//task/jefe/src/main.rs:98
+   |                 @ /hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08011a64   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200025dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200033d8 0x0801cd72 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20003400 0x0801c06e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20003400 0x0801c06e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20003400 0x0801c07c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20003400 0x0801c07c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20003400 0x0801c07c main
-   |                 @ /hubris//drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x200033dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033e0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x200037c8 0x0801ef8e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20003800 0x0801e194 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20003800 0x0801e194 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20003800 0x0801e194 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20003800 0x0801e194 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20003800 0x0801e1a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20003800 0x0801e1a4 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20003800 0x0801e1a4 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20003800 0x0801e1a4 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20003800 0x0801e1a4 main
-   |                 @ /hubris//drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x200037d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200037d8
@@ -193,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 ready
    |
    +--->  0x20003bc0 0x08020e9a userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20003c00 0x08020174 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20003c00 0x08020174 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20003c00 0x08020174 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20003c00 0x08020182 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20003c00 0x08020182 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20003c00 0x08020182 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
    |      0x20003c00 0x08020182 main
-   |                 @ /hubris//drv/stm32h7-usart/src/main.rs:56
+   |                 @ /hubris/drv/stm32h7-usart/src/main.rs:97:9
    |
    |
    +--->   R0 = 0x080213f4   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20003bd8
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b70 0x080158a4 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20002c00 0x08014430 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20002c00 0x08014430 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20002c00 0x08014430 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20002c00 0x08014430 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002c00 0x08014440 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002c00 0x08014440 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20002c00 0x08014440 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20002c00 0x08014440 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20002c00 0x08014440 main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -323,13 +323,13 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20001368 0x080199c4 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0801851e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0801851e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08018536 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08018536 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08018536 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:56
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:125:9
    |
    |
    +--->   R0 = 0x20001382   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20001384
@@ -385,13 +385,13 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x20003fc8 0x08022e3e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20004000 0x08022124 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20004000 0x08022124 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004000 0x08022132 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004000 0x08022132 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/2b5b5bb/runtime/src/lib.rs:142:20
    |      0x20004000 0x08022132 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:110
+   |                 @ /hubris/drv/user-leds/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x20003fcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20003fd8
@@ -447,11 +447,11 @@ ID TASK                       GEN PRI STATE
  7 ping                     40023   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200045b0 0x08024e84 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20004600 0x08024098 task_ping::uart_send
-   |                 @ /hubris//task/ping/src/main.rs:60
+   |                 @ /hubris/sys/userlib/src/lib.rs:154:5
+   |      0x20004600 0x080240c2 task_ping::uart_send
+   |                 @ /hubris/task/ping/src/main.rs:64:10
    |      0x20004600 0x080240c2 main
-   |                 @ /hubris//task/ping/src/main.rs:35
+   |                 @ /hubris/task/ping/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200045dc   R1 = 0x200045d0   R2 = 0x00000000   R3 = 0x00000000
@@ -507,11 +507,13 @@ ID TASK                       GEN PRI STATE
  8 pong                         0   3 recv, notif: bit0(T+484)
    |
    +--->  0x200043b8 0x08026c0a userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20004400 0x080260ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004400 0x080260ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004400 0x080260ba userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
    |      0x20004400 0x080260ba main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x200043c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200043d8
@@ -567,19 +569,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 notif: bit31(T+234)
    |
    +--->  0x20008540 0x0800add2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008580 0x0800ae42 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:723
-   |      0x20008580 0x0800ae1c userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008580 0x0800ae42 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x0800ae42 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008800 0x080089f8 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x080089f8 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x080089f8 main
-   |                 @ /hubris//task/hiffy/src/main.rs:84
+   |                 @ /hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800bc3c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -635,7 +637,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 RUNNING
    |
    +--->  0x20004700 0x08028056 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20004700   R1 = 0x20004700   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.23.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+59)
    |
    +--->  0x20004480 0x0800c980 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20004518 0x0800c1ca userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20004518 0x0800c1ca userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20004518 0x0800c1dc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20004518 0x0800c1dc userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20004518 0x0800c1dc main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |      0x20004518 0x0800c02a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x0800cc4c   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200044f4
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001340 0x08012254 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001368 0x08012050 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001368 0x08012050 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001368 0x08012060 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001368 0x08012060 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20001368 0x08012060 main
-   |                 @ /hubris//drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001368 0x0801202a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001348   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2000134c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001710 0x0801091e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001768 0x08010176 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001768 0x08010176 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20001768 0x08010176 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20001768 0x08010176 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001768 0x08010184 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001768 0x08010184 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20001768 0x08010184 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20001768 0x08010184 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20001768 0x08010184 main
-   |                 @ /hubris//drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /hubris/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001768 0x0801002a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001738   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001740
@@ -199,19 +199,19 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20001b18 0x080113ae userlib::sys_borrow_read_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:634
-   |      0x20001b68 0x080111a2 userlib::hl::Borrow::read_at
-   |                 @ /hubris/sys/userlib/src/hl.rs:374
-   |      0x20001b68 0x08011194 drv_stm32g0_usart::step_transmit
-   |                 @ /hubris//drv/stm32g0-usart/src/main.rs:204
-   |      0x20001b68 0x08011186 drv_stm32g0_usart::main::{{closure}}
-   |                 @ /hubris//drv/stm32g0-usart/src/main.rs:108
-   |      0x20001b68 0x0801114e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
+   |                 @ /hubris/sys/userlib/src/lib.rs:637:13
+   |      0x20001b68 0x080111b6 userlib::hl::Borrow::read_at
+   |                 @ /hubris/sys/userlib/src/hl.rs:383:12
+   |      0x20001b68 0x080111b6 drv_stm32g0_usart::step_transmit
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:224:25
+   |      0x20001b68 0x080111b6 drv_stm32g0_usart::main::{{closure}}
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:123:25
+   |      0x20001b68 0x080111b6 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:96:9
    |      0x20001b68 0x080111b6 main
-   |                 @ /hubris//drv/stm32g0-usart/src/main.rs:56
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:100:9
    |      0x20001b68 0x0801102a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20001b54
@@ -267,15 +267,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20001f20 0x08011b26 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001f68 0x08011908 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001f68 0x08011908 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001f68 0x08011918 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001f68 0x08011918 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20001f68 0x08011918 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:117
+   |                 @ /hubris/drv/user-leds/src/main.rs:124:9
    |      0x20001f68 0x0801182a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001f34   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001f40
@@ -331,15 +331,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+59)
    |
    +--->  0x20004318 0x0801259c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20004368 0x0801248a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20004368 0x0801248a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20004368 0x0801249a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20004368 0x0801249a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20004368 0x0801249a main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |      0x20004368 0x0801242a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x2000432c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004340
@@ -395,13 +395,13 @@ ID TASK                       GEN PRI STATE
  6 ping                      7399   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004770 0x0800ed54 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200047b8 0x0800e064 task_ping::uart_send
-   |                 @ /hubris//task/ping/src/main.rs:65
+   |                 @ /hubris/sys/userlib/src/lib.rs:156:13
+   |      0x200047b8 0x0800e090 task_ping::uart_send
+   |                 @ /hubris/task/ping/src/main.rs:69:10
    |      0x200047b8 0x0800e090 main
-   |                 @ /hubris//task/ping/src/main.rs:37
+   |                 @ /hubris/task/ping/src/main.rs:49:9
    |      0x200047b8 0x0800e02a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x20004788   R2 = 0x00000001   R3 = 0x0000000c
@@ -457,25 +457,25 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   3 notif: bit31(T+170)
    |
    +--->  0x200020a8 0x080098ca userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x200020d8 0x0800993a userlib::sys_recv
-   |                 @ /hubris//sys/userlib/src/lib.rs:279
-   |      0x200020d8 0x0800993a userlib::sys_recv_closed
-   |                 @ /hubris//sys/userlib/src/lib.rs:260
-   |      0x200020d8 0x0800992e userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x200020d8 0x08009948 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:292:9
+   |      0x200020d8 0x08009948 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:265:5
+   |      0x200020d8 0x08009948 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:613:17
    |      0x200020d8 0x08009948 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002368 0x08008482 core::sync::atomic::atomic_load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2354
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2360:23
    |      0x20002368 0x08008482 core::sync::atomic::AtomicU32::load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1495
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1497:26
    |      0x20002368 0x08008482 <core::sync::atomic::AtomicU32 as armv6m_atomic_hack::AtomicU32Ext>::fetch_sub
-   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:61
+   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:63:18
    |      0x20002368 0x08008482 main
-   |                 @ /hubris//task/hiffy/src/main.rs:87
+   |                 @ /hubris/task/hiffy/src/main.rs:105:9
    |      0x20002368 0x0800802a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x0800a168   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200020ac

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.24.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+13)
    |
    +--->  0x20004480 0x0800c980 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20004518 0x0800c1ca userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20004518 0x0800c1ca userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20004518 0x0800c1dc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20004518 0x0800c1dc userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20004518 0x0800c1dc main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |      0x20004518 0x0800c02a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x0800cc4c   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200044f4
@@ -67,15 +67,15 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001340 0x08012254 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001368 0x08012050 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001368 0x08012050 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001368 0x08012060 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001368 0x08012060 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20001368 0x08012060 main
-   |                 @ /hubris//drv/stm32g0-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32g0-rcc/src/main.rs:135:9
    |      0x20001368 0x0801202a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001348   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2000134c
@@ -131,19 +131,19 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001710 0x0801091e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001768 0x08010176 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001768 0x08010176 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20001768 0x08010176 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20001768 0x08010176 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001768 0x08010184 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001768 0x08010184 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20001768 0x08010184 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20001768 0x08010184 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20001768 0x08010184 main
-   |                 @ /hubris//drv/stm32g0-gpio/src/main.rs:237
+   |                 @ /hubris/drv/stm32g0-gpio/src/main.rs:246:9
    |      0x20001768 0x0801002a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001738   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001740
@@ -199,17 +199,17 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x20001b18 0x08011496 userlib::sys_irq_control_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:920
-   |      0x20001b68 0x080111f8 userlib::sys_irq_control
-   |                 @ /hubris/sys/userlib/src/lib.rs:910
-   |      0x20001b68 0x08011186 drv_stm32g0_usart::main::{{closure}}
-   |                 @ /hubris//drv/stm32g0-usart/src/main.rs:108
-   |      0x20001b68 0x0801114e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
+   |                 @ /hubris/sys/userlib/src/lib.rs:923:13
+   |      0x20001b68 0x080111fe userlib::sys_irq_control
+   |                 @ /hubris/sys/userlib/src/lib.rs:912:9
+   |      0x20001b68 0x080111fe drv_stm32g0_usart::main::{{closure}}
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:126:21
+   |      0x20001b68 0x080111fe userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:96:9
    |      0x20001b68 0x080111fe main
-   |                 @ /hubris//drv/stm32g0-usart/src/main.rs:56
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:100:9
    |      0x20001b68 0x0801102a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x00000001   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x20001b54
@@ -265,15 +265,15 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20001f20 0x08011b26 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001f68 0x08011908 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001f68 0x08011908 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001f68 0x08011918 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001f68 0x08011918 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20001f68 0x08011918 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:117
+   |                 @ /hubris/drv/user-leds/src/main.rs:124:9
    |      0x20001f68 0x0801182a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x20001f34   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001f40
@@ -329,15 +329,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+13)
    |
    +--->  0x20004318 0x0801259c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20004368 0x0801248a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20004368 0x0801248a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20004368 0x0801249a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20004368 0x0801249a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20004368 0x0801249a main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |      0x20004368 0x0801242a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x2000432c   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004340
@@ -393,13 +393,13 @@ ID TASK                       GEN PRI STATE
  6 ping                      8028   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004770 0x0800ed54 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200047b8 0x0800e064 task_ping::uart_send
-   |                 @ /hubris//task/ping/src/main.rs:65
+   |                 @ /hubris/sys/userlib/src/lib.rs:156:13
+   |      0x200047b8 0x0800e090 task_ping::uart_send
+   |                 @ /hubris/task/ping/src/main.rs:69:10
    |      0x200047b8 0x0800e090 main
-   |                 @ /hubris//task/ping/src/main.rs:37
+   |                 @ /hubris/task/ping/src/main.rs:49:9
    |      0x200047b8 0x0800e02a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x20004788   R2 = 0x00000001   R3 = 0x0000000c
@@ -455,25 +455,25 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   3 notif: bit31(T+48)
    |
    +--->  0x200020a8 0x080098ca userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x200020d8 0x0800993a userlib::sys_recv
-   |                 @ /hubris//sys/userlib/src/lib.rs:279
-   |      0x200020d8 0x0800993a userlib::sys_recv_closed
-   |                 @ /hubris//sys/userlib/src/lib.rs:260
-   |      0x200020d8 0x0800992e userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x200020d8 0x08009948 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:292:9
+   |      0x200020d8 0x08009948 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:265:5
+   |      0x200020d8 0x08009948 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:613:17
    |      0x200020d8 0x08009948 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002368 0x08008482 core::sync::atomic::atomic_load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2354
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2360:23
    |      0x20002368 0x08008482 core::sync::atomic::AtomicU32::load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1495
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1497:26
    |      0x20002368 0x08008482 <core::sync::atomic::AtomicU32 as armv6m_atomic_hack::AtomicU32Ext>::fetch_sub
-   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:61
+   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:63:18
    |      0x20002368 0x08008482 main
-   |                 @ /hubris//task/hiffy/src/main.rs:87
+   |                 @ /hubris/task/hiffy/src/main.rs:105:9
    |      0x20002368 0x0800802a _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1164
+   |                 @ /hubris/sys/userlib/src/lib.rs:1172:13
    |
    |
    +--->   R0 = 0x0800a168   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200020ac

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.25.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20003538 0x08039540 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20003600 0x080382b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20003600 0x080382b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20003600 0x080382ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20003600 0x080382ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20003600 0x080382ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08039bb4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200035dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20012b58 0x0803ace6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012b80 0x0803a086 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012b80 0x0803a086 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012b80 0x0803a094 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012b80 0x0803a094 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20012b80 0x0803a094 main
-   |                 @ /hubris//drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20012b5c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20012b60
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20012f48 0x0803ceee userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012f80 0x0803c194 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012f80 0x0803c194 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20012f80 0x0803c194 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20012f80 0x0803c194 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012f80 0x0803c1a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012f80 0x0803c1a4 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20012f80 0x0803c1a4 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20012f80 0x0803c1a4 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20012f80 0x0803c1a4 main
-   |                 @ /hubris//drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20012f50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20012f58
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20003ae8 0x08021b70 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20003b68 0x0802061c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20003b68 0x0802061c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20003b68 0x08020638 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20003b68 0x08020638 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20003b68 0x08020638 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:63
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:133:9
    |
    |
    +--->   R0 = 0x20003b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20003b04
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x200102e8 0x08025ca4 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20010368 0x080245f6 userlib::sys_recv
    |                 @ /hubris/sys/userlib/src/lib.rs:279
    |      0x20010368 0x080245f6 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20010a58 0x0802a0b0 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010b80 0x0802868a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010b80 0x0802868a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20010b80 0x0802868a userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20010b80 0x0802868a userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010b80 0x0802869a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010b80 0x0802869a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20010b80 0x0802869a userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20010b80 0x0802869a userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20010b80 0x0802869a main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20010b48   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20010b58
@@ -383,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x0802defa userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20004270 0x0802c674 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x200042a8 0x0802c444 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:741
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:903:17
    |      0x20004380 0x0802ce46 main
-   |                 @ /hubris//task/spd/src/main.rs:197
+   |                 @ /hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x0802e580   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20004254
@@ -445,13 +445,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 recv, notif: bit0(T+462)
    |
    +--->  0x200116c0 0x0803f52e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011780 0x0803e1fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011780 0x0803e1fe idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011780 0x0803e210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011780 0x0803e210 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20011780 0x0803e210 main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:242:9
    |
    |
    +--->   R0 = 0x2001175e   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20011760
@@ -507,15 +507,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   3 notif: bit31(T+577)
    |
    +--->  0x20001518 0x08032096 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20001800 0x08030272 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20001800 0x08030250 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20001800 0x0803022e userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20001800 0x08030272 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20001800 0x08030272 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20001800 0x08030272 main
-   |                 @ /hubris//task/power/src/main.rs:183
+   |                 @ /hubris/task/power/src/main.rs:190:9
    |
    |
    +--->   R0 = 0x080329ac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200017d8
@@ -569,7 +569,7 @@ ID TASK                       GEN PRI STATE
                 }
 
  9 hiffy                        0   3 FAULT: stack overflow; sp=0x20007ff8 (was: ready)
-   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200080a0, sym: None, registers: {R0: 9c24412e, R1: f1eb77d8, R2: baddcafe, R3: baddcafe, R4: 3a, R5: 0, R6: 4, R7: 0, R8: 4, R9: 200080a8, R10: 2, R11: 0, R12: 5, SP: 200080a0, LR: 33a, PC: 3a, PSR: 3}, inlined: None }]
+   stack unwind failed: failed to read cfa 0x8, offset 0xfffffffffffffffc: [HubrisStackFrame { cfa: 200080a0, sym: None, pos: Some([HubrisSrcPosition { file: "/cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.49/src/macros.rs", func: "__divmoddi4", line: 11f, col: e }]), registers: {R0: 9c24412e, R1: f1eb77d8, R2: baddcafe, R3: baddcafe, R4: 3a, R5: 0, R6: 4, R7: 0, R8: 4, R9: 200080a8, R10: 2, R11: 0, R12: 5, SP: 200080a0, LR: 33a, PC: 3a, PSR: 3}, inlined: None }]
 
 Caused by:
     address (0x4) below range (HubrisRegion { daddr: Some(8005198), base: 20008000, size: 8000, attr: HubrisRegionAttr { read: true, write: true, execute: false, device: false, dma: false, external: false }, tasks: [Task(9)] })
@@ -632,13 +632,13 @@ Caused by:
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200024f8 0x080138c2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20002640 0x080109f8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20002640 0x080109f8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20002640 0x08010a00 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20002640 0x08010a00 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20002640 0x08010a00 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:61
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x20002517   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x20002538
@@ -694,13 +694,13 @@ Caused by:
 11 hf                           0   3 recv
    |
    +--->  0x20011e18 0x0803561c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011f80 0x08034276 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011f80 0x08034276 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011f80 0x08034286 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011f80 0x08034286 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20011f80 0x08034286 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:318:9
    |
    |
    +--->   R0 = 0x20011e3c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011f60
@@ -756,13 +756,13 @@ Caused by:
 12 sensor                       0   3 recv, notif: bit0(T+451)
    |
    +--->  0x200123e8 0x08040bbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012780 0x080400aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012780 0x080400aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012780 0x080400b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012780 0x080400b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20012780 0x080400b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20012768   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x200125b0
@@ -818,7 +818,7 @@ Caused by:
 13 idle                         0   5 RUNNING
    |
    +--->  0x20013100 0x08042056 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20013100   R1 = 0x20013100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.26.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+67)
    |
    +--->  0x20001540 0x08009538 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001600 0x080082b0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001600 0x080082b0 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20001600 0x080082c2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001600 0x080082c2 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20001600 0x080082c2 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08009bb4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200015dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20006b50 0x080065d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20006b80 0x08006090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20006b80 0x08006090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20006b80 0x0800609e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20006b80 0x0800609e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20006b80 0x0800609e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20006b58   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20006b60
@@ -127,15 +127,15 @@ ID TASK                       GEN PRI STATE
  2 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20006f40 0x0800ae0e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20006f80 0x0800a17a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20006f80 0x0800a17a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20006f80 0x0800a17a userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20006f80 0x0800a188 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20006f80 0x0800a188 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20006f80 0x0800a188 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
    |      0x20006f80 0x0800a188 main
-   |                 @ /hubris//drv/stm32h7-usart/src/main.rs:55
+   |                 @ /hubris/drv/stm32h7-usart/src/main.rs:96:9
    |
    |
    +--->   R0 = 0x0800b208   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20006f58
@@ -191,17 +191,17 @@ ID TASK                       GEN PRI STATE
  3 i2c_driver                   0   2 recv
    |
    +--->  0x20001af0 0x0800d81c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001b80 0x0800c42c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20001b80 0x0800c42c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20001b80 0x0800c42c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20001b80 0x0800c42c userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20001b80 0x0800c43c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20001b80 0x0800c43c userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20001b80 0x0800c43c userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20001b80 0x0800c43c userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20001b80 0x0800c43c main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:148
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:177:9
    |
    |
    +--->   R0 = 0x20001b54   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001b58
@@ -257,13 +257,13 @@ ID TASK                       GEN PRI STATE
  4 spi_driver                   0   2 recv
    |
    +--->  0x200062f0 0x08029bcc userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20006370 0x08028662 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20006370 0x08028662 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20006370 0x0802867e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20006370 0x0802867e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20006370 0x0802867e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:58
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x2000630a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2000630c
@@ -319,13 +319,13 @@ ID TASK                       GEN PRI STATE
  5 net                          0   2 recv, notif: bit0(irq61)
    |
    +--->  0x20002868 0x08019c6c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20002ed8 0x08011ae4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20002ed8 0x08011ae4 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20002ed8 0x08011af6 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20002ed8 0x08011af6 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20002ed8 0x08011af6 main
-   |                 @ /hubris//task/net/src/main.rs:49
+   |                 @ /hubris/task/net/src/main.rs:184:13
    |
    |
    +--->   R0 = 0x20002c78   R1 = 0x0000001c   R2 = 0x00000001   R3 = 0x20002d40
@@ -381,13 +381,13 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x20007348 0x08006e3c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20007380 0x0800692c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20007380 0x0800692c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20007380 0x0800693c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20007380 0x0800693c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20007380 0x0800693c main
-   |                 @ /hubris//drv/user-leds/src/main.rs:117
+   |                 @ /hubris/drv/user-leds/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x2000734c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20007358
@@ -443,11 +443,11 @@ ID TASK                       GEN PRI STATE
  7 ping                      9057   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007730 0x08030da0 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20007780 0x08030098 task_ping::uart_send
-   |                 @ /hubris//task/ping/src/main.rs:65
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x20007780 0x080300c2 task_ping::uart_send
+   |                 @ /hubris/task/ping/src/main.rs:69:10
    |      0x20007780 0x080300c2 main
-   |                 @ /hubris//task/ping/src/main.rs:37
+   |                 @ /hubris/task/ping/src/main.rs:49:9
    |
    |
    +--->   R0 = 0x2000775c   R1 = 0x20007750   R2 = 0x00000000   R3 = 0x00000000
@@ -503,13 +503,13 @@ ID TASK                       GEN PRI STATE
  8 pong                         0   3 recv, notif: bit0(T+467)
    |
    +--->  0x20007b38 0x08005998 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20007b80 0x080058aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20007b80 0x080058aa userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20007b80 0x080058b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20007b80 0x080058b8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20007b80 0x080058b8 main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x20007b44   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20007b58
@@ -565,11 +565,11 @@ ID TASK                       GEN PRI STATE
  9 udpecho                      0   3 notif: bit0
    |
    +--->  0x20004dd8 0x0802ebe2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20005000 0x0802c368 core::result::Result<T,E>::unwrap
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1296
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1297:9
    |      0x20005000 0x0802c368 main
-   |                 @ /hubris//task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:36:17
    |
    |
    +--->   R0 = 0x0802fe00   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20004fdc
@@ -625,19 +625,19 @@ ID TASK                       GEN PRI STATE
 10 hiffy                        0   3 notif: bit31(T+237)
    |
    +--->  0x20008540 0x08022dbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20008580 0x08022e2e userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20008580 0x08022e08 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20008580 0x08022e2e userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x08022e2e userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008800 0x080209f8 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x080209f8 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x080209f8 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x08023bdc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -693,7 +693,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20007d00 0x08005456 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20007d00   R1 = 0x20007d00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.27.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
    |
    +--->  0x20005538 0x0001953c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20005600 0x000182ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20005600 0x000182ac userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20005600 0x000182be userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20005600 0x000182be userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20005600 0x000182be main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x00019bb4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200055dc
@@ -65,19 +65,19 @@ ID TASK                       GEN PRI STATE
  1 hiffy                        0   3 notif: bit31(T+39)
    |
    +--->  0x20008540 0x00012132 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20008580 0x000121a2 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20008580 0x0001217c userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20008580 0x000121a2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x000121a2 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008800 0x00010634 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x00010634 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x00010634 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x00012bac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -133,7 +133,7 @@ ID TASK                       GEN PRI STATE
  2 idle                         0   5 RUNNING
    |
    +--->  0x2000dd00 0x00029056 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2000dd00   R1 = 0x2000dd00   R2 = 0x00000000   R3 = 0x00000000
@@ -189,15 +189,17 @@ ID TASK                       GEN PRI STATE
  3 syscon_driver                0   2 recv
    |
    +--->  0x20005bc0 0x00028bb6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20005be8 0x00028094 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20005be8 0x00028094 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20005be8 0x00028094 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20005be8 0x000280a2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20005be8 0x000280a2 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20005be8 0x000280a2 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20005be8 0x000280a2 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20005be8 0x000280a2 main
-   |                 @ /hubris//drv/lpc55-syscon/src/main.rs:157
+   |                 @ /hubris/drv/lpc55-syscon/src/main.rs:173:9
    |
    |
    +--->   R0 = 0x20005bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20005bcc
@@ -253,17 +255,17 @@ ID TASK                       GEN PRI STATE
  4 gpio_driver                  0   2 recv
    |
    +--->  0x200063a8 0x0001b6ea userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x200063e8 0x0001a0d2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x200063e8 0x0001a0d2 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x200063e8 0x0001a0d2 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x200063e8 0x0001a0d2 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x200063e8 0x0001a0e0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x200063e8 0x0001a0e0 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x200063e8 0x0001a0e0 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x200063e8 0x0001a0e0 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x200063e8 0x0001a0e0 main
-   |                 @ /hubris//drv/lpc55-gpio/src/main.rs:67
+   |                 @ /hubris/drv/lpc55-gpio/src/main.rs:172:9
    |
    |
    +--->   R0 = 0x200063c0   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200063cc
@@ -319,13 +321,13 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x0001c44c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20006be8 0x0001c0e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20006be8 0x0001c0e2 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20006be8 0x0001c0f2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20006be8 0x0001c0f2 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20006be8 0x0001c0f2 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:121
+   |                 @ /hubris/drv/user-leds/src/main.rs:128:9
    |
    |
    +--->   R0 = 0x20006bb8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20006bc0
@@ -381,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x200073b0 0x0001ef62 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x200073e8 0x0001e16c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x200073e8 0x0001e16c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x200073e8 0x0001e17a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x200073e8 0x0001e17a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x200073e8 0x0001e17a main
-   |                 @ /hubris//drv/lpc55-usart/src/main.rs:46
+   |                 @ /hubris/drv/lpc55-usart/src/main.rs:103:23
    |
    |
    +--->   R0 = 0x0001f32c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200073c0
@@ -443,17 +445,17 @@ ID TASK                       GEN PRI STATE
  7 i2c_driver                   0   2 recv
    |
    +--->  0x20007bb8 0x00021180 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20007be8 0x0002012e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20007be8 0x0002012e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20007be8 0x0002012e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20007be8 0x0002012e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20007be8 0x0002013e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20007be8 0x0002013e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20007be8 0x0002013e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20007be8 0x0002013e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20007be8 0x0002013e main
-   |                 @ /hubris//drv/lpc55-i2c/src/main.rs:58
+   |                 @ /hubris/drv/lpc55-i2c/src/main.rs:90:9
    |
    |
    +--->   R0 = 0x20007bca   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x20007bcc
@@ -509,11 +511,17 @@ ID TASK                       GEN PRI STATE
  8 rng_driver                   0   2 recv
    |
    +--->  0x2000c3b8 0x00022d6a userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x2000c3e8 0x000220ba userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x2000c3e8 0x000220c8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x2000c3e8 0x000220c8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x2000c3e8 0x000220c8 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x2000c3e8 0x000220c8 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x2000c3e8 0x000220c8 main
-   |                 @ /hubris//drv/lpc55-rng/src/main.rs:51
+   |                 @ /hubris/drv/lpc55-rng/src/main.rs:63:9
    |
    |
    +--->   R0 = 0x2000c3bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2000c3c0
@@ -569,13 +577,13 @@ ID TASK                       GEN PRI STATE
  9 spi0_driver                  0   2 notif: bit0(irq59)
    |
    +--->  0x2000cb70 0x0001511e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x2000cbe8 0x000142c0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x2000cbe8 0x000142c0 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:260
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x2000cbe8 0x000142d0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x2000cbe8 0x000142d0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:265:5
    |      0x2000cbe8 0x000142d0 main
-   |                 @ /hubris//drv/lpc55-spi-server/src/main.rs:48
+   |                 @ /hubris/drv/lpc55-spi-server/src/main.rs:101:12
    |
    |
    +--->   R0 = 0x00015530   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2000cb80
@@ -631,11 +639,11 @@ ID TASK                       GEN PRI STATE
 10 ping                        62   4 wait: reply from usart_driver/gen0
    |
    +--->  0x2000d9b0 0x00024da0 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x2000da00 0x00024098 task_ping::uart_send
-   |                 @ /hubris//task/ping/src/main.rs:65
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x2000da00 0x000240c2 task_ping::uart_send
+   |                 @ /hubris/task/ping/src/main.rs:69:10
    |      0x2000da00 0x000240c2 main
-   |                 @ /hubris//task/ping/src/main.rs:37
+   |                 @ /hubris/task/ping/src/main.rs:49:9
    |
    |
    +--->   R0 = 0x2000d9dc   R1 = 0x2000d9d0   R2 = 0x00000000   R3 = 0x00000000
@@ -691,13 +699,13 @@ ID TASK                       GEN PRI STATE
 11 pong                         0   3 recv, notif: bit0(T+36)
    |
    +--->  0x2000d3a0 0x00026198 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x2000d3e8 0x000260aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x2000d3e8 0x000260aa userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x2000d3e8 0x000260b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x2000d3e8 0x000260b8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x2000d3e8 0x000260b8 main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x2000d3ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2000d3c0

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.28.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+85)
    |
    +--->  0x20003538 0x08035544 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20003600 0x080342be userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20003600 0x080342be userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20003600 0x080342d0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20003600 0x080342d0 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20003600 0x080342d0 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08035bc4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200035dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20012b50 0x0803c5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012b80 0x0803c090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012b80 0x0803c090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012b80 0x0803c09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012b80 0x0803c09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20012b80 0x0803c09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20012b58   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20012b60
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 spi4_driver                  0   2 recv
    |
    +--->  0x20003ae8 0x08021bd0 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20003b68 0x08020674 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20003b68 0x08020674 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20003b68 0x0802068e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20003b68 0x0802068e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20003b68 0x0802068e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:58
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x20003b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20003b04
@@ -247,17 +247,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20010a58 0x0802a08c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010b80 0x0802868e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010b80 0x0802868e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20010b80 0x0802868e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20010b80 0x0802868e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010b80 0x0802869e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010b80 0x0802869e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20010b80 0x0802869e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20010b80 0x0802869e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20010b80 0x0802869e main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:148
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:177:9
    |
    |
    +--->   R0 = 0x20010b48   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20010b58
@@ -313,15 +313,15 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit31(T+1)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20004380 0x0802cd88 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20004380 0x0802cd64 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20004380 0x0802cd48 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20004380 0x0802cd88 main
-   |                 @ /hubris//task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:257:9
    |
    |
    +--->   R0 = 0x0802e58c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000435c
@@ -377,13 +377,13 @@ ID TASK                       GEN PRI STATE
  6 thermal                      0   3 recv, notif: bit0(T+196)
    |
    +--->  0x200116c0 0x0803752e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011780 0x080361fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011780 0x080361fe idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011780 0x08036210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011780 0x08036210 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20011780 0x08036210 main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:242:9
    |
    |
    +--->   R0 = 0x2001175e   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20011760
@@ -439,11 +439,11 @@ ID TASK                       GEN PRI STATE
  7 power                        0   3 wait: send to gimlet_seq/gen0
    |
    +--->  0x20001518 0x080320c8 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20001800 0x08030284 drv_gimlet_seq_api::Sequencer::get_state
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-gimlet-seq-api-0c4922606f836f39/out/client_stub.rs:25
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x20001800 0x080302ac drv_gimlet_seq_api::Sequencer::get_state
+   |                 @ /build/drv-gimlet-seq-api-0c4922606f836f39/out/client_stub.rs:56:12
    |      0x20001800 0x080302ac main
-   |                 @ /hubris//task/power/src/main.rs:183
+   |                 @ /hubris/task/power/src/main.rs:192:21
    |
    |
    +--->   R0 = 0x200017d8   R1 = 0x200017d7   R2 = 0x80000000   R3 = 0x200017d8
@@ -499,19 +499,19 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+185)
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009144 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009144 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009144 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x0800c6fc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -567,15 +567,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x200024b0 0x080139ae userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200024f8 0x0801318a drv_spi_api::Spi::write
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:86
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x200024f8 0x080131ba drv_spi_api::Spi::write
+   |                 @ /build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:125:12
    |      0x200024f8 0x080131ba drv_spi_api::SpiDevice::write
-   |                 @ /hubris//drv/spi-api/src/lib.rs:131
-   |      0x20002640 0x08010740 drv_gimlet_seq_server::reprogram_fpga
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:471
+   |                 @ /hubris/drv/spi-api/src/lib.rs:132:9
+   |      0x20002640 0x08010888 drv_gimlet_seq_server::reprogram_fpga
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:487:9
    |      0x20002640 0x08010888 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:61
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:256:19
    |
    |
    +--->   R0 = 0x200024c0   R1 = 0x200024df   R2 = 0x00000100   R3 = 0x0801411b
@@ -631,13 +631,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20011e18 0x0803964c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011f80 0x08038290 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011f80 0x08038290 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011f80 0x080382a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011f80 0x080382a0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20011f80 0x080382a0 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:34
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x20011e3c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011f60
@@ -693,13 +693,13 @@ ID TASK                       GEN PRI STATE
 11 sensor                       0   3 recv, notif: bit0(T+185)
    |
    +--->  0x200123e8 0x0803abbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012780 0x0803a0aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012780 0x0803a0aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012780 0x0803a0b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012780 0x0803a0b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20012780 0x0803a0b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20012768   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x200125b0
@@ -755,7 +755,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 RUNNING
    |
    +--->  0x20012d00 0x0803c856 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20012d00   R1 = 0x20012d00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.29.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+71)
    |
    +--->  0x20010538 0x08035544 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010600 0x080342be userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010600 0x080342be userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010600 0x080342d0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010600 0x080342d0 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20010600 0x080342d0 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08035bc4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200105dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20013350 0x0803c5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20013380 0x0803c090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20013380 0x0803c090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20013380 0x0803c09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20013380 0x0803c09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20013380 0x0803c09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20013358   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20013360
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 spi4_driver                  0   2 recv
    |
    +--->  0x20010ae8 0x08021bd0 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010b68 0x08020674 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010b68 0x08020674 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010b68 0x0802068e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010b68 0x0802068e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20010b68 0x0802068e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:58
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x20010b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20010b04
@@ -189,15 +189,15 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   2 FAULT: panicked at 'explicit panic', drv/stm32h7-spi-server/src/main.rs:438:21 (was: ready)
    |
    +--->  0x20001248 0x08025dbe userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:989
-   |      0x20001280 0x08025df6 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:981
+   |                 @ /hubris/sys/userlib/src/lib.rs:1016:13
+   |      0x20001280 0x08025dfa userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:982:14
    |      0x20001280 0x08025dfa rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1297
+   |                 @ /hubris/sys/userlib/src/lib.rs:1436:5
    |      0x20001298 0x0802538a core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x200012c0 0x0802573e core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20001378 0x08024f14 drv_stm32h7_spi_server::ServerImpl::ready_writey
    |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:242
    |      0x20001400 0x08024848 drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
@@ -264,17 +264,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20011258 0x0802a08c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011380 0x0802868e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011380 0x0802868e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20011380 0x0802868e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20011380 0x0802868e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011380 0x0802869e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011380 0x0802869e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20011380 0x0802869e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20011380 0x0802869e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20011380 0x0802869e main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:148
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:177:9
    |
    |
    +--->   R0 = 0x20011348   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011358
@@ -330,15 +330,15 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit31(T+7)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20004380 0x0802cd88 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20004380 0x0802cd64 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20004380 0x0802cd48 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20004380 0x0802cd88 main
-   |                 @ /hubris//task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:257:9
    |
    |
    +--->   R0 = 0x0802e58c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000435c
@@ -394,13 +394,13 @@ ID TASK                       GEN PRI STATE
  6 thermal                      0   3 recv, notif: bit0(T+382)
    |
    +--->  0x20011ec0 0x0803752e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011f80 0x080361fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011f80 0x080361fe idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011f80 0x08036210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011f80 0x08036210 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20011f80 0x08036210 main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:242:9
    |
    |
    +--->   R0 = 0x20011f5e   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20011f60
@@ -456,11 +456,11 @@ ID TASK                       GEN PRI STATE
  7 power                        0   3 wait: send to gimlet_seq/gen0
    |
    +--->  0x20002518 0x080320c8 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20002800 0x08030284 drv_gimlet_seq_api::Sequencer::get_state
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-gimlet-seq-api-0c4922606f836f39/out/client_stub.rs:25
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x20002800 0x080302ac drv_gimlet_seq_api::Sequencer::get_state
+   |                 @ /build/drv-gimlet-seq-api-0c4922606f836f39/out/client_stub.rs:56:12
    |      0x20002800 0x080302ac main
-   |                 @ /hubris//task/power/src/main.rs:183
+   |                 @ /hubris/task/power/src/main.rs:192:21
    |
    |
    +--->   R0 = 0x200027d8   R1 = 0x200027d7   R2 = 0x80000000   R3 = 0x200027d8
@@ -516,19 +516,19 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+121)
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009144 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009144 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009144 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x0800c6fc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -584,15 +584,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x200034b0 0x080139ae userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200034f8 0x0801318a drv_spi_api::Spi::write
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:86
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x200034f8 0x080131ba drv_spi_api::Spi::write
+   |                 @ /build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:125:12
    |      0x200034f8 0x080131ba drv_spi_api::SpiDevice::write
-   |                 @ /hubris//drv/spi-api/src/lib.rs:131
-   |      0x20003640 0x08010740 drv_gimlet_seq_server::reprogram_fpga
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:471
+   |                 @ /hubris/drv/spi-api/src/lib.rs:132:9
+   |      0x20003640 0x08010888 drv_gimlet_seq_server::reprogram_fpga
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:487:9
    |      0x20003640 0x08010888 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:61
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:256:19
    |
    |
    +--->   R0 = 0x200034c0   R1 = 0x200034df   R2 = 0x00000100   R3 = 0x080140f4
@@ -648,13 +648,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20012618 0x0803964c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012780 0x08038290 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012780 0x08038290 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012780 0x080382a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012780 0x080382a0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20012780 0x080382a0 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:34
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x2001263c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20012760
@@ -710,13 +710,13 @@ ID TASK                       GEN PRI STATE
 11 sensor                       0   3 recv, notif: bit0(T+371)
    |
    +--->  0x20012be8 0x0803abbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012f80 0x0803a0aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012f80 0x0803a0aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012f80 0x0803a0b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012f80 0x0803a0b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20012f80 0x0803a0b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20012f68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x20012db0
@@ -772,7 +772,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 RUNNING
    |
    +--->  0x20013500 0x0803c856 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20013500   R1 = 0x20013500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.30.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+34)
    |
    +--->  0x20010538 0x08035540 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010600 0x080342b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010600 0x080342b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010600 0x080342ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010600 0x080342ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20010600 0x080342ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08035bb4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200105dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20013350 0x0803c5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20013380 0x0803c090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20013380 0x0803c090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20013380 0x0803c09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20013380 0x0803c09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20013380 0x0803c09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20013358   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20013360
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 spi4_driver                  0   2 recv
    |
    +--->  0x20010ae8 0x08021bd0 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20010b68 0x08020674 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20010b68 0x08020674 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20010b68 0x0802068e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20010b68 0x0802068e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20010b68 0x0802068e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:58
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x20010b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20010b04
@@ -189,13 +189,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                124   2 RUNNING
    |
    +--->  0x200012c0 0x08025daa userlib::sys_irq_control_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:922
+   |                 @ /hubris/sys/userlib/src/lib.rs:953:13
    |      0x20001378 0x08024e78 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
+   |                 @ /hubris/sys/userlib/src/lib.rs:292:9
    |      0x20001378 0x08024e78 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:260
+   |                 @ /hubris/sys/userlib/src/lib.rs:265:5
    |      0x20001378 0x08024e78 drv_stm32h7_spi_server::ServerImpl::ready_writey
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:242
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:485:25
    |      0x20001400 0x08024848 drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
    |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32h7-spi-server-de50281c7d454e52/out/server_stub.rs:197
    |      0x20001400 0x0802464e idol_runtime::dispatch
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20011258 0x0802a08c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011380 0x0802868e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011380 0x0802868e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
-   |      0x20011380 0x0802868e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20011380 0x0802868e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011380 0x0802869e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011380 0x0802869e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
+   |      0x20011380 0x0802869e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20011380 0x0802869e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20011380 0x0802869e main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:148
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:177:9
    |
    |
    +--->   R0 = 0x20011348   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011358
@@ -323,15 +323,15 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit31(T+2)
    |
    +--->  0x200042a8 0x0802df16 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20004380 0x0802cd88 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20004380 0x0802cd64 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20004380 0x0802cd48 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20004380 0x0802cd88 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20004380 0x0802cd88 main
-   |                 @ /hubris//task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:257:9
    |
    |
    +--->   R0 = 0x0802e58c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000435c
@@ -387,13 +387,13 @@ ID TASK                       GEN PRI STATE
  6 thermal                      0   3 ready
    |
    +--->  0x20011ec0 0x0803752e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20011f80 0x080361fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20011f80 0x080361fe idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20011f80 0x08036210 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20011f80 0x08036210 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20011f80 0x08036210 main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:242:9
    |
    |
    +--->   R0 = 0x20011f5e   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20011f60
@@ -449,15 +449,15 @@ ID TASK                       GEN PRI STATE
  7 power                        2   3 ready
    |
    +--->  0x20002518 0x08032096 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20002800 0x08030272 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20002800 0x08030250 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20002800 0x0803022e userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20002800 0x08030272 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20002800 0x08030272 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x08030272 main
-   |                 @ /hubris//task/power/src/main.rs:183
+   |                 @ /hubris/task/power/src/main.rs:190:9
    |
    |
    +--->   R0 = 0x080329ac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200027d8
@@ -513,19 +513,19 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 ready
    |
    +--->  0x20008140 0x0800b5e2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
    |      0x20008180 0x0800b652 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1054
-   |      0x20008180 0x0800b62c userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1059:9
+   |      0x20008180 0x0800b652 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b652 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x08009144 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x08009144 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x08009144 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x0800c6fc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -581,15 +581,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                 124   3 wait: reply from spi2_driver/gen60
    |
    +--->  0x200034b0 0x080139ae userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x200034f8 0x0801318a drv_spi_api::Spi::write
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:86
+   |                 @ /hubris/sys/userlib/src/lib.rs:193:13
+   |      0x200034f8 0x080131ba drv_spi_api::Spi::write
+   |                 @ /build/drv-spi-api-504c24c5d9c9fdce/out/client_stub.rs:125:12
    |      0x200034f8 0x080131ba drv_spi_api::SpiDevice::write
-   |                 @ /hubris//drv/spi-api/src/lib.rs:131
-   |      0x20003640 0x08010740 drv_gimlet_seq_server::reprogram_fpga
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:471
+   |                 @ /hubris/drv/spi-api/src/lib.rs:132:9
+   |      0x20003640 0x08010888 drv_gimlet_seq_server::reprogram_fpga
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:487:9
    |      0x20003640 0x08010888 main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:61
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:256:19
    |
    |
    +--->   R0 = 0x200034c0   R1 = 0x200034df   R2 = 0x00000100   R3 = 0x08014547
@@ -645,13 +645,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20012618 0x0803964c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012780 0x08038290 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012780 0x08038290 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012780 0x080382a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012780 0x080382a0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20012780 0x080382a0 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:34
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x2001263c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20012760
@@ -707,13 +707,13 @@ ID TASK                       GEN PRI STATE
 11 sensor                       0   3 ready
    |
    +--->  0x20012be8 0x0803abbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20012f80 0x0803a0aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20012f80 0x0803a0aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:386:13
+   |      0x20012f80 0x0803a0b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20012f80 0x0803a0b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:250:20
    |      0x20012f80 0x0803a0b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20012f68   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x20012db0
@@ -769,7 +769,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x20013500 0x0803c856 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20013500   R1 = 0x20013500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.31.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+62)
    |
    +--->  0x20000ae0 0x0800697c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20000b70 0x080061c6 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20000b70 0x080061c6 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20000b70 0x080061d8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20000b70 0x080061d8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20000b70 0x080061d8 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08006c3c   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x20000b4c
@@ -49,13 +49,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x200009c8 0x08003d6a userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20000a00 0x08003876 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20000a00 0x08003876 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20000a00 0x08003888 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20000a00 0x08003888 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20000a00 0x08003888 main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x200009d8   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200009e0
@@ -95,13 +95,13 @@ ID TASK                       GEN PRI STATE
  2 pong                         0   4 recv, notif: bit0(T+262)
    |
    +--->  0x20000cb0 0x0800319c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20000d00 0x0800308a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20000d00 0x0800308a userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:235
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20000d00 0x0800309a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20000d00 0x0800309a userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:239:11
    |      0x20000d00 0x0800309a main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x20000cc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20000cd8
@@ -141,13 +141,13 @@ ID TASK                       GEN PRI STATE
  3 user_leds                    0   3 recv
    |
    +--->  0x20000db0 0x08007642 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20000e00 0x0800712c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:279
-   |      0x20000e00 0x0800712c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20000e00 0x0800713c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:305:8
+   |      0x20000e00 0x0800713c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/478f0b6/runtime/src/lib.rs:174:20
    |      0x20000e00 0x0800713c main
-   |                 @ /hubris//drv/user-leds/src/main.rs:121
+   |                 @ /hubris/drv/user-leds/src/main.rs:128:9
    |
    |
    +--->   R0 = 0x20000dcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20000dd8
@@ -187,23 +187,23 @@ ID TASK                       GEN PRI STATE
  4 hiffy                        0   4 notif: bit31(T+13)
    |
    +--->  0x200010d0 0x080050ac userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:331
-   |      0x20001100 0x0800511e userlib::sys_recv
-   |                 @ /hubris//sys/userlib/src/lib.rs:279
-   |      0x20001100 0x0800511e userlib::sys_recv_closed
-   |                 @ /hubris//sys/userlib/src/lib.rs:260
-   |      0x20001100 0x08005112 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:340:13
+   |      0x20001100 0x0800512c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:292:9
+   |      0x20001100 0x0800512c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:265:5
+   |      0x20001100 0x0800512c userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:613:17
    |      0x20001100 0x0800512c userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20001390 0x080042d6 core::sync::atomic::atomic_load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2354
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2360:23
    |      0x20001390 0x080042d6 core::sync::atomic::AtomicU32::load
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1495
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1497:26
    |      0x20001390 0x080042d6 <core::sync::atomic::AtomicU32 as armv6m_atomic_hack::AtomicU32Ext>::fetch_sub
-   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:61
+   |                 @ /hubris/lib/armv6m-atomic-hack/src/lib.rs:63:18
    |      0x20001390 0x080042d6 main
-   |                 @ /hubris//task/hiffy/src/main.rs:98
+   |                 @ /hubris/task/hiffy/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x08005408   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200010d4
@@ -243,11 +243,11 @@ ID TASK                       GEN PRI STATE
  5 idle                         0   5 RUNNING
    |
    +--->  0x20000840 0x08002f44 cortex_m::asm::inline::__wfi
-   |                 @ /crates.io/cortex-m-0.7.3/src/../asm/inline.rs:181
+   |                 @ /crates.io/cortex-m-0.7.3/src/../asm/inline.rs:182:5
    |      0x20000840 0x08002f44 cortex_m::asm::wfi
-   |                 @ /crates.io/cortex-m-0.7.3/src/asm.rs:54
+   |                 @ /crates.io/cortex-m-0.7.3/src/asm.rs:55:5
    |      0x20000840 0x08002f44 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:17:9
    |
    |
    +--->   R0 = 0x20000840   R1 = 0x20000840   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.4.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008892 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008892 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008892 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a2 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x08010148 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x08010148 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x08010148 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x08010148 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0801169c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,19 +263,19 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
-   |      0x20002c00 0x080148e2 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002c00 0x08014658 drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x08014658 userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x080142d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x080142d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
+   |      0x20002c00 0x08014920 drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:541:17
+   |      0x20002c00 0x08014920 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:462:23
+   |      0x20002c00 0x08014920 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x08014920 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x08014920 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x08014920 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002b64
@@ -329,17 +331,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003400 0x080180da userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003400 0x080180da userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003400 0x080180da userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x080180da userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003400 0x080180e8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003400 0x080180e8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003400 0x080180e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x080180e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x080180e8 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -395,11 +397,13 @@ ID TASK                       GEN PRI STATE
  6 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003800 0x0801a08c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003800 0x0801a09a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003800 0x0801a09a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20003800 0x0801a09a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -455,11 +459,11 @@ ID TASK                       GEN PRI STATE
  7 ping                        24   4 ready
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20003a00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20003a00 0x0801c0b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:68:10
    |      0x20003a00 0x0801c0b2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200039dc   R1 = 0x00000063   R2 = 0x00000000   R3 = 0x00000000
@@ -515,15 +519,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200045e0 0x08021fa0 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20004650 0x08020522 drv_i2c_api::I2cDevice::read
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:380
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20004650 0x08020580 drv_i2c_api::I2cDevice::read
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:400:9
    |      0x20004650 0x08020580 task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:59
-   |      0x20004800 0x080208c4 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/0ce1f42/src/lib.rs:85
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120:25
+   |      0x20004800 0x08020cfe hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/0ce1f42/src/lib.rs:286:29
    |      0x20004800 0x08020cfe main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:207
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:247:18
    |
    |
    +--->   R0 = 0x20004610   R1 = 0x20004600   R2 = 0x00000002   R3 = 0x00000000
@@ -579,15 +583,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0803030a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080302e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080302d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0803030a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0803030a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0803030a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08031d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -643,7 +647,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.49.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,29 +263,29 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
-   |      0x20002b20 0x08015b9c drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015b9c drv_stm32h7_i2c::ltc4306::write_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:107
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
+   |      0x20002b20 0x08015bc0 drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:449:17
+   |      0x20002b20 0x08015bc0 drv_stm32h7_i2c::ltc4306::write_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:114:11
    |      0x20002b20 0x08015bc0 <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:165:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002ad4
@@ -339,13 +341,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -401,17 +403,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -467,9 +469,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x20004454   R2 = 0x00000001   R3 = 0x00000000
@@ -525,17 +527,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -591,11 +593,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -651,15 +655,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -715,15 +719,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20008610 0x08033a1a drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:317
-   |      0x20008800 0x08030be4 drv_i2c_devices::adt7420::Adt7420::validate
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:60
-   |      0x20008800 0x08030a6c task_thermal::adt7420_read
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:142
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:337:9
+   |      0x20008800 0x08030bec drv_i2c_devices::adt7420::Adt7420::validate
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:61:15
+   |      0x20008800 0x08030bec task_thermal::adt7420_read
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:146:15
    |      0x20008800 0x08030bec main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:331:13
    |
    |
    +--->   R0 = 0x200085e4   R1 = 0x200085bc   R2 = 0x00000001   R3 = 0x00000002
@@ -779,15 +783,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x0804373a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x08040780 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x08040762 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x0804074c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x08040780 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x08040780 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x08040780 main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x080447c8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -843,15 +847,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -907,7 +911,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.5.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x0801425a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x0801425a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x0801425a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x0801425a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x0801426a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x0801426a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x0801426a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x0801426a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x0801426a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:174
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:184:9
    |
    |
    +--->   R0 = 0x200023d4   R1 = 0x00000003   R2 = 0x00000000   R3 = 0x200023d8
@@ -245,13 +247,13 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f68 0x08019822 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20002f88 0x080186cc drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:112
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:114:6
    |      0x20002fe8 0x080180da drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:159
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:195:17
    |      0x20003000 0x080186b0 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:170:5
    |
    |
    +--->   R0 = 0x08019e3c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002f6c
@@ -291,17 +293,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -341,11 +343,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+411)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -385,15 +389,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 notif: bit31(T+911)
    |
    +--->  0x20005fa0 0x08021726 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x0802025e userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020240 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x0802022c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x0802025e userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x0802025e userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x0802025e main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:100
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:103:9
    |
    |
    +--->   R0 = 0x08021cfc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fb8
@@ -433,15 +437,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 notif: bit31(T+361)
    |
    +--->  0x2000ff80 0x0802573e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010000 0x0802426c userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20010000 0x08024250 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20010000 0x08024238 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20010000 0x0802426c userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20010000 0x0802426c userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010000 0x0802426c main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:136:9
    |
    |
    +--->   R0 = 0x08025db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff9c

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.50.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,31 +263,31 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002ad0 0x0801638a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002af0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
-   |      0x20002b20 0x08015cd8 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015bde drv_stm32h7_i2c::ltc4306::read_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:82
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
+   |      0x20002b20 0x08015cea drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:541:17
+   |      0x20002b20 0x08015cea drv_stm32h7_i2c::ltc4306::read_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:91:11
    |      0x20002b20 0x08015cea <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:166:30
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x08016a40   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x20002ad4
@@ -341,13 +343,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -403,17 +405,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -469,9 +471,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -527,17 +529,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -593,11 +595,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -653,15 +657,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -717,15 +721,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -781,15 +785,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -845,15 +849,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x2000c590 0x08050578 drv_i2c_api::I2cDevice::read_reg_into
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:350
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x2000c590 0x080505cc drv_i2c_api::I2cDevice::read_reg_into
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:370:9
    |      0x2000c590 0x080505cc task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120
-   |      0x2000c800 0x08050a90 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:91
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:140:17
+   |      0x2000c800 0x08050eb6 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:298:29
    |      0x2000c800 0x08050eb6 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:308:18
    |
    |
    +--->   R0 = 0x2000c550   R1 = 0x2000c528   R2 = 0x00000001   R3 = 0x00000002
@@ -909,7 +913,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.51.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,7 +263,7 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b20 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
    |      0x20002c00 0x0801493e drv_stm32h7_i2c::I2cController::write_read
    |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
    |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
@@ -329,13 +331,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -391,17 +393,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -457,9 +459,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -705,15 +709,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -769,15 +773,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -833,15 +837,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x2000c590 0x08050602 drv_i2c_api::I2cDevice::read_block
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:381
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x2000c590 0x08050656 drv_i2c_api::I2cDevice::read_block
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:401:9
    |      0x2000c590 0x08050656 task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120
-   |      0x2000c800 0x08050a90 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:91
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:157:23
+   |      0x2000c800 0x08050eb6 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:298:29
    |      0x2000c800 0x08050eb6 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:308:18
    |
    |
    +--->   R0 = 0x2000c550   R1 = 0x2000c528   R2 = 0x00000001   R3 = 0x00000002
@@ -897,7 +901,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.52.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801638a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0801447a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0801447a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x0801448a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x0801448a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x0801448a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x0801448a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x0801448a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -327,13 +329,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -389,19 +391,19 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:448:5
    |      0x20003be8 0x0801c2e8 core::option::Option<T>::ok_or
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:565
-   |      0x20003be8 0x0801c1ea drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x20003be8 0x0801c1ea userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:567:13
+   |      0x20003be8 0x0801c2e8 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:289:48
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c2e8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x20003bc0   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x00000004
@@ -457,9 +459,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x20004474   R2 = 0x00000001   R3 = 0x00000000
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+178)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+178)
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -705,15 +709,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+807)
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -769,15 +773,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 notif: bit31(T+807)
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -833,15 +837,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 notif: bit31(T+10)
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -897,7 +901,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.53.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,35 +263,35 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
    |      0x20002b20 0x08015cee core::ptr::read_volatile
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ptr/mod.rs:1052
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ptr/mod.rs:1058:14
    |      0x20002b20 0x08015cee vcell::VolatileCell<T>::get
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:30
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:33:18
    |      0x20002b20 0x08015cee stm32h7::generic::Reg<U,REG>::read
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/stm32h7-0.13.0/src/generic.rs:50
-   |      0x20002b20 0x08015cd8 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015bde drv_stm32h7_i2c::ltc4306::read_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:82
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/stm32h7-0.13.0/src/generic.rs:51:18
+   |      0x20002b20 0x08015cee drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:538:20
+   |      0x20002b20 0x08015cee drv_stm32h7_i2c::ltc4306::read_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:91:11
    |      0x20002b20 0x08015cee <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:166:30
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002ad4
@@ -345,13 +347,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -407,17 +409,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -473,9 +475,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -531,17 +533,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -597,11 +599,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -657,15 +661,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -721,15 +725,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20008610 0x08033906 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:317
-   |      0x20008800 0x08030be4 drv_i2c_devices::adt7420::Adt7420::validate
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:60
-   |      0x20008800 0x08030a6c task_thermal::adt7420_read
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:142
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:337:9
+   |      0x20008800 0x08030bec drv_i2c_devices::adt7420::Adt7420::validate
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:61:15
+   |      0x20008800 0x08030bec task_thermal::adt7420_read
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:146:15
    |      0x20008800 0x08030bec main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:331:13
    |
    |
    +--->   R0 = 0x200085e4   R1 = 0x200085bc   R2 = 0x00000001   R3 = 0x00000002
@@ -785,15 +789,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -849,15 +853,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -913,7 +917,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.6.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008892 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008892 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008892 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a2 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x08010148 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x08010148 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x08010148 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x08010148 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0801169c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,19 +263,19 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
-   |      0x20002c00 0x080146f8 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002c00 0x08014658 drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x08014658 userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x080142d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x080142d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
+   |      0x20002c00 0x0801478e drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:432:17
+   |      0x20002c00 0x0801478e drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:462:23
+   |      0x20002c00 0x0801478e userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x0801478e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x0801478e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x0801478e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002b64
@@ -329,17 +331,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003400 0x080180da userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003400 0x080180da userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003400 0x080180da userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x080180da userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003400 0x080180e8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003400 0x080180e8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003400 0x080180e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x080180e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x080180e8 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -395,11 +397,13 @@ ID TASK                       GEN PRI STATE
  6 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003800 0x0801a08c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003800 0x0801a09a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003800 0x0801a09a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20003800 0x0801a09a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -455,11 +459,11 @@ ID TASK                       GEN PRI STATE
  7 ping                         4   4 ready
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20003a00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20003a00 0x0801c0b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:68:10
    |      0x20003a00 0x0801c0b2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200039dc   R1 = 0x0000002e   R2 = 0x00000000   R3 = 0x00000000
@@ -515,15 +519,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200045d0 0x08022274 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20004650 0x08020578 drv_i2c_api::I2cDevice::read_reg_into
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:350
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20004650 0x080205cc drv_i2c_api::I2cDevice::read_reg_into
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:370:9
    |      0x20004650 0x080205cc task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120
-   |      0x20004800 0x08020a8c hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:91
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:140:17
+   |      0x20004800 0x08020eb2 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:298:29
    |      0x20004800 0x08020eb2 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:308:18
    |
    |
    +--->   R0 = 0x20004610   R1 = 0x200045e8   R2 = 0x00000002   R3 = 0x00000000
@@ -579,15 +583,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0803030a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080302e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080302d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0803030a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0803030a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0803030a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08031d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -643,7 +647,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.7.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008892 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008892 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008892 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a2 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq37)
    |
    +--->  0x200023c0 0x08011166 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x08010148 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x08010148 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x08010148 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x08010148 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0801169c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015a4a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x080142d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x080142d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x080142d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x080142d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x080142e4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x080142e4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x080142e4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x080142e4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080142e4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -327,17 +329,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003400 0x080180da userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003400 0x080180da userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003400 0x080180da userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x080180da userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003400 0x080180e8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003400 0x080180e8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003400 0x080180e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x080180e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x080180e8 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -393,11 +395,13 @@ ID TASK                       GEN PRI STATE
  6 pong                         0   3 recv, notif: bit0(T+314)
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003800 0x0801a08c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003800 0x0801a09a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003800 0x0801a09a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20003800 0x0801a09a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -453,11 +457,11 @@ ID TASK                       GEN PRI STATE
  7 ping                         1   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20003a00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20003a00 0x0801c0b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:68:10
    |      0x20003a00 0x0801c0b2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200039dc   R1 = 0x00000012   R2 = 0x00000000   R3 = 0x00000000
@@ -513,15 +517,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+71)
    |
    +--->  0x20004650 0x08022242 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20004800 0x08020a3c userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20004800 0x08020a18 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20004800 0x08020a04 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20004800 0x08020a3c userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20004800 0x08020a3c userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20004800 0x08020a3c main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08022ba0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200047d0
@@ -577,15 +581,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 notif: bit31(T+210)
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0803030a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080302e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080302d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0803030a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0803030a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0803030a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08031d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -641,7 +645,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 RUNNING
    |
    +--->  0x20008100 0x08038056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.8.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009dc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008892 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008892 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008892 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a2 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 RUNNING
    |
    +--->  0x200023c0 0x080111a0 userlib::sys_reply_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:326
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:332:5
    |      0x20002400 0x08010212 userlib::sys_irq_control
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:604
-   |      0x20002400 0x08010200 drv_stm32h7_usart::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:110
-   |      0x20002400 0x0801013a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:606:9
+   |      0x20002400 0x08010212 drv_stm32h7_usart::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:121:21
+   |      0x20002400 0x08010212 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:91:9
    |      0x20002400 0x08010212 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0000a007   R1 = 0x00000000   R2 = 0x200023f4   R3 = 0x00000000
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015a4a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x080142d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x080142d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x080142d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x080142d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x080142e4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x080142e4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x080142e4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x080142e4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080142e4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -327,17 +329,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x200033c0 0x08018ed2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003400 0x080180da userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003400 0x080180da userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003400 0x080180da userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x080180da userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003400 0x080180e8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003400 0x080180e8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003400 0x080180e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x080180e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x080180e8 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -393,11 +395,13 @@ ID TASK                       GEN PRI STATE
  6 pong                         0   3 recv, notif: bit0(T+462)
    |
    +--->  0x200037b8 0x0801ad1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003800 0x0801a08c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003800 0x0801a09a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003800 0x0801a09a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20003800 0x0801a09a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -453,11 +457,11 @@ ID TASK                       GEN PRI STATE
  7 ping                        40   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200039b0 0x0801cfd8 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20003a00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20003a00 0x0801c0b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:68:10
    |      0x20003a00 0x0801c0b2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200039dc   R1 = 0x0000003a   R2 = 0x00000000   R3 = 0x00000000
@@ -513,15 +517,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+211)
    |
    +--->  0x20004650 0x08022242 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20004800 0x08020a3c userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20004800 0x08020a18 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20004800 0x08020a04 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20004800 0x08020a3c userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20004800 0x08020a3c userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20004800 0x08020a3c main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08022ba0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200047d0
@@ -577,15 +581,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 notif: bit31(T+212)
    |
    +--->  0x20006280 0x08031816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0803030a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080302e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080302d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0803030a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0803030a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0803030a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08031d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -641,7 +645,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08038056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.9.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+31)
    |
    +--->  0x20013540 0x0803147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013600 0x080302b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013600 0x080302b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013600 0x080302c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013600 0x080302c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20013600 0x080302c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08031a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20014bc8 0x08048d6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014c00 0x08048074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014c00 0x08048074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014c00 0x08048082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014c00 0x08048082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:138:20
    |      0x20014c00 0x08048082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20014bd0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20014be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20014fc8 0x0804af8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20015000 0x0804a194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20015000 0x0804a194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20015000 0x0804a194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20015000 0x0804a194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20015000 0x0804a1a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20015000 0x0804a1a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20015000 0x0804a1a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20015000 0x0804a1a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20015000 0x0804a1a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20014fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20014fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001360 0x08035918 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0803451c userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0803451c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08034534 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08034534 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:138:20
    |      0x200013e8 0x08034534 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x2000137c   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 notif: bit0(irq36)
    |
    +--->  0x200122d8 0x080399ec userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20012360 0x08038a3a userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x20012360 0x08038a3a userlib::sys_recv_closed
@@ -323,17 +323,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20013ad8 0x0803e154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013c00 0x0803c68a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013c00 0x0803c68a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013c00 0x0803c68a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013c00 0x0803c68a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013c00 0x0803c69a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013c00 0x0803c69a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013c00 0x0803c69a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013c00 0x0803c69a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013c00 0x0803c69a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20013bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013bd8
@@ -389,13 +389,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d0 0x08041fa6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200042f0 0x0804067c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x20004328 0x080400e8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:742
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:773:17
    |      0x20004400 0x08040e50 main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:197
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:418:5
    |
    |
    +--->   R0 = 0x08042788   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200042d4
@@ -451,15 +451,15 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 notif: bit31(T+851)
    |
    +--->  0x20002720 0x08013c92 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002760 0x08013d02 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002760 0x08013cdc userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002760 0x08013d02 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002760 0x08013d02 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x080107ec main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:144
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:180:9
    |
    |
    +--->   R0 = 0x08014fb4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002728
@@ -515,7 +515,7 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 wait: reply from spi2_driver/gen0
    |
    +--->  0x20008118 0x0800b4de userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
    |      0x20008180 0x0800864a userlib::sys_send
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:117
    |      0x20008180 0x08008628 drv_spi_api::Spi::exchange
@@ -523,11 +523,11 @@ ID TASK                       GEN PRI STATE
    |      0x20008180 0x0800866c task_hiffy::common::spi_read
    |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:88
    |      0x20008400 0x0800928c hif::execute::function
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:297
-   |      0x20008400 0x08008fe8 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:259
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:303:13
+   |      0x20008400 0x0800928c hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:465:38
    |      0x20008400 0x0800928c main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x2000813c   R1 = 0x00000001   R2 = 0x00000100   R3 = 0x0800b9b8
@@ -583,15 +583,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 notif: bit31(T+2)
    |
    +--->  0x20010288 0x08023222 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200102c8 0x08023292 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x200102c8 0x0802326c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x200102c8 0x08023292 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x200102c8 0x08023292 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20010400 0x08020926 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:45
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:314:5
    |
    |
    +--->   R0 = 0x0802a04c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20010290
@@ -647,13 +647,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20014698 0x0804564c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20014800 0x0804426c userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20014800 0x0804426c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20014800 0x0804427c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20014800 0x0804427c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/60beca4/runtime/src/lib.rs:138:20
    |      0x20014800 0x0804427c main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x200146bc   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200147e0
@@ -709,7 +709,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20015100 0x0804c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20015100   R1 = 0x20015100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.idol.qpsi.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+35)
    |
    +--->  0x20011540 0x0802947c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20011600 0x080282b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20011600 0x080282b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20011600 0x080282c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20011600 0x080282c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20011600 0x080282c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08029a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200115dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20012bc8 0x08040d6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20012c00 0x08040074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20012c00 0x08040074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20012c00 0x08040082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20012c00 0x08040082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:138:20
    |      0x20012c00 0x08040082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20012bd0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x20012be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20012fc8 0x08042f8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20013000 0x08042194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20013000 0x08042194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20013000 0x08042194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20013000 0x08042194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20013000 0x080421a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20013000 0x080421a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20013000 0x080421a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013000 0x080421a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013000 0x080421a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20012fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20012fd8
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20001360 0x0802d918 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0802c51c userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0802c51c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x0802c534 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x0802c534 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:138:20
    |      0x200013e8 0x0802c534 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x2000137c   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001384
@@ -255,7 +255,7 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x20010360 0x080319ec userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200103e8 0x080304e2 userlib::sys_recv
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
    |      0x200103e8 0x080304e2 idol_runtime::dispatch
@@ -317,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20011ad8 0x08036154 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20011c00 0x0803468a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20011c00 0x0803468a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20011c00 0x0803468a userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20011c00 0x0803468a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20011c00 0x0803469a userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20011c00 0x0803469a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20011c00 0x0803469a userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20011c00 0x0803469a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20011c00 0x0803469a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20011bc8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20011bd8
@@ -383,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x200042d8 0x08039ed2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200042f8 0x0803867c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x20004330 0x080380e8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:716
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:747:17
    |      0x20004400 0x08038d9e main
-   |                 @ /home/bmc/hubris/task/spd/src/main.rs:86
+   |                 @ /home/bmc/hubris/task/spd/src/main.rs:388:5
    |
    |
    +--->   R0 = 0x0803a650   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200042dc
@@ -445,15 +445,15 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 notif: bit31(T+382)
    |
    +--->  0x20002718 0x0801397a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002758 0x080139ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002758 0x080139c4 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002758 0x080139ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002758 0x080139ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x080106b6 main
-   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:76
+   |                 @ /home/bmc/hubris/task/thermal/src/main.rs:127:9
    |
    |
    +--->   R0 = 0x08014c94   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002720
@@ -509,23 +509,23 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        1   3 FAULT:  (was: ready)
    |
    +--->  0x20008440 0x0800b53a userlib::sys_panic_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:686
-   |      0x200084f0 0x0800b582 userlib::sys_panic
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:678
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:687:5
+   |      0x200084f0 0x0800b588 userlib::sys_panic
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:679:14
    |      0x200084f0 0x0800b588 rust_begin_unwind
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:863
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:885:5
    |      0x20008508 0x0800a4ba core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x20008530 0x0800aa34 core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20008580 0x08008b2c task_hiffy::common::qspi_page_program
    |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:202
    |      0x20008800 0x0800928c hif::execute::function
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:297
-   |      0x20008800 0x08008fe8 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:259
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:303:13
+   |      0x20008800 0x0800928c hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:465:38
    |      0x20008800 0x0800928c main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x0800c60c   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x0800b323
@@ -584,15 +584,15 @@ ID TASK                       GEN PRI STATE
  9 gimlet_seq                   0   3 notif: bit31(T+3)
    |
    +--->  0x20013298 0x0802138e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x200132d8 0x080213fe userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x200132d8 0x080213d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x200132d8 0x080213fe userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x200132d8 0x080213fe userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20013400 0x080203f8 main
-   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:22
+   |                 @ /home/bmc/hubris/drv/gimlet-seq-server/src/main.rs:224:5
    |
    |
    +--->   R0 = 0x080273ac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200132a0
@@ -648,13 +648,13 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 recv
    |
    +--->  0x20012698 0x0803d64c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20012800 0x0803c26c userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20012800 0x0803c26c idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:131
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20012800 0x0803c27c userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20012800 0x0803c27c idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/ec1047c/runtime/src/lib.rs:138:20
    |      0x20012800 0x0803c27c main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:315:9
    |
    |
    +--->   R0 = 0x200126bc   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200127e0
@@ -710,7 +710,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20013500 0x08044056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20013500   R1 = 0x20013500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.rick.0.stdout
@@ -3,29 +3,29 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x200015c0 0x080081fa <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1635
-   |      0x200015c0 0x080081f2 <&mut ssmarshal::Deserializer as serde::de::EnumAccess>::variant_seed
-   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:778
-   |      0x200015c0 0x080081f2 serde::de::EnumAccess::variant
-   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.129/src/de/mod.rs:1978
-   |      0x200015c0 0x080081f2 <abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize::__Visitor as serde::de::Visitor>::visit_enum
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/abi/src/lib.rs:297
-   |      0x200015c0 0x080081f2 <&mut ssmarshal::Deserializer as serde::de::Deserializer>::deserialize_enum
-   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:732
-   |      0x200015c0 0x080081f2 abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/abi/src/lib.rs:297
-   |      0x200015c0 0x080081ee ssmarshal::deserialize
-   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:130
-   |      0x200015c0 0x080081e6 userlib::kipc::read_task_status
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/kipc.rs:7
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1636:9
+   |      0x200015c0 0x080081fa <&mut ssmarshal::Deserializer as serde::de::EnumAccess>::variant_seed
+   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:779:21
+   |      0x200015c0 0x080081fa serde::de::EnumAccess::variant
+   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.129/src/de/mod.rs:1982:9
+   |      0x200015c0 0x080081fa <abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize::__Visitor as serde::de::Visitor>::visit_enum
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/abi/src/lib.rs:297:45
+   |      0x200015c0 0x080081fa <&mut ssmarshal::Deserializer as serde::de::Deserializer>::deserialize_enum
+   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:737:9
+   |      0x200015c0 0x080081fa abi::_::<impl serde::de::Deserialize for abi::TaskState>::deserialize
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/abi/src/lib.rs:297:45
+   |      0x200015c0 0x080081fa ssmarshal::deserialize
+   |                 @ /home/kc8apf/.cargo/registry/src/github.com-1ecc6299db9ec823/ssmarshal-1.0.0/src/lib.rs:132:15
+   |      0x200015c0 0x080081fa userlib::kipc::read_task_status
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/kipc.rs:14:5
    |      0x200015c0 0x080081fa task_jefe::check_tasks
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:89
-   |      0x20001600 0x0800890a task_jefe::main::{{closure}}
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:150
-   |      0x20001600 0x0800889c userlib::hl::recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:79
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:94:15
+   |      0x20001600 0x08008916 task_jefe::main::{{closure}}
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:152:21
+   |      0x20001600 0x08008916 userlib::hl::recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:92:9
    |      0x20001600 0x08008916 main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x20001580   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000001
@@ -81,15 +81,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:212
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:79
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:117
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:272:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:238:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:172:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:89:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:124:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -145,17 +147,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
-   |      0x20002000 0x0800e166 userlib::sys_recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:212
-   |      0x20002000 0x0800e166 userlib::sys_recv_open
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:168
-   |      0x20002000 0x0800e166 userlib::hl::recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:79
-   |      0x20002000 0x0800e166 userlib::hl::recv_without_notification
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:117
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:272:5
+   |      0x20002000 0x0800e176 userlib::sys_recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:238:5
+   |      0x20002000 0x0800e176 userlib::sys_recv_open
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:172:11
+   |      0x20002000 0x0800e176 userlib::hl::recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:89:14
+   |      0x20002000 0x0800e176 userlib::hl::recv_without_notification
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:124:5
    |      0x20002000 0x0800e176 main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -211,15 +213,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
-   |      0x20002400 0x0801018e userlib::sys_recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:212
-   |      0x20002400 0x0801018e userlib::sys_recv_open
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:168
-   |      0x20002400 0x0801018e userlib::hl::recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:79
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:272:5
+   |      0x20002400 0x0801019e userlib::sys_recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:238:5
+   |      0x20002400 0x0801019e userlib::sys_recv_open
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:172:11
+   |      0x20002400 0x0801019e userlib::hl::recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:89:14
    |      0x20002400 0x0801019e main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x080114f0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -275,17 +277,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801622a userlib::sys_recv_stub
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:265
-   |      0x20002c00 0x080144ce userlib::sys_recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:212
-   |      0x20002c00 0x080144ce userlib::sys_recv_open
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:168
-   |      0x20002c00 0x080144ce userlib::hl::recv
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x080144ce userlib::hl::recv_without_notification
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:117
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:272:5
+   |      0x20002c00 0x080144de userlib::sys_recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:238:5
+   |      0x20002c00 0x080144de userlib::sys_recv_open
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:172:11
+   |      0x20002c00 0x080144de userlib::hl::recv
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x080144de userlib::hl::recv_without_notification
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x080144de main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-i2c-server/src/main.rs:179
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-i2c-server/src/main.rs:508:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -341,29 +343,29 @@ ID TASK                       GEN PRI STATE
  5 spd                         14   2 FAULT: panicked at 'called `Result::unwrap()` on an `Err` value: BadArg', drv/stm32h7-rcc-api/src/lib.rs:56:50 (was: ready)
    |
    +--->  0x20003268 0x080198e6 userlib::sys_panic_stub
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:655
-   |      0x20003318 0x0801992e userlib::sys_panic
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:646
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:656:5
+   |      0x20003318 0x08019934 userlib::sys_panic
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:647:14
    |      0x20003318 0x08019934 rust_begin_unwind
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:833
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:855:5
    |      0x20003330 0x0801892a core::panicking::panic_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:92:14
    |      0x20003370 0x08019122 core::result::unwrap_failed
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/result.rs:1354
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1355:5
    |      0x20003380 0x080195b8 core::result::Result<T,E>::unwrap
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1034
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/result.rs:1037:23
    |      0x200033d0 0x08019506 core::cell::Cell<T>::get
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/cell.rs:433
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/cell.rs:436:18
    |      0x200033d0 0x08019506 userlib::hl::send_with_retry
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:504
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/hl.rs:525:27
    |      0x200033d0 0x08019506 drv_stm32h7_rcc_api::Rcc::leave_reset_raw
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc-api/src/lib.rs:143
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc-api/src/lib.rs:154:9
    |      0x200033d0 0x08019506 drv_stm32h7_rcc_api::Rcc::leave_reset
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc-api/src/lib.rs:137
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-rcc-api/src/lib.rs:140:9
    |      0x200033d0 0x08019506 drv_stm32h7_i2c::I2cController::enable
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-i2c/src/lib.rs:182
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/drv/stm32h7-i2c/src/lib.rs:184:9
    |      0x20003400 0x080186c0 main
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-spd/src/main.rs:53
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/task-spd/src/main.rs:119:5
    |
    |
    +--->   R0 = 0x20003270   R1 = 0x00000067   R2 = 0x00000000   R3 = 0x00000001
@@ -422,7 +424,7 @@ ID TASK                       GEN PRI STATE
  6 spi2_driver                  0   2 ready
    |
    +--->  0x200043e8 0x0801c001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -478,7 +480,7 @@ ID TASK                       GEN PRI STATE
  7 spi4_driver                  0   2 ready
    |
    +--->  0x200053e8 0x08020001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -534,7 +536,7 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 ready
    |
    +--->  0x20006400 0x08024001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -590,7 +592,7 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20006800 0x08026001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -646,7 +648,7 @@ ID TASK                       GEN PRI STATE
 10 thermal                      0   3 ready
    |
    +--->  0x20008800 0x08030001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -702,7 +704,7 @@ ID TASK                       GEN PRI STATE
 11 power                        0   3 ready
    |
    +--->  0x2000a800 0x08040001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -758,7 +760,7 @@ ID TASK                       GEN PRI STATE
 12 hiffy                        0   3 ready
    |
    +--->  0x2000c800 0x08050001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -814,7 +816,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x20010100 0x08058001 _start
-   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:766
+   |                 @ /home/kc8apf/Projects/oxidecomputer/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.kiowa.stm32h743-nucleo.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+7)
    |
    +--->  0x20004540 0x08011480 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004600 0x080102ba userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004600 0x080102ba userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004600 0x080102cc userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004600 0x080102cc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20004600 0x080102cc main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08011a64   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200045dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005400 0x08020074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005400 0x08020074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005400 0x08020082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005400 0x08020082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20005400 0x08020082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x200053d0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x200053e0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005800 0x08022194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005800 0x08022194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005800 0x08022194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20005800 0x08022194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005800 0x080221a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005800 0x080221a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005800 0x080221a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20005800 0x080221a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20005800 0x080221a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x200057d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200057d8
@@ -193,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005c00 0x08024174 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005c00 0x08024174 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005c00 0x08024174 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005c00 0x08024182 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005c00 0x08024182 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005c00 0x08024182 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
    |      0x20005c00 0x08024182 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:97:9
    |
    |
    +--->   R0 = 0x08025404   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20005bd8
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004c00 0x08014430 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004c00 0x08014430 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20004c00 0x08014430 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20004c00 0x08014430 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004c00 0x08014440 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004c00 0x08014440 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20004c00 0x08014440 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20004c00 0x08014440 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20004c00 0x08014440 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20004bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -323,13 +323,13 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20001360 0x08019954 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x200013e8 0x0801851a userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x200013e8 0x0801851a idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x200013e8 0x08018532 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x200013e8 0x08018532 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x200013e8 0x08018532 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:124:9
    |
    |
    +--->   R0 = 0x2000137c   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001384
@@ -385,13 +385,13 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006000 0x08026128 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20006000 0x08026128 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006000 0x08026136 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006000 0x08026136 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20006000 0x08026136 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:110
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x20005fc8   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20005fd8
@@ -447,11 +447,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+207)
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006400 0x080280ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006400 0x080280ba userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006400 0x080280ba userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20006400 0x080280ba main
-   |                 @ /home/bmc/hubris/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x200063c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200063d8
@@ -507,19 +509,19 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+207)
    |
    +--->  0x20008540 0x0800b12e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20008580 0x0800b19e userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20008580 0x0800b178 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20008580 0x0800b19e userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x0800b19e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008800 0x08008cac core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x08008cac core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x08008cac main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x0800c1dc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -575,15 +577,15 @@ ID TASK                       GEN PRI STATE
  9 hf                           0   3 notif: bit31(T+718)
    |
    +--->  0x20002658 0x0801d660 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002698 0x0801d6ce userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002698 0x0801d6a8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002698 0x0801d6ce userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002698 0x0801d6ce userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x0801c234 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:301:13
    |
    |
    +--->   R0 = 0x0801dd18   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002660
@@ -639,7 +641,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 RUNNING
    |
    +--->  0x20006500 0x0802a056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20006500   R1 = 0x20006500   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.new-ringbuf.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.new-ringbuf.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+79)
    |
    +--->  0x2403a4f0 0x0800971a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403a600 0x0800830e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403a600 0x0800830e idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403a600 0x0800831c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403a600 0x0800831c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2403a600 0x0800831c main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x2403a598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x2403a5d8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x24001f48 0x08006632 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24001f80 0x0800618c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24001f80 0x0800618c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24001f80 0x0800619a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24001f80 0x0800619a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24001f80 0x0800619a main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24001f50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x24001f58
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 spi1_driver                  0   2 recv
    |
    +--->  0x2403ab08 0x0800de4e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403ab70 0x0800c5a0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403ab70 0x0800c5a0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403ab70 0x0800c5ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403ab70 0x0800c5ba idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2403ab70 0x0800c5ba main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403ab22   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403ab24
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi2_driver                  0   2 recv
    |
    +--->  0x2403b308 0x080a1d6e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403b370 0x080a05fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403b370 0x080a05fe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403b370 0x080a0618 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403b370 0x080a0618 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2403b370 0x080a0618 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403b322   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403b324
@@ -235,13 +235,13 @@ ID TASK                       GEN PRI STATE
  4 spi3_driver                  0   2 recv
    |
    +--->  0x24032380 0x080a5d72 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x240323e8 0x080a4600 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x240323e8 0x080a4600 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x240323e8 0x080a461a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x240323e8 0x080a461a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x240323e8 0x080a461a main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403239a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403239c
@@ -293,13 +293,13 @@ ID TASK                       GEN PRI STATE
  5 spi4_driver                  0   3 recv
    |
    +--->  0x2403bb00 0x080a9d6e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403bb68 0x080a85fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403bb68 0x080a85fe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403bb68 0x080a8618 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403bb68 0x080a8618 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2403bb68 0x080a8618 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403bb1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403bb1c
@@ -351,13 +351,13 @@ ID TASK                       GEN PRI STATE
  6 spi5_driver                  0   2 recv
    |
    +--->  0x2403c308 0x080ade4e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403c370 0x080ac5a0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403c370 0x080ac5a0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403c370 0x080ac5ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403c370 0x080ac5ba idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2403c370 0x080ac5ba main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403c322   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403c324
@@ -409,13 +409,13 @@ ID TASK                       GEN PRI STATE
  7 update_server                0   3 recv
    |
    +--->  0x240333b8 0x080b14b2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24033800 0x080b01be userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24033800 0x080b01be idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24033800 0x080b01ce userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24033800 0x080b01ce idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24033800 0x080b01ce main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:394
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:404:9
    |
    |
    +--->   R0 = 0x240333dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240333e0
@@ -467,13 +467,13 @@ ID TASK                       GEN PRI STATE
  8 auxflash                     0   3 recv
    |
    +--->  0x24034c20 0x08073674 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24034db0 0x080705d8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24034db0 0x080705d8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24034db0 0x080705e8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24034db0 0x080705e8 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24034db0 0x080705e8 main
-   |                 @ /hubris/drv/auxflash-server/src/main.rs:54
+   |                 @ /hubris/drv/auxflash-server/src/main.rs:137:9
    |
    |
    +--->   R0 = 0x24034c68   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24034ca4
@@ -525,13 +525,13 @@ ID TASK                       GEN PRI STATE
  9 net                          0   5 recv, notif: bit0(irq61) bit2(T+84)
    |
    +--->  0x240108d0 0x080309b4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24010b50 0x0802012e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24010b50 0x08020142 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
    |      0x24010b50 0x08020142 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24011798 0x08028a98 main
-   |                 @ /hubris/task/net/src/main.rs:151
+   |                 @ /hubris/task/net/src/main.rs:275:13
    |
    |
    +--->   R0 = 0x240114f8   R1 = 0x00000020   R2 = 0x00000005   R3 = 0x240109e8
@@ -583,13 +583,13 @@ ID TASK                       GEN PRI STATE
 10 control_plane_agent          0   7 recv, notif: bit0 bit1 bit2
    |
    +--->  0x240024e8 0x08019524 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24002a00 0x08014214 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24002a00 0x08014214 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24002a00 0x08014224 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24002a00 0x08014224 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24002a00 0x08014224 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:127
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:133:9
    |
    |
    +--->   R0 = 0x24002714   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24002830
@@ -641,13 +641,13 @@ ID TASK                       GEN PRI STATE
 11 sprot                        0   4 recv
    |
    +--->  0x2400b6b8 0x0807b080 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2400c000 0x08078416 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2400c000 0x08078416 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2400c000 0x08078426 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2400c000 0x08078426 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2400c000 0x08078426 main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:136
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:153:9
    |
    |
    +--->   R0 = 0x2400b708   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2400bfa0
@@ -699,13 +699,13 @@ ID TASK                       GEN PRI STATE
 12 udpecho                      0   6 notif: bit0
    |
    +--->  0x24004e40 0x0800b720 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24005000 0x0800a5e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24005000 0x0800a5e2 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24005000 0x0800a5f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24005000 0x0800a5f0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x24005000 0x0800a5f0 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x0800bda8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24004f90
@@ -757,13 +757,15 @@ ID TASK                       GEN PRI STATE
 13 udpbroadcast                 0   6 notif: bit31(T+349)
    |
    +--->  0x24006f50 0x080cd3fe userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24007000 0x080cc1b2 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24007000 0x080cc174 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24007000 0x080cc1b2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24007000 0x080cc1b2 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24007000 0x080cc1b2 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:47:9
    |
    |
    +--->   R0 = 0x080cda14   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24006fac
@@ -815,13 +817,13 @@ ID TASK                       GEN PRI STATE
 14 udprpc                       0   6 notif: bit0
    |
    +--->  0x24028668 0x080b5e14 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24029000 0x080b4236 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24029000 0x080b4236 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24029000 0x080b4246 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24029000 0x080b4246 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x24029000 0x080b4246 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:149:17
    |
    |
    +--->   R0 = 0x080b6644   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24028fb0
@@ -873,13 +875,13 @@ ID TASK                       GEN PRI STATE
 15 monorail                     2   6 recv, notif: bit0(T+9)
    |
    +--->  0x2402af48 0x0804dde6 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402b000 0x0804a386 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402b000 0x0804a386 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402b000 0x0804a394 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402b000 0x0804a394 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2402b000 0x0804a394 main
-   |                 @ /hubris/task/monorail-server/src/main.rs:38
+   |                 @ /hubris/task/monorail-server/src/main.rs:77:9
    |
    |
    +--->   R0 = 0x2402afd0   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x2402afe0
@@ -931,17 +933,17 @@ ID TASK                       GEN PRI STATE
 16 i2c_driver                   0   2 recv
    |
    +--->  0x2403ca40 0x080ba67c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403cb80 0x080b8856 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403cb80 0x080b8856 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:237
-   |      0x2403cb80 0x080b8856 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x2403cb80 0x080b8856 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403cb80 0x080b8866 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403cb80 0x080b8866 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:241:11
+   |      0x2403cb80 0x080b8866 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x2403cb80 0x080b8866 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x2403cb80 0x080b8866 main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:200
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229:9
    |
    |
    +--->   R0 = 0x2403cb44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2403cb58
@@ -993,19 +995,19 @@ ID TASK                       GEN PRI STATE
 17 hiffy                        0   5 notif: bit31(T+239)
    |
    +--->  0x24020228 0x08083784 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24020270 0x08083800 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24020270 0x080837c6 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24020270 0x08083800 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24020270 0x08083800 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24020400 0x08080d96 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24020400 0x08080d96 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24020400 0x08080d96 main
-   |                 @ /hubris/task/hiffy/src/main.rs:125
+   |                 @ /hubris/task/hiffy/src/main.rs:142:9
    |
    |
    +--->   R0 = 0x080847e8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24020234
@@ -1057,13 +1059,13 @@ ID TASK                       GEN PRI STATE
 18 sensor                       0   4 recv, notif: bit0(T+580)
    |
    +--->  0x2403d368 0x080ceec4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2403d780 0x080ce0ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2403d780 0x080ce0ac idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2403d780 0x080ce0ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2403d780 0x080ce0ba idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2403d780 0x080ce0ba main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x2403d768   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x2403d570
@@ -1115,13 +1117,13 @@ ID TASK                       GEN PRI STATE
 19 ecp5_mainboard               0   3 recv
    |
    +--->  0x240354b8 0x0808b3b8 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24035800 0x08088af0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24035800 0x08088ae8 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24035800 0x08088b06 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24035800 0x08088b06 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24035800 0x08088b06 main
-   |                 @ /hubris/drv/fpga-server/src/main.rs:43
+   |                 @ /hubris/drv/fpga-server/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24035534   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x240355e8
@@ -1173,13 +1175,13 @@ ID TASK                       GEN PRI STATE
 20 ecp5_front_io                0   3 recv
    |
    +--->  0x240364c8 0x08093828 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24036800 0x08090b4e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24036800 0x08090b46 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24036800 0x08090b64 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24036800 0x08090b64 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24036800 0x08090b64 main
-   |                 @ /hubris/drv/fpga-server/src/main.rs:43
+   |                 @ /hubris/drv/fpga-server/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24036534   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x240365e8
@@ -1231,13 +1233,13 @@ ID TASK                       GEN PRI STATE
 21 transceivers                 0   6 recv, notif: bit0 bit1(T+131)
    |
    +--->  0x2402c578 0x0809d8b4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402c800 0x08099a90 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402c800 0x08099a90 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402c800 0x08099a9e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402c800 0x08099a9e idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2402c800 0x08099a9e main
-   |                 @ /hubris/drv/transceivers-server/src/main.rs:316
+   |                 @ /hubris/drv/transceivers-server/src/main.rs:374:13
    |
    |
    +--->   R0 = 0x2402c638   R1 = 0x00000006   R2 = 0x00000003   R3 = 0x2402c640
@@ -1289,13 +1291,13 @@ ID TASK                       GEN PRI STATE
 22 sequencer                    0   4 recv, notif: bit0(T+225)
    |
    +--->  0x2402ee98 0x08067a4c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402f000 0x08060d18 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402f000 0x08060d18 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402f000 0x08060d28 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402f000 0x08060d28 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2402f000 0x08060d28 main
-   |                 @ /hubris/drv/sidecar-seq-server/src/main.rs:422
+   |                 @ /hubris/drv/sidecar-seq-server/src/main.rs:607:9
    |
    |
    +--->   R0 = 0x2402eedc   R1 = 0x0000000c   R2 = 0x00000001   R3 = 0x2402ef50
@@ -1347,13 +1349,13 @@ ID TASK                       GEN PRI STATE
 23 thermal                      0   5 recv, notif: bit0(T+228)
    |
    +--->  0x24030fd8 0x080bed7e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24031198 0x080bcef8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24031198 0x080bcef8 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24031198 0x080bcf06 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24031198 0x080bcf06 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24031198 0x080bcf06 main
-   |                 @ /hubris/task/thermal/src/main.rs:275
+   |                 @ /hubris/task/thermal/src/main.rs:301:9
    |
    |
    +--->   R0 = 0x240310f0   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x24031100
@@ -1405,15 +1407,15 @@ ID TASK                       GEN PRI STATE
 24 power                        0   6 notif: bit31(T+274)
    |
    +--->  0x240377a8 0x080c2852 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24037800 0x080c026a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24037800 0x080c0230 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
-   |      0x24037800 0x080c0206 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24037800 0x080c026a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24037800 0x080c026a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24037800 0x080c026a main
-   |                 @ /hubris/task/power/src/main.rs:380
+   |                 @ /hubris/task/power/src/main.rs:390:9
    |
    |
    +--->   R0 = 0x080c3514   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240377d8
@@ -1465,13 +1467,13 @@ ID TASK                       GEN PRI STATE
 25 validate                     0   5 recv
    |
    +--->  0x240383b0 0x080c5a26 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x240383e8 0x080c4248 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x240383e8 0x080c4248 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x240383e8 0x080c4258 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x240383e8 0x080c4258 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x240383e8 0x080c4258 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x240383b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240383c0
@@ -1523,13 +1525,13 @@ ID TASK                       GEN PRI STATE
 26 ignition                     0   5 recv, notif: bit0(T+226)
    |
    +--->  0x24039508 0x080c9ca4 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039800 0x080c84ea userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039800 0x080c84ea idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039800 0x080c84fc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039800 0x080c84fc idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24039800 0x080c84fc main
-   |                 @ /hubris/drv/ignition-server/src/main.rs:39
+   |                 @ /hubris/drv/ignition-server/src/main.rs:75:9
    |
    |
    +--->   R0 = 0x24039556   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x240396b0
@@ -1581,7 +1583,7 @@ ID TASK                       GEN PRI STATE
 27 idle                         0   8 RUNNING
    |
    +--->  0x24001a00 0x08005952 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x24001a00   R1 = 0x24001a00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.new-sensors.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.new-sensors.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+63)
    |
    +--->  0x24002520 0x0800973e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24002600 0x08008308 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24002600 0x08008308 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24002600 0x08008316 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24002600 0x08008316 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24002600 0x08008316 main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24002598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x240025d8
@@ -61,7 +61,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   9 RUNNING
    |
    +--->  0x24002900 0x0800a052 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x24002900   R1 = 0x24002900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.nightly-2022-11-01.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.nightly-2022-11-01.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+14)
    |
    +--->  0x240334f8 0x0808d736 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24033600 0x0808c30c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24033600 0x0808c30c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24033600 0x0808c31a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24033600 0x0808c31a idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24033600 0x0808c31a main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24033598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x240335b8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                         82   5 recv, notif: bit0(irq61) bit2(T+145)
    |
    +--->  0x24008ab0 0x0803071c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24008d30 0x0802012e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24008d30 0x08020142 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
    |      0x24008d30 0x08020142 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24009798 0x080287f6 main
-   |                 @ /hubris/task/net/src/main.rs:151
+   |                 @ /hubris/task/net/src/main.rs:275:13
    |
    |
    +--->   R0 = 0x24009560   R1 = 0x00000020   R2 = 0x00000005   R3 = 0x24008bc8
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x24035b48 0x08096632 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24035b80 0x0809618c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24035b80 0x0809618c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24035b80 0x0809619a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24035b80 0x0809619a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24035b80 0x0809619a main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24035b50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x24035b58
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x24033b00 0x08061d6e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24033b68 0x080605fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24033b68 0x080605fe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24033b68 0x08060618 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24033b68 0x08060618 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24033b68 0x08060618 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x24033b1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24033b1c
@@ -235,13 +235,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x24034300 0x08065eb2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24034368 0x080645c0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24034368 0x080645c0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24034368 0x080645da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24034368 0x080645da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24034368 0x080645da main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403431a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403431c
@@ -293,17 +293,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 recv
    |
    +--->  0x24034a58 0x0806a608 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24034b80 0x080687bc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24034b80 0x080687bc userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:237
-   |      0x24034b80 0x080687bc userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x24034b80 0x080687bc userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24034b80 0x080687cc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24034b80 0x080687cc userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:241:11
+   |      0x24034b80 0x080687cc userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x24034b80 0x080687cc userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x24034b80 0x080687cc main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:200
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229:9
    |
    |
    +--->   R0 = 0x24034b44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24034b58
@@ -355,19 +355,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x24004290 0x0806e370 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x240042b0 0x0806c7fc core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x240042e8 0x0806c118 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x240042e8 0x0806c118 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240042e8 0x0806c118 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240042e8 0x0806c118 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:774
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:823:17
    |      0x24004380 0x0806d078 main
-   |                 @ /hubris/task/spd/src/main.rs:203
+   |                 @ /hubris/task/spd/src/main.rs:420:5
    |
    |
    +--->   R0 = 0x0806eaa4   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24004294
@@ -419,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: bit0(T+608)
    |
    +--->  0x24002738 0x0800b076 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24003198 0x08008fe6 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24003198 0x08008fe6 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24003198 0x08008ff4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24003198 0x08008ff4 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24003198 0x08008ff4 main
-   |                 @ /hubris/task/thermal/src/main.rs:275
+   |                 @ /hubris/task/thermal/src/main.rs:301:9
    |
    |
    +--->   R0 = 0x24002bcc   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x24002be8
@@ -477,15 +477,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 notif: bit31(T+349)
    |
    +--->  0x2402c390 0x08072a1e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x2402c3e8 0x0807026a userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x2402c3e8 0x08070230 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
-   |      0x2402c3e8 0x08070206 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x2402c3e8 0x0807026a userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x2402c3e8 0x0807026a userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x2402c3e8 0x0807026a main
-   |                 @ /hubris/task/power/src/main.rs:380
+   |                 @ /hubris/task/power/src/main.rs:390:9
    |
    |
    +--->   R0 = 0x080739e8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2402c3c0
@@ -537,19 +537,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+108)
    |
    +--->  0x24010228 0x08055504 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24010270 0x08055580 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24010270 0x08055546 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24010270 0x08055580 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24010270 0x08055580 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24010400 0x08052652 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24010400 0x08052652 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24010400 0x08052652 main
-   |                 @ /hubris/task/hiffy/src/main.rs:122
+   |                 @ /hubris/task/hiffy/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x08056f48   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24010234
@@ -601,13 +601,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x2402d4d8 0x08013142 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402d640 0x08010a52 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402d640 0x08010a52 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402d640 0x08010a62 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402d640 0x08010a62 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x2402d640 0x08010a62 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:66
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:345:9
    |
    |
    +--->   R0 = 0x2402d507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x2402d520
@@ -659,13 +659,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x2402e540 0x080757ba userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402e800 0x080742dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402e800 0x080742dc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402e800 0x080742ec userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402e800 0x080742ec idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2402e800 0x080742ec main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x2402e55c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2402e7d4
@@ -717,13 +717,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x240355c8 0x08079eac userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24035780 0x08078376 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24035780 0x08078376 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24035780 0x08078386 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24035780 0x08078386 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24035780 0x08078386 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:78
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x24035610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24035730
@@ -775,13 +775,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x2402f3b8 0x0807d4b2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402f800 0x0807c1be userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402f800 0x0807c1be idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402f800 0x0807c1ce userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402f800 0x0807c1ce idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2402f800 0x0807c1ce main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:394
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:404:9
    |
    |
    +--->   R0 = 0x2402f3dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2402f3e0
@@ -833,13 +833,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: bit0(T+214)
    |
    +--->  0x24030660 0x0808eed0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24030ed8 0x0808e0ae userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24030ed8 0x0808e0ae idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24030ed8 0x0808e0bc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24030ed8 0x0808e0bc idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24030ed8 0x0808e0bc main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x24030ec0   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x24030a98
@@ -891,13 +891,13 @@ ID TASK                       GEN PRI STATE
 15 host_sp_comms                0   7 recv, notif: bit0(irq82) bit1 bit2(T+3) bit3
    |
    +--->  0x24020650 0x08083108 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24020800 0x08080b64 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24020800 0x08080b64 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24020800 0x08080b74 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24020800 0x08080b74 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24020800 0x08080b74 main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:120
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:130:9
    |
    |
    +--->   R0 = 0x24020738   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24020740
@@ -949,13 +949,13 @@ ID TASK                       GEN PRI STATE
 16 udpecho                      0   6 notif: bit0
    |
    +--->  0x24028e40 0x08091724 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24029000 0x080905e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24029000 0x080905e2 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24029000 0x080905f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24029000 0x080905f0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x24029000 0x080905f0 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x08091dac   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24028f90
@@ -1007,13 +1007,15 @@ ID TASK                       GEN PRI STATE
 17 udpbroadcast                82   6 notif: bit31(T+171)
    |
    +--->  0x24031750 0x080933fe userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24031800 0x080921b2 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24031800 0x08092174 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24031800 0x080921b2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24031800 0x080921b2 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24031800 0x080921b2 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:47:9
    |
    |
    +--->   R0 = 0x08093a14   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240317ac
@@ -1065,13 +1067,13 @@ ID TASK                       GEN PRI STATE
 18 udprpc                       0   6 notif: bit0
    |
    +--->  0x2402a668 0x08085e18 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402b000 0x08084236 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402b000 0x08084236 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402b000 0x08084246 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402b000 0x08084246 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x2402b000 0x08084246 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:149:17
    |
    |
    +--->   R0 = 0x08086640   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2402afb0
@@ -1123,13 +1125,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: bit0 bit1(irq37) bit2
    |
    +--->  0x24024518 0x08048346 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24024a00 0x08044660 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24024a00 0x08044660 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24024a00 0x08044670 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24024a00 0x08044670 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:269:20
    |      0x24024a00 0x08044670 main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:127
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:133:9
    |
    |
    +--->   R0 = 0x24024720   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24024850
@@ -1181,13 +1183,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x2401b6b8 0x0805b080 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2401c000 0x08058416 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2401c000 0x08058416 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2401c000 0x08058426 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2401c000 0x08058426 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x2401c000 0x08058426 main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:136
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:153:9
    |
    |
    +--->   R0 = 0x2401b708   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2401bfa0
@@ -1239,13 +1241,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240323b0 0x08089d1a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x240323e8 0x08088248 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x240323e8 0x08088248 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x240323e8 0x08088258 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x240323e8 0x08088258 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x240323e8 0x08088258 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x240323b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240323c0
@@ -1297,13 +1299,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x24035e08 0x08095400 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24035f20 0x0809407a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24035f20 0x0809407a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24035f20 0x08094088 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24035f20 0x08094088 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f01add5/runtime/src/lib.rs:193:20
    |      0x24035f20 0x08094088 main
-   |                 @ /hubris/task/vpd/src/main.rs:115
+   |                 @ /hubris/task/vpd/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x24035e40   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24035e50
@@ -1355,7 +1357,7 @@ ID TASK                       GEN PRI STATE
 23 idle                         0   8 RUNNING
    |
    +--->  0x24036100 0x08096852 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x24036100   R1 = 0x24036100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x080154f6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x08014238 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x08014238 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x08014238 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x08014238 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x08014248 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x08014248 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x08014248 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x08014248 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x08014248 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:187
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:197:9
    |
    |
    +--->   R0 = 0x200023d4   R1 = 0x00000003   R2 = 0x00000000   R3 = 0x200023d8
@@ -245,17 +247,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x200027c8 0x08018e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002800 0x080180d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002800 0x080180d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002800 0x080180d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x080180d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002800 0x080180e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002800 0x080180e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002800 0x080180e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x080180e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002800 0x080180e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200027cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027d8
@@ -295,11 +297,13 @@ ID TASK                       GEN PRI STATE
  6 pong                         0   3 recv, notif: bit0(T+110)
    |
    +--->  0x20002bb8 0x0801ad36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002c00 0x0801a08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20002c00 0x0801a098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20002bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002bd8
@@ -339,11 +343,11 @@ ID TASK                       GEN PRI STATE
  7 ping                         4   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20002da8 0x0801cf50 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20002e00 0x0801c090 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20002e00 0x0801c0b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:68:10
    |      0x20002e00 0x0801c0b2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x20002ddc   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x00000000
@@ -383,15 +387,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 notif: bit31(T+110)
    |
    +--->  0x20005fa0 0x080216c6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x08020260 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020242 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x0802022e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x08020260 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x08020260 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x08020260 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:76
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:79:9
    |
    |
    +--->   R0 = 0x08021c80   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fd0

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x0801425a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x0801425a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x0801425a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x0801425a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x0801426a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x0801426a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x0801426a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x0801426a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x0801426a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:174
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:184:9
    |
    |
    +--->   R0 = 0x200023d4   R1 = 0x00000003   R2 = 0x00000000   R3 = 0x200023d8
@@ -278,17 +280,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -328,11 +330,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -372,15 +376,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 ready
    |
    +--->  0x20005fa0 0x080216c6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x08020260 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020242 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x0802022e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x08020260 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x08020260 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x08020260 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:76
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:79:9
    |
    |
    +--->   R0 = 0x08021c80   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fd0
@@ -420,15 +424,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 ready
    |
    +--->  0x2000ff80 0x08024f88 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010000 0x080244ee userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20010000 0x080244d4 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20010000 0x080244bc userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20010000 0x080244ee userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20010000 0x080244ee userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010000 0x080244ee main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:168
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:183:9
    |
    |
    +--->   R0 = 0x08025298   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff9c
@@ -468,7 +472,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20010100 0x08026052 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20010000   R1 = 0x20010000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.10.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001400 0x080101ca userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001400 0x080101c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080101da userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080101da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20001400 0x080101da main
-   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x08012454   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001800 0x0801806e userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001800 0x0801806e userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20001800 0x0801806e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0801807c userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0801807c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0801807c userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0801807c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20001800 0x0801807c main
-   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:100
+   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:114:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -130,15 +132,17 @@ ID TASK                       GEN PRI STATE
  3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002000 0x0802009c userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20002000 0x0802009c userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20002000 0x0802009c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002000 0x080200aa userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002000 0x080200aa userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20002000 0x080200aa userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20002000 0x080200aa userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20002000 0x080200aa main
-   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20001fc4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001fdc
@@ -178,11 +182,11 @@ ID TASK                       GEN PRI STATE
  4 ping                        58   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200021a8 0x08024f50 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:124
-   |      0x20002200 0x08024090 task_ping::uart_send
-   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:125:5
+   |      0x20002200 0x080240b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:68:10
    |      0x20002200 0x080240b2 main
-   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200021dc   R1 = 0x00000029   R2 = 0x00000000   R3 = 0x00000000
@@ -222,11 +226,13 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+242)
    |
    +--->  0x200027b8 0x08026d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002800 0x0802608a userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002800 0x08026098 userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002800 0x08026098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20002800 0x08026098 main
-   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200027c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200027d8
@@ -266,7 +272,7 @@ ID TASK                       GEN PRI STATE
  6 idle                         0   5 ready
    |
    +--->  0x20002900 0x08028001 _start
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:806
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:812:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.11.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -197,7 +199,7 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x20002400 0x08014130 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248:0
    |
    |
    +-----------> 0x20000388 Task {
@@ -231,13 +233,13 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b60 0x080197ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20002b80 0x08018650 drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:112
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:114:6
    |      0x20002be0 0x080180d0 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:323
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:356:17
    |      0x20002c00 0x08018630 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:185:5
    |
    |
    +--->   R0 = 0x08019d40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b64
@@ -277,17 +279,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -327,11 +329,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -371,15 +375,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 ready
    |
    +--->  0x20004378 0x08022be6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20004400 0x08020378 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20004400 0x08020358 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20004400 0x08020342 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20004400 0x08020378 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20004400 0x08020378 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20004400 0x08020378 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x08023db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200043a0
@@ -419,15 +423,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 ready
    |
    +--->  0x20008378 0x0802984e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20008400 0x08028276 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20008400 0x0802825a userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20008400 0x08028244 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20008400 0x08028276 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20008400 0x08028276 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20008400 0x08028276 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:137:9
    |
    |
    +--->   R0 = 0x08029ec4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008398
@@ -467,15 +471,15 @@ ID TASK                       GEN PRI STATE
 10 max31790                     0   3 ready
    |
    +--->  0x20010360 0x0802d2ce userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x200103a0 0x0802d336 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x200103a0 0x0802d314 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x200103a0 0x0802d336 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
    |      0x200103a0 0x0802d336 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010400 0x0802c63e main
-   |                 @ /home/bmc/hubris/task-max31790/src/main.rs:20
+   |                 @ /home/bmc/hubris/task-max31790/src/main.rs:65:9
    |
    |
    +--->   R0 = 0x0802d88c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20010368
@@ -515,19 +519,19 @@ ID TASK                       GEN PRI STATE
 11 ds2482                       0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x20011368 0x08031134 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x200113d0 0x08030212 userlib::sys_send
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:87
-   |      0x200113d0 0x080301ce drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:168
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x200113d0 0x0803022e userlib::sys_send
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:104:14
+   |      0x200113d0 0x0803022e drv_i2c_api::I2c::read_reg
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:174:25
    |      0x200113d0 0x0803022e task_ds2482::ds2482::read_register
-   |                 @ /home/bmc/hubris/task-ds2482/src/ds2482.rs:51
+   |                 @ /home/bmc/hubris/task-ds2482/src/ds2482.rs:53:16
    |      0x20011400 0x08030340 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20011400 0x08030336 task_ds2482::ds2482::initialize
-   |                 @ /home/bmc/hubris/task-ds2482/src/ds2482.rs:97
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20011400 0x08030340 task_ds2482::ds2482::initialize
+   |                 @ /home/bmc/hubris/task-ds2482/src/ds2482.rs:98:5
    |      0x20011400 0x08030340 main
-   |                 @ /home/bmc/hubris/task-ds2482/src/main.rs:17
+   |                 @ /home/bmc/hubris/task-ds2482/src/main.rs:35:15
    |
    |
    +--->   R0 = 0x20011394   R1 = 0x2001136c   R2 = 0x00000001   R3 = 0x00000003
@@ -567,7 +571,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x20012100 0x08034056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20012100   R1 = 0x20012100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.12.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015926 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080142f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080142f2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080142f2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080142f2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x08014300 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x08014300 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x08014300 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x08014300 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x08014300 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:237
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:256:9
    |
    |
    +--->   R0 = 0x200023d0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023d8
@@ -327,15 +329,15 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x20002ba0 0x080190d8 rust_begin_unwind
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874:0
    |      0x20002bb8 0x080182b2 core::panicking::panic_fmt
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78//library/core/src/panicking.rs:77
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/panicking.rs:92:14
    |      0x20002bf0 0x08018190 core::panicking::panic_bounds_check
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78//library/core/src/panicking.rs:64
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/panicking.rs:69:5
    |      0x20002bf8 0x08018110 task_spd::Ringbuf<T,_>::entry
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:114
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:114:1
    |      0x20002c00 0x080180fa main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:117
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:152:5
    |
    |
    +-----------> 0x200004f8 Task {
@@ -385,7 +387,7 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 ready
    |
    +--->  0x20003400 0x0801c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -441,7 +443,7 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 ready
    |
    +--->  0x20003800 0x0801e001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -497,7 +499,7 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 ready
    |
    +--->  0x20004400 0x08020001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -553,7 +555,7 @@ ID TASK                       GEN PRI STATE
  9 thermal                      0   3 ready
    |
    +--->  0x20006800 0x08028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -609,7 +611,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.13.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -261,25 +263,25 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x200022e8 0x08015ee0 drv_stm32h7_i2c::max7358::write_reg
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:90
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:90:0
    |      0x20002310 0x08016212 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:164
-   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:110
-   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:75
-   |      0x20002400 0x080147aa drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:102
-   |      0x20002400 0x0801451c drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:315
-   |      0x20002400 0x0801451c userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002400 0x080144c2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144c2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:201:6
+   |      0x20002400 0x080147c4 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:126:66
+   |      0x20002400 0x080147c4 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:93:24
+   |      0x20002400 0x080147c4 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:110:5
+   |      0x20002400 0x080147c4 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:333:23
+   |      0x20002400 0x080147c4 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002400 0x080147c4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002400 0x080147c4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080147c4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:315:9
    |
    |
    +-----------> 0x20000488 Task {
@@ -329,13 +331,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:591
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:625:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f1c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -391,17 +393,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200033e8 0x0801c154 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200033e8 0x0801c154 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x200033e8 0x0801c154 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x200033e8 0x0801c154 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200033e8 0x0801c164 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200033e8 0x0801c164 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x200033e8 0x0801c164 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x200033e8 0x0801c164 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x200033e8 0x0801c164 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138:9
    |
    |
    +--->   R0 = 0x0801d9a8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200033c0
@@ -457,7 +459,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 not started
    |
    +--->  0x20003c00 0x08020001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -513,17 +515,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -579,11 +581,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -639,15 +643,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -703,15 +707,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085c0 0x08035636 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20008618 0x08033bfe drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:314
-   |      0x20008800 0x08030fd6 <drv_i2c_devices::max6634::Max6634 as drv_i2c_devices::TempSensor<drv_i2c_devices::max6634::Error>>::read_temperature
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max6634.rs:60
-   |      0x20008800 0x08030fd6 task_thermal::temp_read
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:128
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:333:9
+   |      0x20008800 0x08030fdc <drv_i2c_devices::max6634::Max6634 as drv_i2c_devices::TempSensor<drv_i2c_devices::max6634::Error>>::read_temperature
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max6634.rs:65:13
+   |      0x20008800 0x08030fdc task_thermal::temp_read
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:131:11
    |      0x20008800 0x08030fdc main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:341:13
    |
    |
    +--->   R0 = 0x200085ec   R1 = 0x00000001   R2 = 0x200085c5   R3 = 0x00000001
@@ -767,7 +771,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.14.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022b0 0x080166b2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200022d0 0x0801406c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
-   |      0x20002310 0x08015de0 drv_stm32h7_i2c::I2cController::special
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:462
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
+   |      0x20002310 0x08015e6c drv_stm32h7_i2c::I2cController::special
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:531:17
    |      0x20002310 0x08015e6c <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x0801445c drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:487
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:136:9
+   |      0x20002400 0x080144ae drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:497:5
    |      0x20002400 0x080144ae main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:312:5
    |
    |
    +--->   R0 = 0x08016d18   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x200022b4
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:591
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:625:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f1c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -387,17 +389,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200033e8 0x0801c154 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200033e8 0x0801c154 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x200033e8 0x0801c154 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x200033e8 0x0801c154 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200033e8 0x0801c164 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200033e8 0x0801c164 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x200033e8 0x0801c164 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x200033e8 0x0801c164 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x200033e8 0x0801c164 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138:9
    |
    |
    +--->   R0 = 0x0801d9a8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200033c0
@@ -453,7 +455,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 not started
    |
    +--->  0x20003c00 0x08020001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -509,17 +511,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -575,11 +577,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+121)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -635,15 +639,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+621)
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -699,17 +703,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x08035636 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033b66 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:314
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:333:9
    |      0x20008618 0x08034b16 drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:220
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:221:16
    |      0x20008800 0x08030440 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030436 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:283
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030440 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:286:43
    |      0x20008800 0x08030440 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -767,11 +771,11 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x2000a100 0x08040054 cortex_m::asm::inline::__wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:180
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:181:5
    |      0x2000a100 0x08040054 cortex_m::asm::wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:54
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:55:5
    |      0x2000a100 0x08040054 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:13:9
    |
    |
    +-----------> 0x20000a08 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.15.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200022e0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
-   |      0x20002310 0x08015e28 drv_stm32h7_i2c::I2cController::send_konami_code
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:471
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
+   |      0x20002310 0x08015eb0 drv_stm32h7_i2c::I2cController::send_konami_code
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:542:17
    |      0x20002310 0x08015eb0 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x08014452 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:496
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:169:9
+   |      0x20002400 0x080144b2 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:515:17
    |      0x20002400 0x080144b2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:317:5
    |
    |
    +--->   R0 = 0x08016be4   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x200022c4
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:602
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:636:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f1c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -436,7 +438,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -494,17 +496,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -560,11 +562,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+477)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -620,15 +624,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+477)
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -684,17 +688,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x0803559e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033aa2 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:314
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:333:9
    |      0x20008618 0x08034a92 drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -750,7 +754,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.16.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200022e0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
-   |      0x20002310 0x08015e28 drv_stm32h7_i2c::I2cController::send_konami_code
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:471
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
+   |      0x20002310 0x08015eb0 drv_stm32h7_i2c::I2cController::send_konami_code
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:542:17
    |      0x20002310 0x08015eb0 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x08014452 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:496
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:169:9
+   |      0x20002400 0x080144b2 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:515:17
    |      0x20002400 0x080144b2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:317:5
    |
    |
    +--->   R0 = 0x08016be4   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x200022c4
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:602
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:636:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f1c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -387,21 +389,21 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200033e8 0x0801c314 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200033e8 0x0801c314 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:189
-   |      0x200033e8 0x0801c1c8 drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x200033e8 0x0801c1c8 userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x200033e8 0x0801c154 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x200033e8 0x0801c154 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200033e8 0x0801c322 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200033e8 0x0801c322 userlib::sys_recv_closed
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:194:5
+   |      0x200033e8 0x0801c322 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:331:29
+   |      0x200033e8 0x0801c322 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x200033e8 0x0801c322 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x200033e8 0x0801c322 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x200033e8 0x0801c322 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d9a8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200033ac
@@ -457,7 +459,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+420)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+920)
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -705,17 +709,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x0803559e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033aa2 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:314
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:333:9
    |      0x20008618 0x08034a92 drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -773,11 +777,11 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x2000a100 0x08040054 cortex_m::asm::inline::__wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:180
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/../asm/inline.rs:181:5
    |      0x2000a100 0x08040054 cortex_m::asm::wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:54
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.1/src/asm.rs:55:5
    |      0x2000a100 0x08040054 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:13:9
    |
    |
    +-----------> 0x20000a08 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.17.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016552 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200022e0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
-   |      0x20002310 0x08015e28 drv_stm32h7_i2c::I2cController::send_konami_code
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:471
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
+   |      0x20002310 0x08015eb0 drv_stm32h7_i2c::I2cController::send_konami_code
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:542:17
    |      0x20002310 0x08015eb0 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x08014452 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:496
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:169:9
+   |      0x20002400 0x080144b2 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:515:17
    |      0x20002400 0x080144b2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:172
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:317:5
    |
    |
    +--->   R0 = 0x08016be4   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x200022c4
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801998a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:602
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:636:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f1c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -436,7 +438,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -494,17 +496,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -560,11 +562,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -620,15 +624,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006380 0x08028e98 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -684,17 +688,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x0803559e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033aa2 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:314
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:333:9
    |      0x20008618 0x08034a92 drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -750,7 +754,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.18.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,19 +261,19 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 notif: bit3(irq95/irq96)
    |
    +--->  0x200022c0 0x08016652 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200022e0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
-   |      0x20002310 0x08015e5c drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:330
-   |      0x20002310 0x08015e56 drv_stm32h7_i2c::max7358::read_regs
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:62
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
+   |      0x20002310 0x08015e8e drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:444:21
+   |      0x20002310 0x08015e8e drv_stm32h7_i2c::max7358::read_regs
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:68:11
    |      0x20002310 0x08015e8e <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x08014452 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:497
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:166:9
+   |      0x20002400 0x080144b2 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:516:17
    |      0x20002400 0x080144b2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:318:5
    |
    |
    +--->   R0 = 0x08016cc8   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x200022c4
@@ -327,13 +329,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801999e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:621
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:655:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -390,7 +392,8 @@ ID TASK                       GEN PRI STATE
    could not read registers: register PC not found in dump
    guessing at stack trace using saved frame pointer
    |
-   +--->  0x200033e8 0x00000000
+   +--->  0x200033e8 0x00000000 __aeabi_idiv0
+   |                 @ /checkout/src/llvm-project/compiler-rt/lib/builtins/arm/aeabi_div0.c:37:0
    |
    |
    +-----------> 0x200005e8 Task {
@@ -440,7 +443,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -498,17 +501,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -564,11 +567,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+135)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -624,15 +629,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+635)
    |
    +--->  0x20006380 0x08028e9c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -688,17 +693,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x080355ba userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033a2e drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:316
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:335:9
    |      0x20008618 0x08034aae drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -754,7 +759,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.19.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -308,13 +310,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801999e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:621
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:655:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -370,21 +372,21 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x200033a0 0x0801d412 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200033e8 0x0801c314 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200033e8 0x0801c314 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:189
-   |      0x200033e8 0x0801c1c8 drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x200033e8 0x0801c1c8 userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x200033e8 0x0801c154 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x200033e8 0x0801c154 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200033e8 0x0801c322 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200033e8 0x0801c322 userlib::sys_recv_closed
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:194:5
+   |      0x200033e8 0x0801c322 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:331:29
+   |      0x200033e8 0x0801c322 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x200033e8 0x0801c322 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x200033e8 0x0801c322 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x200033e8 0x0801c322 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d9a8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200033ac
@@ -440,7 +442,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -498,17 +500,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -564,11 +566,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+283)
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -624,15 +628,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+783)
    |
    +--->  0x20006380 0x08028e9c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -688,17 +692,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x080355ba userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033a2e drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:316
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:335:9
    |      0x20008618 0x08034aae drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -754,7 +758,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.2.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cf2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
-   |      0x20001400 0x080101ca userlib::sys_recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:210
-   |      0x20001400 0x080101c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:166
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:270:5
+   |      0x20001400 0x080101da userlib::sys_recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:236:5
+   |      0x20001400 0x080101da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:170:11
    |      0x20001400 0x080101da main
-   |                 @ /home/bmc/hubris-logging/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris-logging/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x08012460   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e3a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
-   |      0x20001800 0x0801806e userlib::sys_recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:210
-   |      0x20001800 0x0801806e userlib::hl::recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:78
-   |      0x20001800 0x0801806e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:270:5
+   |      0x20001800 0x0801807c userlib::sys_recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:236:5
+   |      0x20001800 0x0801807c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:170:11
+   |      0x20001800 0x0801807c userlib::hl::recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0801807c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:123:5
    |      0x20001800 0x0801807c main
-   |                 @ /home/bmc/hubris-logging/drv/stm32f4-rcc/src/main.rs:100
+   |                 @ /home/bmc/hubris-logging/drv/stm32f4-rcc/src/main.rs:114:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,15 +99,15 @@ ID TASK                       GEN PRI STATE
  2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001bb0 0x0801d1e2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
-   |      0x20001c00 0x0801c130 userlib::sys_recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:210
-   |      0x20001c00 0x0801c130 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:166
-   |      0x20001c00 0x0801c130 userlib::hl::recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:270:5
+   |      0x20001c00 0x0801c13e userlib::sys_recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:236:5
+   |      0x20001c00 0x0801c13e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:170:11
+   |      0x20001c00 0x0801c13e userlib::hl::recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:88:14
    |      0x20001c00 0x0801c13e main
-   |                 @ /home/bmc/hubris-logging/drv/stm32f4-usart/src/main.rs:50
+   |                 @ /home/bmc/hubris-logging/drv/stm32f4-usart/src/main.rs:99:9
    |
    |
    +--->   R0 = 0x0801d7b0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001bdc
@@ -145,15 +147,17 @@ ID TASK                       GEN PRI STATE
  3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:263
-   |      0x20002000 0x0802009c userlib::sys_recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:210
-   |      0x20002000 0x0802009c userlib::hl::recv
-   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:78
-   |      0x20002000 0x0802009c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:270:5
+   |      0x20002000 0x080200aa userlib::sys_recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:236:5
+   |      0x20002000 0x080200aa userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:170:11
+   |      0x20002000 0x080200aa userlib::hl::recv
+   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:88:14
+   |      0x20002000 0x080200aa userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-logging/userlib/src/hl.rs:123:5
    |      0x20002000 0x080200aa main
-   |                 @ /home/bmc/hubris-logging/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris-logging/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20001fc4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001fdc
@@ -193,11 +197,11 @@ ID TASK                       GEN PRI STATE
  4 ping                        25   4 wait: reply from pong/gen0
    |
    +--->  0x20002fa0 0x080250fc userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:127
-   |      0x20003000 0x08024120 userlib::sys_send
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:90
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:128:5
+   |      0x20003000 0x08024140 userlib::sys_send
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:107:14
    |      0x20003000 0x08024140 main
-   |                 @ /home/bmc/hubris-logging/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris-logging/task-ping/src/main.rs:55:13
    |
    |
    +--->   R0 = 0x20002fdc   R1 = 0x00000000   R2 = 0x08025850   R3 = 0x00000800
@@ -273,17 +277,17 @@ Caused by:
  6 pong                         0   3 wait: reply from log/gen0
    |
    +--->  0x20004f40 0x08030ee2 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:127
-   |      0x20004f80 0x0803101a <userlib::logging::Logger as defmt::Logger>::release
-   |                 @ /home/bmc/hubris-logging/userlib/src/logging.rs:37
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:128:5
+   |      0x20004f80 0x08031062 <userlib::logging::Logger as defmt::Logger>::release
+   |                 @ /home/bmc/hubris-logging/userlib/src/logging.rs:42:9
    |      0x20004f80 0x08031062 _defmt_release
-   |                 @ /home/bmc/hubris-logging/userlib/src/logging.rs:10
+   |                 @ /home/bmc/hubris-logging/userlib/src/logging.rs:10:1
    |      0x20004fa0 0x08030b5c defmt::export::release
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/defmt-0.1.3//home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/defmt-0.1.3/src/export.rs:44
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/defmt-0.1.3/src/export.rs:49:2
    |      0x20005000 0x08030116 userlib::sys_reply
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:317
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:319:9
    |      0x20005000 0x08030116 main
-   |                 @ /home/bmc/hubris-logging/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris-logging/task-pong/src/main.rs:27:13
    |
    |
    +--->   R0 = 0x20004f4c   R1 = 0x00000002   R2 = 0x00000100   R3 = 0x0803166c
@@ -323,7 +327,7 @@ Caused by:
  7 idle                         0   5 ready
    |
    +--->  0x20005100 0x08032001 _start
-   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:809
+   |                 @ /home/bmc/hubris-logging/userlib/src/lib.rs:815:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.20.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001300 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013bc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f0ba userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,23 +261,23 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 ready
    |
    +--->  0x200022e0 0x080166ba userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
    |      0x20002310 0x08015e92 core::ptr::read_volatile
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ptr/mod.rs:1050
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ptr/mod.rs:1056:14
    |      0x20002310 0x08015e92 vcell::VolatileCell<T>::get
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:30
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:33:18
    |      0x20002310 0x08015e92 stm32h7::generic::Reg<U,REG>::read
-   |                 @ /home/bmc/.cargo/git/checkouts/stm32-rs-nightlies-668d701d80d8e2e7/0258085/stm32h7/src/generic.rs:50
-   |      0x20002310 0x08015e5c drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:330
-   |      0x20002310 0x08015e56 drv_stm32h7_i2c::max7358::read_regs
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:62
+   |                 @ /home/bmc/.cargo/git/checkouts/stm32-rs-nightlies-668d701d80d8e2e7/0258085/stm32h7/src/generic.rs:51:18
+   |      0x20002310 0x08015e92 drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:446:31
+   |      0x20002310 0x08015e92 drv_stm32h7_i2c::max7358::read_regs
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:68:11
    |      0x20002310 0x08015e92 <drv_stm32h7_i2c::max7358::Max7358 as drv_stm32h7_i2c::I2cMuxDriver>::configure
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:129
-   |      0x20002400 0x08014452 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:497
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/max7358.rs:166:9
+   |      0x20002400 0x080144b2 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:516:17
    |      0x20002400 0x080144b2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:318:5
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x200022c4
@@ -331,13 +333,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x0801999e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:621
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:655:17
    |      0x20002c00 0x08018684 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -442,7 +444,7 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x08020212 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
    |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
    |
@@ -500,17 +502,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -566,11 +568,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x200047b8 0x08024d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x08024098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x08024098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x08024098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -626,15 +630,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006380 0x08028e9c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028306 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028306 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028306 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028306 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x080290a8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -690,17 +694,17 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: send to i2c_driver/gen0
    |
    +--->  0x20008598 0x080355ba userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x200085f0 0x08033a2e drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:316
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:335:9
    |      0x20008618 0x08034aae drv_i2c_devices::max31790::read_reg8
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:235
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:236:16
    |      0x20008800 0x08030442 <core::result::Result<T,E> as core::ops::try::Try>::into_result
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1502
-   |      0x20008800 0x08030438 drv_i2c_devices::max31790::Max31790::initialize
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:298
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/result.rs:1503:9
+   |      0x20008800 0x08030442 drv_i2c_devices::max31790::Max31790::initialize
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/max31790.rs:301:43
    |      0x20008800 0x08030442 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:312:15
    |
    |
    +--->   R0 = 0x200085c4   R1 = 0x2000859e   R2 = 0x00000002   R3 = 0x00000000
@@ -756,7 +760,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.21.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -389,7 +391,7 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x200033e8 0x0801c094 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74:0
    |
    |
    +-----------> 0x20000610 Task {
@@ -439,9 +441,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003cd4   R2 = 0x00000001   R3 = 0x00000000
@@ -497,17 +499,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -563,11 +565,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+177)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -623,15 +627,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+677)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -687,15 +691,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+590)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -751,17 +755,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -817,7 +821,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.22.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -436,9 +438,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003cd4   R2 = 0x00000001   R3 = 0x00000000
@@ -494,17 +496,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -560,11 +562,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -620,15 +624,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -684,15 +688,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -748,17 +752,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -814,7 +818,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.23.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -438,9 +440,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c54   R2 = 0x00000001   R3 = 0x00000000
@@ -496,17 +498,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -562,11 +564,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+479)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -622,15 +626,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+979)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -686,15 +690,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+916)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -750,17 +754,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -816,7 +820,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.24.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -436,9 +438,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c54   R2 = 0x00000001   R3 = 0x00000000
@@ -494,17 +496,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -560,11 +562,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -620,15 +624,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -684,15 +688,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -748,17 +752,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -814,7 +818,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.25.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -389,7 +391,7 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x200033e8 0x0801c094 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74:0
    |
    |
    +-----------> 0x20000610 Task {
@@ -439,9 +441,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c74   R2 = 0x00000001   R3 = 0x00000000
@@ -497,17 +499,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -563,11 +565,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+250)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -623,15 +627,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+750)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -687,15 +691,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+162)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -751,17 +755,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -817,7 +821,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.26.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -438,9 +440,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c54   R2 = 0x00000001   R3 = 0x00000000
@@ -496,17 +498,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -562,11 +564,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+222)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -622,15 +626,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+722)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -686,15 +690,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+523)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -750,17 +754,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -816,7 +820,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.27.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -387,7 +389,7 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x20003398 0x0801d3b2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200033e8 0x0801c31e userlib::sys_recv
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
    |      0x200033e8 0x0801c31e userlib::sys_recv_closed
@@ -457,9 +459,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c54   R2 = 0x00000001   R3 = 0x00000000
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+23)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+23)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -705,15 +709,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+182)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -769,17 +773,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -837,11 +841,11 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x2000a900 0x08044054 cortex_m::asm::inline::__wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/../asm/inline.rs:181
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/../asm/inline.rs:182:5
    |      0x2000a900 0x08044054 cortex_m::asm::wfi
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/asm.rs:54
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.7.2/src/asm.rs:55:5
    |      0x2000a900 0x08044054 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:13:9
    |
    |
    +-----------> 0x20000ae0 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.29.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -438,9 +440,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c54   R2 = 0x00000001   R3 = 0x00000000
@@ -496,17 +498,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -562,11 +564,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+5)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -622,15 +626,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+5)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -686,15 +690,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+199)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -750,17 +754,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -816,7 +820,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.3.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001400 0x080101ca userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001400 0x080101c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080101da userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080101da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20001400 0x080101da main
-   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x08012454   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001800 0x0801806e userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001800 0x0801806e userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20001800 0x0801806e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0801807c userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0801807c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0801807c userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0801807c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20001800 0x0801807c main
-   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:100
+   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:114:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,15 +99,15 @@ ID TASK                       GEN PRI STATE
  2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001bb0 0x0801d1c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001c00 0x0801c130 userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001c00 0x0801c130 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:163
-   |      0x20001c00 0x0801c130 userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0801c13e userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0801c13e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0801c13e userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
    |      0x20001c00 0x0801c13e main
-   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-usart/src/main.rs:50
+   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-usart/src/main.rs:99:9
    |
    |
    +--->   R0 = 0x0801d798   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001bdc
@@ -145,15 +147,17 @@ ID TASK                       GEN PRI STATE
  3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002000 0x0802009c userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20002000 0x0802009c userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20002000 0x0802009c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002000 0x080200aa userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002000 0x080200aa userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20002000 0x080200aa userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20002000 0x080200aa userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20002000 0x080200aa main
-   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20001fc4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001fdc
@@ -194,7 +198,8 @@ ID TASK                       GEN PRI STATE
    could not read registers: register PC not found in dump
    guessing at stack trace using saved frame pointer
    |
-   +--->  0x20002200 0x00000000
+   +--->  0x20002200 0x00000000 __aeabi_idiv0
+   |                 @ /checkout/src/llvm-project/compiler-rt/lib/builtins/arm/aeabi_div0.c:37:0
    |
    |
    +-----------> 0x200002c8 Task {
@@ -228,11 +233,13 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+477)
    |
    +--->  0x200027b8 0x08026d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002800 0x0802608a userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002800 0x08026098 userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002800 0x08026098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20002800 0x08026098 main
-   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200027c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200027d8
@@ -272,7 +279,7 @@ ID TASK                       GEN PRI STATE
  6 idle                         0   5 ready
    |
    +--->  0x20002900 0x08028001 _start
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:806
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:812:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.30.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001348 0x08009b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x080081c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x080081c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a3cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800f03e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001c00 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002330 0x0801620a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x200023cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -325,13 +327,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002b50 0x080198fa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002b70 0x080183f0 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x20002bd8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20002c00 0x08018640 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019edc   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002b54
@@ -436,9 +438,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c74   R2 = 0x00000001   R3 = 0x00000000
@@ -494,17 +496,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -560,11 +562,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+402)
    |
    +--->  0x200047b8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -620,15 +624,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+902)
    |
    +--->  0x20006388 0x08028dee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x080282c2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282a0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x0802828c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x080282c2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x080282c2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x080282c2 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029058   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -684,15 +688,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+731)
    |
    +--->  0x200085d0 0x08034d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x08034de2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x08034dc0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x08034de2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x08034de2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803122c main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080363b4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -748,17 +752,17 @@ ID TASK                       GEN PRI STATE
 12 net                          0   2 notif: bit31(T+1)
    |
    +--->  0x2000a3d8 0x0804224e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a400 0x080401f2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a400 0x080401d8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a400 0x080401c2 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
-   |      0x2000a400 0x080401b2 drv_stm32h7_eth::Ethernet::new
-   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:59
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a400 0x080401f2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
+   |      0x2000a400 0x080401f2 drv_stm32h7_eth::Ethernet::new
+   |                 @ /home/bmc/hubris/drv/stm32h7-eth/src/lib.rs:75:13
    |      0x2000a400 0x080401f2 main
-   |                 @ /home/bmc/hubris/task-net/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-net/src/main.rs:157:19
    |
    |
    +--->   R0 = 0x0804327c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a3e0
@@ -814,7 +818,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 ready
    |
    +--->  0x2000a900 0x08044056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a900   R1 = 0x2000a900   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.33.stdout
@@ -4,7 +4,12 @@ ID TASK                       GEN PRI STATE
    could not read registers: register PC not found in dump
    guessing at stack trace using saved frame pointer
    |
-   +--->  0x20001400 0x00000000
+   +--->  0x20001400 0x00000000 core::num::<impl u32>::checked_div
+   |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/int/specialized_div_rem/delegate.rs:21:0
+   |      0x20001400 0x00000000 compiler_builtins::int::specialized_div_rem::u32_by_u32_div_rem
+   |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/int/specialized_div_rem/mod.rs:203:24
+   |      0x20001400 0x00000000 compiler_builtins::int::specialized_div_rem::u64_div_rem
+   |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/int/specialized_div_rem/delegate.rs:148:47
    |
    |
    +-----------> 0x200001a8 Task {
@@ -54,7 +59,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -110,15 +115,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -174,17 +181,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -240,7 +247,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   60   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -296,7 +303,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -352,7 +359,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -408,7 +415,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -464,7 +471,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -520,7 +527,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -576,7 +583,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -632,7 +639,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.35.stdout
@@ -3,11 +3,11 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001400 0x00010242 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
    |      0x20001400 0x00010242 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013c8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -63,7 +63,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -119,15 +119,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -183,17 +185,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -249,7 +251,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   35   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -305,7 +307,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -361,7 +363,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -417,7 +419,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -473,7 +475,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -529,7 +531,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -585,7 +587,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -641,7 +643,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.36.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001360 0x00011b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001400 0x000101b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001400 0x000101b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001400 0x000101c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001400 0x000101c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20001400 0x000101c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x000123cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013c8
@@ -65,7 +65,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -121,15 +121,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -185,17 +187,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -251,7 +253,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   17   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -307,7 +309,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -363,7 +365,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -419,7 +421,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -475,7 +477,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -531,7 +533,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -587,7 +589,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -643,7 +645,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.37.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001360 0x00011b56 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001400 0x000101b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001400 0x000101b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001400 0x000101c6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001400 0x000101c6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20001400 0x000101c6 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x000123cc   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013c8
@@ -65,7 +65,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -121,15 +121,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -185,17 +187,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 ready
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -251,13 +253,13 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    7   2 wait: reply from gpio_driver/gen0
    |
    +--->  0x20002f88 0x0002520a userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20002fc0 0x000242d8 drv_user_leds::led_off
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:431
-   |      0x20003000 0x0002405a drv_user_leds::enable_led_pins
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:369
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:436:10
+   |      0x20003000 0x00024070 drv_user_leds::enable_led_pins
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:398:5
    |      0x20003000 0x00024070 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:70:5
    |
    |
    +--->   R0 = 0x20002f94   R1 = 0x000257e0   R2 = 0x00000000   R3 = 0x00000000
@@ -313,7 +315,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -369,7 +371,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -425,7 +427,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -481,7 +483,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -537,7 +539,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -593,7 +595,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -649,7 +651,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.38.stdout
@@ -3,11 +3,11 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001400 0x00010242 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
    |      0x20001400 0x00010242 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013c8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -63,7 +63,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -119,15 +119,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -183,17 +185,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -249,7 +251,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   59   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -305,7 +307,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -361,7 +363,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -417,7 +419,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -473,7 +475,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -529,7 +531,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -585,7 +587,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -641,7 +643,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.39.stdout
@@ -2,20 +2,20 @@ system time = 19544
 ID TASK                       GEN PRI STATE    
  0 jefe                         0   0 RUNNING
    |
-   +--->  0x20001290 0x000115ae cortex_m::itm::write_words
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:16
-   |      0x20001290 0x000115aa cortex_m::itm::write_aligned
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:100
+   +--->  0x20001290 0x000115b6 cortex_m::itm::write_words
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:19:9
+   |      0x20001290 0x000115b6 cortex_m::itm::write_aligned
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:109:9
    |      0x20001290 0x000115b6 cortex_m::itm::write_all
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:39
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:79:9
    |      0x20001298 0x0001013e <&mut W as core::fmt::Write>::write_str
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:190
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:192:6
    |      0x200012f0 0x000110f0 core::fmt::write
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:1093:48
    |      0x20001328 0x00010078 core::fmt::Write::write_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:183
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:185:6
    |      0x20001360 0x00010168 cortex_m::itm::write_fmt
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:137
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-0.6.7/src/itm.rs:141:2
    |      0x20001400 0x000103b4 task_jefe::log_fault
    |                 @ /home/bmc/hubris/task-jefe/src/main.rs:27
    |      0x20001400 0x00010428 main
@@ -75,7 +75,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -131,15 +131,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -319,7 +321,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -375,7 +377,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -431,7 +433,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -487,7 +489,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -543,7 +545,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -599,7 +601,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -655,7 +657,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.4.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08011cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001400 0x080101ca userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001400 0x080101c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080101da userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080101da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20001400 0x080101da main
-   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris-fixes/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x08012454   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x08018e22 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20001800 0x0801806e userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20001800 0x0801806e userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20001800 0x0801806e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0801807c userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0801807c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0801807c userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0801807c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20001800 0x0801807c main
-   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:100
+   |                 @ /home/bmc/hubris-fixes/drv/stm32f4-rcc/src/main.rs:114:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -133,15 +135,17 @@ Caused by:
  3 user_leds                    0   2 recv
    |
    +--->  0x20001fb8 0x08020fc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002000 0x0802009c userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
-   |      0x20002000 0x0802009c userlib::hl::recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:78
-   |      0x20002000 0x0802009c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002000 0x080200aa userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002000 0x080200aa userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
+   |      0x20002000 0x080200aa userlib::hl::recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:88:14
+   |      0x20002000 0x080200aa userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris-fixes/userlib/src/hl.rs:123:5
    |      0x20002000 0x080200aa main
-   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris-fixes/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20001fc4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001fdc
@@ -181,11 +185,11 @@ Caused by:
  4 ping                         1   4 wait: reply from usart_driver/gen0
    |
    +--->  0x200021a8 0x08024f50 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:124
-   |      0x20002200 0x08024090 task_ping::uart_send
-   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:64
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:125:5
+   |      0x20002200 0x080240b2 task_ping::uart_send
+   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:68:10
    |      0x20002200 0x080240b2 main
-   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris-fixes/task-ping/src/main.rs:48:9
    |
    |
    +--->   R0 = 0x200021dc   R1 = 0x00000061   R2 = 0x00000000   R3 = 0x00000000
@@ -225,11 +229,13 @@ Caused by:
  5 pong                         0   3 recv, notif: bit0(T+336)
    |
    +--->  0x200027b8 0x08026d36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:260
-   |      0x20002800 0x0802608a userlib::sys_recv
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:267:5
+   |      0x20002800 0x08026098 userlib::sys_recv
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:233:5
+   |      0x20002800 0x08026098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:167:11
    |      0x20002800 0x08026098 main
-   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris-fixes/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200027c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200027d8
@@ -269,7 +275,7 @@ Caused by:
  6 idle                         0   5 ready
    |
    +--->  0x20002900 0x08028001 _start
-   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:806
+   |                 @ /home/bmc/hubris-fixes/userlib/src/lib.rs:812:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.40.stdout
@@ -3,11 +3,11 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001400 0x00010242 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
    |      0x20001400 0x00010242 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013c8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -63,7 +63,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -119,15 +119,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -183,17 +185,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -307,7 +309,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -363,7 +365,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -419,7 +421,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -475,7 +477,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -531,7 +533,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -587,7 +589,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -643,7 +645,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.41.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011d80 __aeabi_memset4
-   |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/arm.rs:211
+   |                 @ /cargo/registry/src/github.com-1ecc6299db9ec823/compiler_builtins-0.1.39/src/arm.rs:217:5
    |      0x20001400 0x00010220 userlib::sys_send
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:88
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:95:20
+   |      0x20001400 0x00010220 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:12:9
    |      0x20001400 0x00010220 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013b0   R1 = 0x00000014   R2 = 0x00000000   R3 = 0x00000000
@@ -65,7 +65,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -121,15 +121,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -185,17 +187,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -251,7 +253,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   13   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -307,7 +309,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -363,7 +365,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -419,7 +421,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -475,7 +477,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -531,7 +533,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -587,7 +589,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -643,7 +645,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.42.stdout
@@ -3,11 +3,11 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001400 0x00010242 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
    |      0x20001400 0x00010242 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013c8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -63,7 +63,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -119,15 +119,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -183,17 +185,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -249,7 +251,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   22   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -305,7 +307,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -361,7 +363,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -417,7 +419,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -473,7 +475,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -529,7 +531,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -585,7 +587,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -641,7 +643,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.43.stdout
@@ -3,11 +3,11 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 RUNNING
    |
    +--->  0x20001360 0x00011b72 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001400 0x0001021a userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001400 0x00010242 userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
    |      0x20001400 0x00010242 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:95:25
    |
    |
    +--->   R0 = 0x200013c8   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -63,7 +63,7 @@ ID TASK                       GEN PRI STATE
  1 idle                         0   5 ready
    |
    +--->  0x20002100 0x00018001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -119,15 +119,17 @@ ID TASK                       GEN PRI STATE
  2 syscon_driver                0   2 recv
    |
    +--->  0x200027d8 0x0001cdb2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002800 0x0001c094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002800 0x0001c094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x0001c094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002800 0x0001c0a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002800 0x0001c0a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x0001c0a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002800 0x0001c0a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200027e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027e4
@@ -183,17 +185,17 @@ ID TASK                       GEN PRI STATE
  3 gpio_driver                  0   2 recv
    |
    +--->  0x20002bc0 0x0002115e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0002010a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0002010a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0002010a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0002010a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x00020118 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x00020118 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x00020118 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x00020118 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x00020118 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:81:9
    |
    |
    +--->   R0 = 0x20002bd8   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20002bdc
@@ -249,7 +251,7 @@ ID TASK                       GEN PRI STATE
  4 user_leds                   24   2 ready
    |
    +--->  0x20003000 0x00024001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -305,7 +307,7 @@ ID TASK                       GEN PRI STATE
  5 usart_driver                 0   2 ready
    |
    +--->  0x20003400 0x00028001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -361,7 +363,7 @@ ID TASK                       GEN PRI STATE
  6 i2c_driver                   0   2 ready
    |
    +--->  0x20003800 0x0002c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -417,7 +419,7 @@ ID TASK                       GEN PRI STATE
  7 rng_driver                   0   2 ready
    |
    +--->  0x20003c00 0x00030001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -473,7 +475,7 @@ ID TASK                       GEN PRI STATE
  8 spi_driver                   0   2 ready
    |
    +--->  0x20004000 0x00034001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -529,7 +531,7 @@ ID TASK                       GEN PRI STATE
  9 ping                         0   4 ready
    |
    +--->  0x20004400 0x00038001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -585,7 +587,7 @@ ID TASK                       GEN PRI STATE
 10 pong                         0   3 ready
    |
    +--->  0x20004800 0x0003a001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -641,7 +643,7 @@ ID TASK                       GEN PRI STATE
 11 spam                         0   3 not started
    |
    +--->  0x20004be8 0x0003c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.44.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+55)
    |
    +--->  0x20001320 0x08009e7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x200013e8 0x080081f8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x200013e8 0x080081f8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x200013e8 0x0800820a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x200013e8 0x0800820a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x200013e8 0x0800820a main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:116:23
    |
    |
    +--->   R0 = 0x0800a74c   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200013b0
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,35 +263,35 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x20002838 0x080160ac <userlib::panic::PrefixWrite as core::fmt::Write>::write_str
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:882
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:882:0
    |      0x20002840 0x08016160 <&mut W as core::fmt::Write>::write_str
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:190
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:192:6
    |      0x20002898 0x080154ca core::fmt::write
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:1113:40
    |      0x200028d0 0x0801559c <&T as core::fmt::Display>::fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:2012
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:2012:84
    |      0x20002928 0x08015484 core::fmt::write
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:1094:59
    |      0x20002978 0x08015fbc <core::panic::PanicInfo as core::fmt::Display>::fmt
    |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panic.rs:168
    |      0x20002978 0x08016012 <&T as core::fmt::Display>::fmt
    |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:2012
    |      0x200029d0 0x08015484 core::fmt::write
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/fmt/mod.rs:1077
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:1094:59
    |      0x20002a08 0x08016148 core::fmt::Write::write_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:183
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/fmt/mod.rs:185:6
    |      0x20002ab8 0x08016386 rust_begin_unwind
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:895:23
    |      0x20002ad0 0x08014d7e core::panicking::panic_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:92:14
    |      0x20002af8 0x08014c1a core::panicking::panic
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:39
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:50:5
    |      0x20002b28 0x08014b38 drv_stm32h7_i2c_server::configure_port
    |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:500
-   |      0x20002c00 0x08014406 drv_stm32h7_i2c_server::configure_muxes
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:598
+   |      0x20002c00 0x08014438 drv_stm32h7_i2c_server::configure_muxes
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:614:19
    |      0x20002c00 0x08014438 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:400:5
    |
    |
    +-----------> 0x20000490 Task {
@@ -344,13 +346,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003350 0x08019972 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003370 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20003400 0x08018680 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f14   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20003354
@@ -406,19 +408,19 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d438 userlib::sys_borrow_write_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:506
-   |      0x20003be8 0x0801c378 userlib::hl::Borrow::write_at
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:348
-   |      0x20003be8 0x0801c1ea drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x20003be8 0x0801c1ea userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:509:5
+   |      0x20003be8 0x0801c392 userlib::hl::Borrow::write_at
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:354:9
+   |      0x20003be8 0x0801c392 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:313:33
+   |      0x20003be8 0x0801c392 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20003be8 0x0801c392 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20003be8 0x0801c392 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c392 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x20003bc0   R1 = 0x00032017   R2 = 0x00000001   R3 = 0x00000000
@@ -474,9 +476,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x20004454   R2 = 0x00000001   R3 = 0x00000000
@@ -532,17 +534,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    1   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -598,15 +600,15 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 FAULT: panicked at 'explicit panic', drv/user-leds-api/src/lib.rs:38:18 (was: ready)
    |
    +--->  0x20004ec8 0x08024d6c userlib::sys_panic_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:651
-   |      0x20004f78 0x08024dae userlib::sys_panic
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:642
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:652:5
+   |      0x20004f78 0x08024db2 userlib::sys_panic
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:643:14
    |      0x20004f78 0x08024db2 rust_begin_unwind
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:874
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:895:5
    |      0x20004f90 0x080243fe core::panicking::panic_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:92:14
    |      0x20004fb8 0x0802417e core::panicking::panic
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:39
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:50:5
    |      0x20005000 0x08024124 main
    |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
    |
@@ -667,15 +669,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+363)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028302 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282cc userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028302 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028302 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028302 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029078   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -731,13 +733,13 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+363)
    |
    +--->  0x200085d0 0x08035396 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353fe userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353dc userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353fe userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353fe userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x0803049a main
    |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
    |
@@ -795,7 +797,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.45.stdout
@@ -61,15 +61,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -125,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -191,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -255,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b30 0x080162a2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x080144e8 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x080144e8 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x080144e8 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x080144e8 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x080144f8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x080144f8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x080144f8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x080144f8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080144f8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:173
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:336:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -321,13 +323,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003350 0x08019972 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003370 0x08018430 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180ce drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:642
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:676:17
    |      0x20003400 0x08018680 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f14   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20003354
@@ -383,19 +385,19 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:448:5
    |      0x20003be8 0x0801c2e8 core::option::Option<T>::ok_or
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:565
-   |      0x20003be8 0x0801c1ea drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x20003be8 0x0801c1ea userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:567:13
+   |      0x20003be8 0x0801c2e8 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:289:48
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c2e8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x20003bc0   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x00000004
@@ -451,9 +453,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044d4   R2 = 0x00000001   R3 = 0x00000000
@@ -509,17 +511,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -575,11 +577,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 FAULT: killed by jefe/gen0 (was: recv, notif: bit0)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -638,15 +642,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+671)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028302 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282cc userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028302 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028302 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028302 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029078   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -702,15 +706,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+552)
    |
    +--->  0x200085d0 0x08035396 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353fe userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353dc userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353fe userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353fe userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x08036804   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -766,7 +770,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x2000a100 0x08040056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000a100   R1 = 0x2000a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.46.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 runner                       0   0 ready
    |
    +--->  0x20001598 0x0800a48e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20001640 0x080083ac test_runner::start_test
-   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:296
-   |      0x20001640 0x080082ec test_runner::test_run
-   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:119
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20001640 0x080083d4 test_runner::start_test
+   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:300:5
+   |      0x20001640 0x080083d4 test_runner::test_run
+   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:150:9
    |      0x20001640 0x080083d4 main
-   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:228
+   |                 @ /home/bmc/hubris/test/test-runner/src/main.rs:230:9
    |
    |
    +--->   R0 = 0x20001608   R1 = 0x00010003   R2 = 0x80000000   R3 = 0x00000000
@@ -65,11 +65,11 @@ ID TASK                       GEN PRI STATE
  1 suite                       18   2 ready
    |
    +--->  0x20002510 0x080155a6 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20002570 0x08010a94 test_suite::test_fault
-   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:143
+   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:147:10
    |      0x200025a8 0x08010e3e test_suite::test_fault_badtaskop
-   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:265
+   |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:275:5
    |      0x20002640 0x080120e6 test_suite::main::{{closure}}
    |                 @ /home/bmc/hubris/test/test-suite/src/main.rs:861
    |      0x20002640 0x080120e6 userlib::hl::recv_without_notification::{{closure}}
@@ -135,19 +135,19 @@ ID TASK                       GEN PRI STATE
  2 assist                      18   1 RUNNING
    |
    +--->  0x20003558 0x08019d46 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x20003640 0x08018434 userlib::kipc::read_task_status
-   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:7
-   |      0x20003640 0x08018370 test_assist::main::{{closure}}
-   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:163
-   |      0x20003640 0x08018370 userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20003640 0x080182c0 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003640 0x080182c0 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x20003640 0x0801845a userlib::kipc::read_task_status
+   |                 @ /home/bmc/hubris/userlib/src/kipc.rs:13:5
+   |      0x20003640 0x0801845a test_assist::main::{{closure}}
+   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:230:33
+   |      0x20003640 0x0801845a userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20003640 0x0801845a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20003640 0x0801845a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003640 0x0801845a main
-   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:139
+   |                 @ /home/bmc/hubris/test/test-assist/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x2000361c   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -203,7 +203,7 @@ ID TASK                       GEN PRI STATE
  3 idle                         0   3 ready
    |
    +--->  0x20004100 0x0801c001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:807
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:813:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.47.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+76)
    |
    +--->  0x20001538 0x08009ef2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x080081f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x080081f2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x08008204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x08008204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20001600 0x08008204 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x0800a804   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200015c8
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b60 0x08015a16 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0801432a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0801432a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0801432a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801432a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x0801433a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x0801433a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x0801433a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x0801433a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x0801433a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -325,19 +327,19 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003398 0x080193ca userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:448:5
    |      0x200033e8 0x080182e8 core::option::Option<T>::ok_or
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:565
-   |      0x200033e8 0x080181ea drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x200033e8 0x080181ea userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x200033e8 0x08018166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x200033e8 0x08018166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:567:13
+   |      0x200033e8 0x080182e8 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:289:48
+   |      0x200033e8 0x080182e8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x200033e8 0x080182e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x200033e8 0x080182e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x200033e8 0x080182e8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x200033c0   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x00000004
@@ -393,9 +395,9 @@ ID TASK                       GEN PRI STATE
  6 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0801c20e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x0801c118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c74   R2 = 0x00000001   R3 = 0x00000000
@@ -451,17 +453,17 @@ ID TASK                       GEN PRI STATE
  7 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x0801eea6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x0801e0ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x0801e0ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x0801e0ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x0801e0ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x0801e0dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x0801e0dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x0801e0dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x0801e0dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x0801e0dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -517,11 +519,13 @@ ID TASK                       GEN PRI STATE
  8 pong                         0   3 recv, notif: bit0(T+276)
    |
    +--->  0x200047b8 0x08020d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802008c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802009a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802009a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802009a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -577,15 +581,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 notif: bit31(T+276)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028302 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282cc userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028302 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028302 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028302 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029078   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -641,7 +645,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20008100 0x08030056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.48.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20001538 0x08009ef2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x080081f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x080081f2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x08008204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x08008204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20001600 0x08008204 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x0800a804   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200015c8
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b60 0x08015a16 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0801432a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0801432a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0801432a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801432a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x0801433a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x0801433a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x0801433a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x0801433a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x0801433a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -325,7 +327,7 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 notif: bit0(irq84)
    |
    +--->  0x20003398 0x080193ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x200033e8 0x08018330 userlib::sys_recv
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
    |      0x200033e8 0x08018330 userlib::sys_recv_closed
@@ -395,9 +397,9 @@ ID TASK                       GEN PRI STATE
  6 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20003bb8 0x0801c20e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20003c00 0x0801c118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x20003c74   R2 = 0x00000001   R3 = 0x00000000
@@ -453,17 +455,17 @@ ID TASK                       GEN PRI STATE
  7 user_leds                    0   2 recv
    |
    +--->  0x200043c0 0x0801eea6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004400 0x0801e0ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004400 0x0801e0ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004400 0x0801e0ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004400 0x0801e0ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004400 0x0801e0dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004400 0x0801e0dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004400 0x0801e0dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004400 0x0801e0dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004400 0x0801e0dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -519,11 +521,13 @@ ID TASK                       GEN PRI STATE
  8 pong                         0   3 recv, notif: bit0(T+54)
    |
    +--->  0x200047b8 0x08020d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004800 0x0802008c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004800 0x0802009a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004800 0x0802009a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20004800 0x0802009a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -579,15 +583,15 @@ ID TASK                       GEN PRI STATE
  9 i2c_debug                    0   3 notif: bit31(T+54)
    |
    +--->  0x20006388 0x08028e6e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x08028302 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e0 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282cc userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x08028302 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x08028302 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x08028302 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:183
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:186:9
    |
    |
    +--->   R0 = 0x08029078   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200063d8
@@ -643,7 +647,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 RUNNING
    |
    +--->  0x20008100 0x08030056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20008100   R1 = 0x20008100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.49.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,29 +263,29 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
-   |      0x20002b20 0x08015b9c drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015b9c drv_stm32h7_i2c::ltc4306::write_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:107
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
+   |      0x20002b20 0x08015bc0 drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:449:17
+   |      0x20002b20 0x08015bc0 drv_stm32h7_i2c::ltc4306::write_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:114:11
    |      0x20002b20 0x08015bc0 <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:165:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002ad4
@@ -339,13 +341,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -401,17 +403,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -467,9 +469,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x20004454   R2 = 0x00000001   R3 = 0x00000000
@@ -525,17 +527,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -591,11 +593,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -651,15 +655,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -715,15 +719,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20008610 0x08033a1a drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:317
-   |      0x20008800 0x08030be4 drv_i2c_devices::adt7420::Adt7420::validate
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:60
-   |      0x20008800 0x08030a6c task_thermal::adt7420_read
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:142
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:337:9
+   |      0x20008800 0x08030bec drv_i2c_devices::adt7420::Adt7420::validate
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:61:15
+   |      0x20008800 0x08030bec task_thermal::adt7420_read
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:146:15
    |      0x20008800 0x08030bec main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:331:13
    |
    |
    +--->   R0 = 0x200085e4   R1 = 0x200085bc   R2 = 0x00000001   R3 = 0x00000002
@@ -779,15 +783,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x0804373a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x08040780 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x08040762 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x0804074c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x08040780 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x08040780 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x08040780 main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:161:9
    |
    |
    +--->   R0 = 0x080447c8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -843,15 +847,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -907,7 +911,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.5.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023c0 0x08015512 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x0801425a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x0801425a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x0801425a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x0801425a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x0801426a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x0801426a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x0801426a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x0801426a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x0801426a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:174
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:184:9
    |
    |
    +--->   R0 = 0x200023d4   R1 = 0x00000003   R2 = 0x00000000   R3 = 0x200023d8
@@ -245,13 +247,13 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f68 0x08019822 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20002f88 0x080186cc drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:112
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:114:6
    |      0x20002fe8 0x080180da drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:159
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:195:17
    |      0x20003000 0x080186b0 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:170:5
    |
    |
    +--->   R0 = 0x08019e3c   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002f6c
@@ -291,17 +293,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -341,11 +343,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+411)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -385,15 +389,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 notif: bit31(T+911)
    |
    +--->  0x20005fa0 0x08021726 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x0802025e userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020240 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x0802022c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x0802025e userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x0802025e userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x0802025e main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:100
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:103:9
    |
    |
    +--->   R0 = 0x08021cfc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fb8
@@ -433,15 +437,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 notif: bit31(T+361)
    |
    +--->  0x2000ff80 0x0802573e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010000 0x0802426c userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20010000 0x08024250 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20010000 0x08024238 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20010000 0x0802426c userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20010000 0x0802426c userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010000 0x0802426c main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:136:9
    |
    |
    +--->   R0 = 0x08025db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff9c

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.50.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,31 +263,31 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002ad0 0x0801638a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20002af0 0x08014064 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
-   |      0x20002b20 0x08015cd8 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015bde drv_stm32h7_i2c::ltc4306::read_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:82
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
+   |      0x20002b20 0x08015cea drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:541:17
+   |      0x20002b20 0x08015cea drv_stm32h7_i2c::ltc4306::read_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:91:11
    |      0x20002b20 0x08015cea <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:166:30
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x08016a40   R1 = 0x00000000   R2 = 0x00000008   R3 = 0x20002ad4
@@ -341,13 +343,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -403,17 +405,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -469,9 +471,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -527,17 +529,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -593,11 +595,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -653,15 +657,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -717,15 +721,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -781,15 +785,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -845,15 +849,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x2000c590 0x08050578 drv_i2c_api::I2cDevice::read_reg_into
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:350
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x2000c590 0x080505cc drv_i2c_api::I2cDevice::read_reg_into
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:370:9
    |      0x2000c590 0x080505cc task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120
-   |      0x2000c800 0x08050a90 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:91
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:140:17
+   |      0x2000c800 0x08050eb6 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:298:29
    |      0x2000c800 0x08050eb6 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:308:18
    |
    |
    +--->   R0 = 0x2000c550   R1 = 0x2000c528   R2 = 0x00000001   R3 = 0x00000002
@@ -909,7 +913,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.51.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,7 +263,7 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002b20 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
    |      0x20002c00 0x0801493e drv_stm32h7_i2c::I2cController::write_read
    |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
    |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
@@ -329,13 +331,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -391,17 +393,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -457,9 +459,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -705,15 +709,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 ready
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -769,15 +773,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -833,15 +837,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000c510 0x08052278 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
-   |      0x2000c590 0x08050602 drv_i2c_api::I2cDevice::read_block
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:381
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
+   |      0x2000c590 0x08050656 drv_i2c_api::I2cDevice::read_block
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:401:9
    |      0x2000c590 0x08050656 task_hiffy::i2c_read
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:120
-   |      0x2000c800 0x08050a90 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:91
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:157:23
+   |      0x2000c800 0x08050eb6 hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/6c48aec/src/lib.rs:298:29
    |      0x2000c800 0x08050eb6 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:308:18
    |
    |
    +--->   R0 = 0x2000c550   R1 = 0x2000c528   R2 = 0x00000001   R3 = 0x00000002
@@ -897,7 +901,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.52.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801638a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0801447a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002c00 0x0801447a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x0801448a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x0801448a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002c00 0x0801448a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002c00 0x0801448a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x0801448a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -327,13 +329,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -389,19 +391,19 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 RUNNING
    |
    +--->  0x20003b98 0x0801d3ca userlib::sys_borrow_read_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:447
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:448:5
    |      0x20003be8 0x0801c2e8 core::option::Option<T>::ok_or
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:565
-   |      0x20003be8 0x0801c1ea drv_stm32h7_spi_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:138
-   |      0x20003be8 0x0801c1ea userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/option.rs:567:13
+   |      0x20003be8 0x0801c2e8 drv_stm32h7_spi_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:289:48
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20003be8 0x0801c2e8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c2e8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x20003bc0   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x00000004
@@ -457,9 +459,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x20004474   R2 = 0x00000001   R3 = 0x00000000
@@ -515,17 +517,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -581,11 +583,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+178)
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -641,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 notif: bit31(T+178)
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -705,15 +709,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 notif: bit31(T+807)
    |
    +--->  0x200085d0 0x08035382 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20008610 0x080353ea userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20008610 0x080353c8 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20008610 0x080353ea userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
    |      0x20008610 0x080353ea userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20008800 0x08031626 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:364:9
    |
    |
    +--->   R0 = 0x080367f0   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200085d8
@@ -769,15 +773,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 notif: bit31(T+807)
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -833,15 +837,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 notif: bit31(T+10)
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -897,7 +901,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.53.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015b8 0x08009dc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08008898 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08008898 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08008898 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x080088a8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x080088a8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x080088a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x080088a8 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ceee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc8 0x0800f052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0800e14e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0800e14e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0800e14e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002000 0x0800e14e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0800e15e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0800e15e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0800e15e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002000 0x0800e15e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002000 0x0800e15e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x0801116a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0801013e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002400 0x0801013e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002400 0x0801013e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x0801014c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x0801014c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x0801014c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002400 0x0801014c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116a0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,35 +263,35 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 RUNNING
    |
    +--->  0x20002af0 0x08016408 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:615
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:616:5
    |      0x20002b20 0x08015cee core::ptr::read_volatile
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ptr/mod.rs:1052
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ptr/mod.rs:1058:14
    |      0x20002b20 0x08015cee vcell::VolatileCell<T>::get
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:30
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/vcell-0.1.3/src/lib.rs:33:18
    |      0x20002b20 0x08015cee stm32h7::generic::Reg<U,REG>::read
-   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/stm32h7-0.13.0/src/generic.rs:50
-   |      0x20002b20 0x08015cd8 drv_stm32h7_i2c::I2cController::write_read
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:357
-   |      0x20002b20 0x08015bde drv_stm32h7_i2c::ltc4306::read_reg_u8
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:82
+   |                 @ /home/bmc/.cargo/registry/src/github.com-1ecc6299db9ec823/stm32h7-0.13.0/src/generic.rs:51:18
+   |      0x20002b20 0x08015cee drv_stm32h7_i2c::I2cController::write_read
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:538:20
+   |      0x20002b20 0x08015cee drv_stm32h7_i2c::ltc4306::read_reg_u8
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:91:11
    |      0x20002b20 0x08015cee <drv_stm32h7_i2c::ltc4306::Ltc4306 as drv_stm32h7_i2c::I2cMuxDriver>::enable_segment
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:138
-   |      0x20002c00 0x08014852 drv_stm32h7_i2c_server::configure_mux::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::find_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:90
-   |      0x20002c00 0x08014830 drv_stm32h7_i2c_server::configure_mux
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:117
-   |      0x20002c00 0x0801476e drv_stm32h7_i2c_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403
-   |      0x20002c00 0x0801476e userlib::hl::recv_without_notification::{{closure}}
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123
-   |      0x20002c00 0x0801447a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002c00 0x0801447a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/ltc4306.rs:166:30
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:141:9
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::find_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:108:24
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::configure_mux
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:125:5
+   |      0x20002c00 0x080148a8 drv_stm32h7_i2c_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:421:23
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification::{{closure}}
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:47
+   |      0x20002c00 0x080148a8 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:100:29
+   |      0x20002c00 0x080148a8 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002c00 0x080148a8 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:188
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:403:9
    |
    |
    +--->   R0 = 0x00000008   R1 = 0x00000001   R2 = 0x00000008   R3 = 0x20002ad4
@@ -345,13 +347,13 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20003348 0x0801996e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20003368 0x0801842c core::ops::function::FnOnce::call_once
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/ops/function.rs:227:5
    |      0x200033d8 0x080180cc drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:683
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:717:17
    |      0x20003400 0x0801867c main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:68
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:200:5
    |
    |
    +--->   R0 = 0x08019f10   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x2000334c
@@ -407,17 +409,17 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 recv
    |
    +--->  0x20003b98 0x0801d3ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20003be8 0x0801c166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20003be8 0x0801c166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20003be8 0x0801c166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003be8 0x0801c166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20003be8 0x0801c176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20003be8 0x0801c176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003be8 0x0801c176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003be8 0x0801c176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:74
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:134:9
    |
    |
    +--->   R0 = 0x0801d980   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20003bc0
@@ -473,9 +475,9 @@ ID TASK                       GEN PRI STATE
  7 spi                          0   3 ready
    |
    +--->  0x200043b8 0x0802020e userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20004400 0x08020118 main
-   |                 @ /home/bmc/hubris/task-spi/src/main.rs:24
+   |                 @ /home/bmc/hubris/task-spi/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200043dc   R1 = 0x200044b4   R2 = 0x00000001   R3 = 0x00000000
@@ -531,17 +533,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x20004bc0 0x08022eae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20004c00 0x080220ce userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20004c00 0x080220ce userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20004c00 0x080220ce userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20004c00 0x080220ce userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20004c00 0x080220dc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20004c00 0x080220dc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20004c00 0x080220dc userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20004c00 0x080220dc userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20004c00 0x080220dc main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20004bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -597,11 +599,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 ready
    |
    +--->  0x20004fb8 0x08024d1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20005000 0x0802408c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20005000 0x0802409a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20005000 0x0802409a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20005000 0x0802409a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20004fc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004fd8
@@ -657,15 +661,15 @@ ID TASK                       GEN PRI STATE
 10 i2c_debug                    0   3 ready
    |
    +--->  0x20006280 0x08029816 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20006400 0x0802830a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20006400 0x080282e6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20006400 0x080282d0 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20006400 0x0802830a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20006400 0x0802830a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20006400 0x0802830a main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:204
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:210:9
    |
    |
    +--->   R0 = 0x08029d7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200062b0
@@ -721,15 +725,15 @@ ID TASK                       GEN PRI STATE
 11 thermal                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x200085b8 0x0803541a userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:126:5
    |      0x20008610 0x08033906 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:317
-   |      0x20008800 0x08030be4 drv_i2c_devices::adt7420::Adt7420::validate
-   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:60
-   |      0x20008800 0x08030a6c task_thermal::adt7420_read
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:142
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:337:9
+   |      0x20008800 0x08030bec drv_i2c_devices::adt7420::Adt7420::validate
+   |                 @ /home/bmc/hubris/drv/i2c-devices/src/adt7420.rs:61:15
+   |      0x20008800 0x08030bec task_thermal::adt7420_read
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:146:15
    |      0x20008800 0x08030bec main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:159
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:331:13
    |
    |
    +--->   R0 = 0x200085e4   R1 = 0x200085bc   R2 = 0x00000001   R3 = 0x00000002
@@ -785,15 +789,15 @@ ID TASK                       GEN PRI STATE
 12 power                        0   3 ready
    |
    +--->  0x2000a758 0x08043656 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000a800 0x0804077a userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000a800 0x0804075c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000a800 0x08040746 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000a800 0x0804077a userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000a800 0x0804077a userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000a800 0x0804077a main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:49
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x080446e4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000a7d8
@@ -849,15 +853,15 @@ ID TASK                       GEN PRI STATE
 13 hiffy                        0   3 ready
    |
    +--->  0x2000c590 0x08052246 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x2000c800 0x08050a40 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x2000c800 0x08050a1c userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x2000c800 0x08050a08 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x2000c800 0x08050a40 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x2000c800 0x08050a40 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:260
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:277:9
    |
    |
    +--->   R0 = 0x08052ba4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c7d0
@@ -913,7 +917,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 ready
    |
    +--->  0x2000e100 0x08060056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000e100   R1 = 0x2000e100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.54.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c8 0x08011db6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001600 0x08010886 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001600 0x08010886 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20001600 0x08010886 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001600 0x08010896 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001600 0x08010896 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001600 0x08010896 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20001600 0x08010896 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x08018e06 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20001c00 0x0801806e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20001c00 0x0801806e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0801806e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20001c00 0x0801807c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20001c00 0x0801807c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20001c00 0x0801807c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0801807c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0801807c main
-   |                 @ /home/bmc/hubris/drv/stm32fx-rcc/src/main.rs:105
+   |                 @ /home/bmc/hubris/drv/stm32fx-rcc/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,15 +133,15 @@ ID TASK                       GEN PRI STATE
  2 usart_driver                 0   2 recv, notif: bit0(irq38)
    |
    +--->  0x20001fc0 0x0801d202 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002000 0x0801c12c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
-   |      0x20002000 0x0801c12c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:164
-   |      0x20002000 0x0801c12c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002000 0x0801c13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002000 0x0801c13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002000 0x0801c13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x0801c13a main
-   |                 @ /home/bmc/hubris/drv/stm32fx-usart/src/main.rs:55
+   |                 @ /home/bmc/hubris/drv/stm32fx-usart/src/main.rs:116:9
    |
    |
    +--->   R0 = 0x0801d7f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fdc
@@ -195,11 +197,17 @@ ID TASK                       GEN PRI STATE
  3 user_leds                    0   2 recv
    |
    +--->  0x200023d0 0x08021052 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002400 0x0802009c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002400 0x080200aa userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002400 0x080200aa userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
+   |      0x20002400 0x080200aa userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x080200aa userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x080200aa main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200023d8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023dc
@@ -255,11 +263,11 @@ ID TASK                       GEN PRI STATE
  4 ping                        59   4 FAULT: divide by zero (was: ready)
    |
    +--->  0x200025b0 0x0802405e task_ping::divzero
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:28
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:34:9
    |      0x20002600 0x080240f2 userlib::sys_panic
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:642
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:643:14
    |      0x20002600 0x080240f2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:39
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:59:9
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x0000007b   R2 = 0x00000000   R3 = 0x00000000
@@ -318,11 +326,13 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+296)
    |
    +--->  0x20002bb8 0x08026d1a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
-   |      0x20002c00 0x0802608c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:208
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
+   |      0x20002c00 0x0802609a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:234:5
+   |      0x20002c00 0x0802609a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168:11
    |      0x20002c00 0x0802609a main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20002bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002bd8
@@ -378,15 +388,15 @@ ID TASK                       GEN PRI STATE
  6 hiffy                        0   3 notif: bit31(T+203)
    |
    +--->  0x20004588 0x08029ae6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:261
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:268:5
    |      0x20004800 0x080283ac userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:688
-   |      0x20004800 0x08028388 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:474
-   |      0x20004800 0x08028374 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:499
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693:9
+   |      0x20004800 0x080283ac userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:489:12
+   |      0x20004800 0x080283ac userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:500:5
    |      0x20004800 0x080283ac main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:279
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:304:9
    |
    |
    +--->   R0 = 0x0802a340   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200047b0
@@ -442,7 +452,7 @@ ID TASK                       GEN PRI STATE
  7 idle                         0   5 RUNNING
    |
    +--->  0x20006100 0x08030056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20006100   R1 = 0x20006100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.6.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -197,7 +199,7 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x20002400 0x08014130 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248:0
    |
    |
    +-----------> 0x20000348 Task {
@@ -231,17 +233,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 wait: reply from i2c_driver/gen0
    |
    +--->  0x20002f80 0x08019806 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20002fe0 0x08018156 drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:168
-   |      0x20002fe0 0x08018128 drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:130
-   |      0x20002fe0 0x08018128 core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
-   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:268
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20002fe0 0x080181c8 drv_i2c_api::I2c::read_reg
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:184:9
+   |      0x20002fe0 0x080181c8 drv_stm32h7_i2c_target_server::main::{{closure}}
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:142:23
+   |      0x20002fe0 0x080181c8 core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
+   |                 @ /rustc/2987785df3d46d5ff144a5c67fbb8f5cca798d78/library/core/src/ops/function.rs:269:13
    |      0x20002fe0 0x080181c8 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:323
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:405:30
    |      0x20003000 0x08018630 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:185:5
    |
    |
    +--->   R0 = 0x20002fbc   R1 = 0x20002fad   R2 = 0x00000002   R3 = 0x00000004
@@ -281,17 +283,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -331,11 +333,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 ready
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -375,15 +379,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 ready
    |
    +--->  0x20005f78 0x08022be6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x08020378 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020358 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x08020342 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x08020378 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x08020378 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x08020378 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x08023db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fa0
@@ -423,13 +427,13 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 ready
    |
    +--->  0x2000ff78 0x08029880 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20010000 0x080282b8 drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:168
-   |      0x20010000 0x0802829a task_adt7420::validate
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:36
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20010000 0x08028310 drv_i2c_api::I2c::read_reg
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:184:9
+   |      0x20010000 0x08028310 task_adt7420::validate
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:40:11
    |      0x20010000 0x08028310 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:143:20
    |
    |
    +--->   R0 = 0x2000ff98   R1 = 0x00040001   R2 = 0x00000002   R3 = 0x00000000
@@ -469,7 +473,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 ready
    |
    +--->  0x20010100 0x0802c052 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20010000   R1 = 0x20010000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.63.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009d9e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001600 0x08008892 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001600 0x08008892 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20001600 0x08008892 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001600 0x080088a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001600 0x080088a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001600 0x080088a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20001600 0x080088a2 main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002000 0x0800e166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002000 0x0800e166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002000 0x0800e166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002000 0x0800e166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002000 0x0800e176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002000 0x0800e176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002000 0x0800e176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002000 0x0800e176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002000 0x0800e176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002400 0x0801018e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002400 0x0801018e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002400 0x0801018e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002400 0x0801019e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002400 0x0801019e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002400 0x0801019e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20002400 0x0801019e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x080114d0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b80 0x08015962 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002c00 0x08014314 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002c00 0x08014314 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002c00 0x08014314 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x08014314 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002c00 0x08014322 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002c00 0x08014322 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002c00 0x08014322 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x08014322 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x08014322 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:508:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -327,17 +329,17 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20003388 0x080193c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x200033e8 0x08018200 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x200033e8 0x08018200 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x200033e8 0x08018200 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200033e8 0x08018200 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x200033e8 0x0801820e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x200033e8 0x0801820e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x200033e8 0x0801820e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200033e8 0x0801820e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200033e8 0x0801820e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x08019970   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200033c0
@@ -393,17 +395,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200043c8 0x0801ce6a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20004400 0x0801c0de userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20004400 0x0801c0de userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20004400 0x0801c0de userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20004400 0x0801c0de userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20004400 0x0801c0ee userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20004400 0x0801c0ee userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20004400 0x0801c0ee userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20004400 0x0801c0ee userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20004400 0x0801c0ee main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200043cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200043d8
@@ -459,11 +461,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+221)
    |
    +--->  0x200047b0 0x0801ecde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20004800 0x0801e096 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20004800 0x0801e0a6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20004800 0x0801e0a6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
    |      0x20004800 0x0801e0a6 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200047c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200047d8
@@ -519,15 +523,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+175)
    |
    +--->  0x20008580 0x08022386 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x20008800 0x08020abc userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x20008800 0x08020a9a userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
-   |      0x20008800 0x08020a7c userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x20008800 0x08020abc userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
+   |      0x20008800 0x08020abc userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x20008800 0x08020abc main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:626
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:665:9
    |
    |
    +--->   R0 = 0x08022dac   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200087b0
@@ -583,11 +587,11 @@ ID TASK                       GEN PRI STATE
  9 ping                        20   4 wait: reply from usart_driver/gen0
    |
    +--->  0x2000c1b0 0x08028f58 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:128
-   |      0x2000c200 0x08028098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:56
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:129:5
+   |      0x2000c200 0x080280c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:60:10
    |      0x2000c200 0x080280c2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:31
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x2000c1dc   R1 = 0x2000c1d0   R2 = 0x00000000   R3 = 0x00000000
@@ -643,7 +647,7 @@ ID TASK                       GEN PRI STATE
 10 idle                         0   5 RUNNING
    |
    +--->  0x2000c300 0x0802a056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000c300   R1 = 0x2000c300   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.64.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009daa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001600 0x0800889c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001600 0x0800889c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20001600 0x0800889c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001600 0x080088ac userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001600 0x080088ac userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001600 0x080088ac userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20001600 0x080088ac main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002000 0x0800e166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002000 0x0800e166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002000 0x0800e166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002000 0x0800e166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002000 0x0800e176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002000 0x0800e176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002000 0x0800e176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002000 0x0800e176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002000 0x0800e176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002400 0x0801018e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002400 0x0801018e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002400 0x0801018e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002400 0x0801019e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002400 0x0801019e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002400 0x0801019e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20002400 0x0801019e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x080114d0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801624a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002c00 0x080144d2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002c00 0x080144d2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002c00 0x080144d2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x080144d2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002c00 0x080144e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002c00 0x080144e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002c00 0x080144e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x080144e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x080144e2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:508:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -327,19 +329,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          1   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:300:17 (was: ready)
    |
    +--->  0x20004230 0x08019d00 userlib::sys_panic_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:654
-   |      0x200042e0 0x08019d46 userlib::sys_panic
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:645
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:655:5
+   |      0x200042e0 0x08019d4c userlib::sys_panic
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:646:14
    |      0x200042e0 0x08019d4c rust_begin_unwind
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:832
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:854:5
    |      0x200042f8 0x08018d4c core::panicking::panic_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:92:14
    |      0x20004320 0x08018a8a core::panicking::panic
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:39
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:50:5
    |      0x20004360 0x08018402 drv_stm32h7_i2c::I2cController::operate_as_target
    |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:711
    |      0x20004400 0x08018912 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:70
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:336:5
    |
    |
    +--->   R0 = 0x20004238   R1 = 0x00000047   R2 = 0x00000000   R3 = 0x00000001
@@ -398,17 +400,17 @@ ID TASK                       GEN PRI STATE
  6 spi2_driver                  0   2 recv
    |
    +--->  0x20008390 0x0801d3ae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x200083e8 0x0801c1f6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x200083e8 0x0801c1f6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x200083e8 0x0801c1f6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200083e8 0x0801c1f6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x200083e8 0x0801c204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x200083e8 0x0801c204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x200083e8 0x0801c204 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200083e8 0x0801c204 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200083e8 0x0801c204 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x0801d960   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200083c0
@@ -464,17 +466,17 @@ ID TASK                       GEN PRI STATE
  7 spi4_driver                  0   2 recv
    |
    +--->  0x20009390 0x080213ae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x200093e8 0x080201f6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x200093e8 0x080201f6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x200093e8 0x080201f6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200093e8 0x080201f6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x200093e8 0x08020204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x200093e8 0x08020204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x200093e8 0x08020204 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200093e8 0x08020204 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200093e8 0x08020204 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x08021960   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200093c0
@@ -530,17 +532,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x2000a3c8 0x08024e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x2000a400 0x080240e0 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x2000a400 0x080240e0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x2000a400 0x080240e0 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x2000a400 0x080240e0 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x2000a400 0x080240f0 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x2000a400 0x080240f0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x2000a400 0x080240f0 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x2000a400 0x080240f0 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x2000a400 0x080240f0 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x2000a3cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2000a3d8
@@ -596,11 +598,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+61)
    |
    +--->  0x2000a7b0 0x08026cde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x2000a800 0x08026096 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x2000a800 0x080260a6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x2000a800 0x080260a6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
    |      0x2000a800 0x080260a6 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x2000a7c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2000a7d8
@@ -656,15 +660,15 @@ ID TASK                       GEN PRI STATE
 10 thermal                      0   3 notif: bit31(T+609)
    |
    +--->  0x2000c670 0x08033fde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x2000c6b0 0x0803404e userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x2000c6b0 0x08034028 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x2000c6b0 0x0803404e userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
    |      0x2000c6b0 0x0803404e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x2000c800 0x080307e2 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:155
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:432:9
    |
    |
    +--->   R0 = 0x080352bc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c678
@@ -720,15 +724,15 @@ ID TASK                       GEN PRI STATE
 11 power                        0   3 notif: bit31(T+608)
    |
    +--->  0x2000e760 0x08043686 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x2000e800 0x080407d8 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x2000e800 0x080407b6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
-   |      0x2000e800 0x0804079e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x2000e800 0x080407d8 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
+   |      0x2000e800 0x080407d8 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x2000e800 0x080407d8 main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:45
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x08044750   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000e7d8
@@ -784,15 +788,15 @@ ID TASK                       GEN PRI STATE
 12 hiffy                        0   3 notif: bit31(T+171)
    |
    +--->  0x20010580 0x08052d06 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x20010800 0x080512e8 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x20010800 0x080512c6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
-   |      0x20010800 0x080512a8 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x20010800 0x080512e8 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
+   |      0x20010800 0x080512e8 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x20010800 0x080512e8 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:626
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:665:9
    |
    |
    +--->   R0 = 0x0805385c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200107b0
@@ -848,7 +852,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 RUNNING
    |
    +--->  0x20014100 0x08058056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20014100   R1 = 0x20014100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.65.stdout
@@ -3,15 +3,15 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x200015c0 0x08009daa userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001600 0x0800889c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001600 0x0800889c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20001600 0x0800889c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001600 0x080088ac userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001600 0x080088ac userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001600 0x080088ac userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20001600 0x080088ac main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:132
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x200015e0   R1 = 0x00000004   R2 = 0x00000001   R3 = 0x200015e4
@@ -67,15 +67,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20001bd8 0x0800ce66 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20001c00 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20001c00 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20001c00 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20001c00 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20001c00 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20001c00 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20001c00 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20001be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20001be4
@@ -131,17 +133,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001fc0 0x0800f012 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002000 0x0800e166 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002000 0x0800e166 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002000 0x0800e166 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002000 0x0800e166 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002000 0x0800e176 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002000 0x0800e176 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002000 0x0800e176 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002000 0x0800e176 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002000 0x0800e176 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20001fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001fd8
@@ -197,15 +199,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200023c0 0x08010fe6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002400 0x0801018e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002400 0x0801018e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002400 0x0801018e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002400 0x0801019e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002400 0x0801019e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002400 0x0801019e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20002400 0x0801019e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x080114d0   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200023d8
@@ -261,17 +263,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b20 0x0801624a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x20002c00 0x080144d2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x20002c00 0x080144d2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x20002c00 0x080144d2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x080144d2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x20002c00 0x080144e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x20002c00 0x080144e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x20002c00 0x080144e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x080144e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x080144e2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:508:9
    |
    |
    +--->   R0 = 0x20002bcc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bdc
@@ -327,19 +329,19 @@ ID TASK                       GEN PRI STATE
  5 spd                          2   2 FAULT: panicked at 'attempt to add with overflow', task-spd/src/main.rs:312:17 (was: ready)
    |
    +--->  0x20004230 0x08019d00 userlib::sys_panic_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:654
-   |      0x200042e0 0x08019d46 userlib::sys_panic
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:645
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:655:5
+   |      0x200042e0 0x08019d4c userlib::sys_panic
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:646:14
    |      0x200042e0 0x08019d4c rust_begin_unwind
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:832
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:854:5
    |      0x200042f8 0x08018d4c core::panicking::panic_fmt
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:77
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:92:14
    |      0x20004320 0x08018a8a core::panicking::panic
-   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82//library/core/src/panicking.rs:39
+   |                 @ /rustc/7f4afdf0255600306bf67432da722c7b5d2cbf82/library/core/src/panicking.rs:50:5
    |      0x20004360 0x08018402 drv_stm32h7_i2c::I2cController::operate_as_target
    |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:711
    |      0x20004400 0x08018912 main
-   |                 @ /home/bmc/hubris/task-spd/src/main.rs:70
+   |                 @ /home/bmc/hubris/task-spd/src/main.rs:334:5
    |
    |
    +--->   R0 = 0x20004238   R1 = 0x00000047   R2 = 0x00000000   R3 = 0x00000001
@@ -398,17 +400,17 @@ ID TASK                       GEN PRI STATE
  6 spi2_driver                  0   2 recv
    |
    +--->  0x20008390 0x0801d3ae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x200083e8 0x0801c1f6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x200083e8 0x0801c1f6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x200083e8 0x0801c1f6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200083e8 0x0801c1f6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x200083e8 0x0801c204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x200083e8 0x0801c204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x200083e8 0x0801c204 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200083e8 0x0801c204 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200083e8 0x0801c204 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x0801d960   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200083c0
@@ -464,17 +466,17 @@ ID TASK                       GEN PRI STATE
  7 spi4_driver                  0   2 recv
    |
    +--->  0x20009390 0x080213ae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x200093e8 0x080201f6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x200093e8 0x080201f6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x200093e8 0x080201f6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200093e8 0x080201f6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x200093e8 0x08020204 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x200093e8 0x08020204 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x200093e8 0x08020204 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200093e8 0x08020204 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200093e8 0x08020204 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x08021960   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x200093c0
@@ -530,17 +532,17 @@ ID TASK                       GEN PRI STATE
  8 user_leds                    0   2 recv
    |
    +--->  0x2000a3c8 0x08024e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x2000a400 0x080240e0 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
-   |      0x2000a400 0x080240e0 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167
-   |      0x2000a400 0x080240e0 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x2000a400 0x080240e0 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x2000a400 0x080240f0 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x2000a400 0x080240f0 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
+   |      0x2000a400 0x080240f0 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x2000a400 0x080240f0 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x2000a400 0x080240f0 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x2000a3cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x2000a3d8
@@ -596,11 +598,13 @@ ID TASK                       GEN PRI STATE
  9 pong                         0   3 recv, notif: bit0(T+432)
    |
    +--->  0x2000a7b0 0x08026cde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
-   |      0x2000a800 0x08026096 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:211
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
+   |      0x2000a800 0x080260a6 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:237:5
+   |      0x2000a800 0x080260a6 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:171:11
    |      0x2000a800 0x080260a6 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x2000a7c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2000a7d8
@@ -656,15 +660,15 @@ ID TASK                       GEN PRI STATE
 10 thermal                      0   3 notif: bit31(T+661)
    |
    +--->  0x2000c670 0x08033fde userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x2000c6b0 0x0803404e userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x2000c6b0 0x08034028 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x2000c6b0 0x0803404e userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
    |      0x2000c6b0 0x0803404e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x2000c800 0x080307e2 main
-   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:155
+   |                 @ /home/bmc/hubris/task-thermal/src/main.rs:432:9
    |
    |
    +--->   R0 = 0x080352bc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000c678
@@ -720,15 +724,15 @@ ID TASK                       GEN PRI STATE
 11 power                        0   3 notif: bit31(T+660)
    |
    +--->  0x2000e760 0x08043686 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x2000e800 0x080407d8 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x2000e800 0x080407b6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
-   |      0x2000e800 0x0804079e userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x2000e800 0x080407d8 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
+   |      0x2000e800 0x080407d8 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x2000e800 0x080407d8 main
-   |                 @ /home/bmc/hubris/task-power/src/main.rs:45
+   |                 @ /home/bmc/hubris/task-power/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x08044750   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000e7d8
@@ -784,15 +788,15 @@ ID TASK                       GEN PRI STATE
 12 hiffy                        0   3 notif: bit31(T+42)
    |
    +--->  0x20010580 0x08052d06 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:264
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:271:5
    |      0x20010800 0x080512e8 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:691
-   |      0x20010800 0x080512c6 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:553
-   |      0x20010800 0x080512a8 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:578
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:696:9
+   |      0x20010800 0x080512e8 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:568:12
+   |      0x20010800 0x080512e8 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:579:5
    |      0x20010800 0x080512e8 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:626
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:665:9
    |
    |
    +--->   R0 = 0x0805385c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200107b0
@@ -848,7 +852,7 @@ ID TASK                       GEN PRI STATE
 13 idle                         0   5 RUNNING
    |
    +--->  0x20014100 0x08058056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20014100   R1 = 0x20014100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.66.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+97)
    |
    +--->  0x20005538 0x00011efe userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20005600 0x000101ee userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20005600 0x000101ee userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20005600 0x000101fe userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20005600 0x000101fe userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x20005600 0x000101fe main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x00012818   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200055dc
@@ -65,15 +65,15 @@ ID TASK                       GEN PRI STATE
  1 hiffy                        0   3 notif: bit31(T+101)
    |
    +--->  0x20008580 0x0001a13a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
    |      0x20008800 0x000182d2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692
-   |      0x20008800 0x000182b4 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:622
-   |      0x20008800 0x00018294 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:647
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:697:9
+   |      0x20008800 0x000182d2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:637:12
+   |      0x20008800 0x000182d2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:648:5
    |      0x20008800 0x000182d2 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:75
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:92:9
    |
    |
    +--->   R0 = 0x0001ab7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200087b0
@@ -129,7 +129,7 @@ ID TASK                       GEN PRI STATE
  2 idle                         0   5 RUNNING
    |
    +--->  0x2000c900 0x00042056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000c900   R1 = 0x2000c900   R2 = 0x00000000   R3 = 0x00000000
@@ -185,15 +185,17 @@ ID TASK                       GEN PRI STATE
  3 syscon_driver                0   2 recv
    |
    +--->  0x200063c0 0x00020d2a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200063e8 0x00020094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200063e8 0x00020094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200063e8 0x00020094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200063e8 0x000200a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200063e8 0x000200a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200063e8 0x000200a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200063e8 0x000200a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200063e8 0x000200a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200063c8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200063cc
@@ -249,17 +251,17 @@ ID TASK                       GEN PRI STATE
  4 gpio_driver                  0   2 recv
    |
    +--->  0x200067a8 0x000258da userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200067e8 0x000240d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200067e8 0x000240d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x200067e8 0x000240d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200067e8 0x000240d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200067e8 0x000240e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200067e8 0x000240e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200067e8 0x000240e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200067e8 0x000240e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200067e8 0x000240e2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:63
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:168:9
    |
    |
    +--->   R0 = 0x200067c0   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200067cc
@@ -315,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x00028f7e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20006be8 0x000280c6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20006be8 0x000280c6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x20006be8 0x000280c6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20006be8 0x000280c6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20006be8 0x000280d4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20006be8 0x000280d4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x20006be8 0x000280d4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20006be8 0x000280d4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20006be8 0x000280d4 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20006bb8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20006bc0
@@ -381,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x20006fb0 0x0002d15e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20006fe8 0x0002c176 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20006fe8 0x0002c176 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20006fe8 0x0002c184 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20006fe8 0x0002c184 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x20006fe8 0x0002c184 main
-   |                 @ /home/bmc/hubris/drv/lpc55-usart/src/main.rs:42
+   |                 @ /home/bmc/hubris/drv/lpc55-usart/src/main.rs:99:23
    |
    |
    +--->   R0 = 0x0002d698   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20006fc0
@@ -443,17 +445,17 @@ ID TASK                       GEN PRI STATE
  7 i2c_driver                   0   2 recv
    |
    +--->  0x200073b8 0x0003133c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200073e8 0x0003012e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200073e8 0x0003012e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x200073e8 0x0003012e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200073e8 0x0003012e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200073e8 0x0003013e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200073e8 0x0003013e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200073e8 0x0003013e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200073e8 0x0003013e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200073e8 0x0003013e main
-   |                 @ /home/bmc/hubris/drv/lpc55-i2c/src/main.rs:54
+   |                 @ /home/bmc/hubris/drv/lpc55-i2c/src/main.rs:86:9
    |
    |
    +--->   R0 = 0x200073ca   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200073cc
@@ -509,11 +511,17 @@ ID TASK                       GEN PRI STATE
  8 rng_driver                   0   2 recv
    |
    +--->  0x200077b8 0x00034f1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200077e8 0x000340b4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200077e8 0x000340c2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200077e8 0x000340c2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200077e8 0x000340c2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200077e8 0x000340c2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200077e8 0x000340c2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-rng/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/lpc55-rng/src/main.rs:59:9
    |
    |
    +--->   R0 = 0x200077bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200077c0
@@ -569,15 +577,15 @@ ID TASK                       GEN PRI STATE
  9 spi_driver                   0   2 recv, notif: bit0(irq59)
    |
    +--->  0x20007b68 0x00039594 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20007be8 0x00038256 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20007be8 0x00038256 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x20007be8 0x00038256 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20007be8 0x00038264 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20007be8 0x00038264 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x20007be8 0x00038264 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20007be8 0x00038264 main
-   |                 @ /home/bmc/hubris/drv/lpc55-spi-server/src/main.rs:70
+   |                 @ /home/bmc/hubris/drv/lpc55-spi-server/src/main.rs:115:9
    |
    |
    +--->   R0 = 0x00039b38   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20007b80
@@ -633,11 +641,11 @@ ID TASK                       GEN PRI STATE
 10 ping                        44   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007f98 0x0003cfa0 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:129
-   |      0x20007fe8 0x0003c098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:56
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:130:5
+   |      0x20007fe8 0x0003c0c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:60:10
    |      0x20007fe8 0x0003c0c2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:31
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x20007fc4   R1 = 0x20007fb8   R2 = 0x00000000   R3 = 0x00000000
@@ -693,11 +701,13 @@ ID TASK                       GEN PRI STATE
 11 pong                         0   3 recv, notif: bit0(T+97)
    |
    +--->  0x2000c398 0x0003ed02 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x2000c3e8 0x0003e0ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x2000c3e8 0x0003e0bc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x2000c3e8 0x0003e0bc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x2000c3e8 0x0003e0bc main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:22:23
    |
    |
    +--->   R0 = 0x2000c3ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2000c3c0
@@ -753,7 +763,7 @@ ID TASK                       GEN PRI STATE
 12 spam                         0   3 not started
    |
    +--->  0x2000c7e8 0x00040001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:766
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.67.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+27)
    |
    +--->  0x20005538 0x00011efe userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20005600 0x000101ee userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20005600 0x000101ee userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20005600 0x000101fe userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20005600 0x000101fe userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x20005600 0x000101fe main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x00012818   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200055dc
@@ -65,15 +65,15 @@ ID TASK                       GEN PRI STATE
  1 hiffy                        0   3 notif: bit31(T+31)
    |
    +--->  0x20008580 0x0001a13a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
    |      0x20008800 0x000182d2 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692
-   |      0x20008800 0x000182b4 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:622
-   |      0x20008800 0x00018294 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:647
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:697:9
+   |      0x20008800 0x000182d2 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:637:12
+   |      0x20008800 0x000182d2 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:648:5
    |      0x20008800 0x000182d2 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:75
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:92:9
    |
    |
    +--->   R0 = 0x0001ab7c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200087b0
@@ -129,7 +129,7 @@ ID TASK                       GEN PRI STATE
  2 idle                         0   5 RUNNING
    |
    +--->  0x2000c900 0x00042056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x2000c900   R1 = 0x2000c900   R2 = 0x00000000   R3 = 0x00000000
@@ -185,15 +185,17 @@ ID TASK                       GEN PRI STATE
  3 syscon_driver                0   2 recv
    |
    +--->  0x200063c0 0x00020d2a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200063e8 0x00020094 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200063e8 0x00020094 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200063e8 0x00020094 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200063e8 0x000200a2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200063e8 0x000200a2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200063e8 0x000200a2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200063e8 0x000200a2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200063e8 0x000200a2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:153
+   |                 @ /home/bmc/hubris/drv/lpc55-syscon/src/main.rs:169:9
    |
    |
    +--->   R0 = 0x200063c8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200063cc
@@ -249,17 +251,17 @@ ID TASK                       GEN PRI STATE
  4 gpio_driver                  0   2 recv
    |
    +--->  0x200067a8 0x000258da userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200067e8 0x000240d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200067e8 0x000240d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x200067e8 0x000240d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200067e8 0x000240d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200067e8 0x000240e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200067e8 0x000240e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200067e8 0x000240e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200067e8 0x000240e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200067e8 0x000240e2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:63
+   |                 @ /home/bmc/hubris/drv/lpc55-gpio/src/main.rs:168:9
    |
    |
    +--->   R0 = 0x200067c0   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x200067cc
@@ -315,17 +317,17 @@ ID TASK                       GEN PRI STATE
  5 user_leds                    0   2 recv
    |
    +--->  0x20006bb0 0x00028f7e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20006be8 0x000280c6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20006be8 0x000280c6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x20006be8 0x000280c6 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20006be8 0x000280c6 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20006be8 0x000280d4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20006be8 0x000280d4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x20006be8 0x000280d4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20006be8 0x000280d4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20006be8 0x000280d4 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x20006bb8   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20006bc0
@@ -381,13 +383,13 @@ ID TASK                       GEN PRI STATE
  6 usart_driver                 0   2 recv, notif: bit0(irq14)
    |
    +--->  0x20006fb0 0x0002d15e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20006fe8 0x0002c176 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20006fe8 0x0002c176 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20006fe8 0x0002c184 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20006fe8 0x0002c184 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x20006fe8 0x0002c184 main
-   |                 @ /home/bmc/hubris/drv/lpc55-usart/src/main.rs:42
+   |                 @ /home/bmc/hubris/drv/lpc55-usart/src/main.rs:99:23
    |
    |
    +--->   R0 = 0x0002d698   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20006fc0
@@ -443,17 +445,17 @@ ID TASK                       GEN PRI STATE
  7 i2c_driver                   0   2 recv
    |
    +--->  0x200073b8 0x0003133c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200073e8 0x0003012e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x200073e8 0x0003012e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x200073e8 0x0003012e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x200073e8 0x0003012e userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200073e8 0x0003013e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200073e8 0x0003013e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200073e8 0x0003013e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200073e8 0x0003013e userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200073e8 0x0003013e main
-   |                 @ /home/bmc/hubris/drv/lpc55-i2c/src/main.rs:54
+   |                 @ /home/bmc/hubris/drv/lpc55-i2c/src/main.rs:86:9
    |
    |
    +--->   R0 = 0x200073ca   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x200073cc
@@ -509,11 +511,17 @@ ID TASK                       GEN PRI STATE
  8 rng_driver                   0   2 recv
    |
    +--->  0x200077b8 0x00034f1e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x200077e8 0x000340b4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x200077e8 0x000340c2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x200077e8 0x000340c2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x200077e8 0x000340c2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x200077e8 0x000340c2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x200077e8 0x000340c2 main
-   |                 @ /home/bmc/hubris/drv/lpc55-rng/src/main.rs:47
+   |                 @ /home/bmc/hubris/drv/lpc55-rng/src/main.rs:59:9
    |
    |
    +--->   R0 = 0x200077bc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200077c0
@@ -569,15 +577,15 @@ ID TASK                       GEN PRI STATE
  9 spi_driver                   0   2 recv, notif: bit0(irq59)
    |
    +--->  0x20007b68 0x00039594 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x20007be8 0x00038256 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
-   |      0x20007be8 0x00038256 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:168
-   |      0x20007be8 0x00038256 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x20007be8 0x00038264 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x20007be8 0x00038264 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
+   |      0x20007be8 0x00038264 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20007be8 0x00038264 main
-   |                 @ /home/bmc/hubris/drv/lpc55-spi-server/src/main.rs:70
+   |                 @ /home/bmc/hubris/drv/lpc55-spi-server/src/main.rs:115:9
    |
    |
    +--->   R0 = 0x00039b38   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20007b80
@@ -633,11 +641,11 @@ ID TASK                       GEN PRI STATE
 10 ping                        50   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20007f98 0x0003cfa0 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:129
-   |      0x20007fe8 0x0003c098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:56
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:130:5
+   |      0x20007fe8 0x0003c0c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:60:10
    |      0x20007fe8 0x0003c0c2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:31
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x20007fc4   R1 = 0x20007fb8   R2 = 0x00000000   R3 = 0x00000000
@@ -693,11 +701,13 @@ ID TASK                       GEN PRI STATE
 11 pong                         0   3 recv, notif: bit0(T+27)
    |
    +--->  0x2000c398 0x0003ed02 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:265
-   |      0x2000c3e8 0x0003e0ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:212
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:272:5
+   |      0x2000c3e8 0x0003e0bc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:238:5
+   |      0x2000c3e8 0x0003e0bc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:172:11
    |      0x2000c3e8 0x0003e0bc main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:22:23
    |
    |
    +--->   R0 = 0x2000c3ac   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x2000c3c0
@@ -753,7 +763,7 @@ ID TASK                       GEN PRI STATE
 12 spam                         0   3 not started
    |
    +--->  0x2000c7e8 0x00040001 _start
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:766
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:772:5
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.68.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+41)
    |
    +--->  0x20002540 0x08011fc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20002600 0x080102bc userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20002600 0x080102bc userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20002600 0x080102ce userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20002600 0x080102ce userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
    |      0x20002600 0x080102ce main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x08012918   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200025dc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08020e66 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20003c00 0x0802006c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20003c00 0x0802006c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20003c00 0x0802006c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20003c00 0x0802007a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20003c00 0x0802007a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20003c00 0x0802007a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20003c00 0x0802007a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20003c00 0x0802007a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20003be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20003be4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc0 0x08023036 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004000 0x0802217c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004000 0x0802217c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004000 0x0802217c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20004000 0x0802217c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004000 0x0802218c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004000 0x0802218c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004000 0x0802218c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20004000 0x0802218c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20004000 0x0802218c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20003fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20003fd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200043c0 0x08024fee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004400 0x0802418e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004400 0x0802418e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004400 0x0802418e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004400 0x0802419e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004400 0x0802419e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004400 0x0802419e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20004400 0x0802419e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x08025514   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200043d8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b78 0x08015ba0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20002c00 0x0801442c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20002c00 0x0801442c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20002c00 0x0801442c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x0801442c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20002c00 0x0801443a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20002c00 0x0801443a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20002c00 0x0801443a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x0801443a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x0801443a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:146
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:175:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -325,15 +327,15 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20001370 0x08019968 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x200013e8 0x080183ea userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x200013e8 0x080183ea userlib::hl::recv_from
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:132
-   |      0x200013e8 0x080183ea userlib::hl::recv_from_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:173
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x200013e8 0x080183f2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x200013e8 0x080183f2 userlib::hl::recv_from
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:145:9
+   |      0x200013e8 0x080183f2 userlib::hl::recv_from_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:182:5
    |      0x200013e8 0x080183f2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:42
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:104:18
    |
    |
    +--->   R0 = 0x200013aa   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x200013c0
@@ -389,17 +391,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200047c8 0x08026ece userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004800 0x08026122 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004800 0x08026122 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004800 0x08026122 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20004800 0x08026122 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004800 0x08026130 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004800 0x08026130 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004800 0x08026130 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20004800 0x08026130 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20004800 0x08026130 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200047cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200047d8
@@ -455,11 +457,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+141)
    |
    +--->  0x20004bb0 0x08028d02 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004c00 0x080280ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004c00 0x080280bc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004c00 0x080280bc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
    |      0x20004c00 0x080280bc main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:22:23
    |
    |
    +--->   R0 = 0x20004bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004bd8
@@ -515,15 +519,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+169)
    |
    +--->  0x20008578 0x0800c02e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
    |      0x20008800 0x08008a38 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693
-   |      0x20008800 0x08008a14 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:622
-   |      0x20008800 0x080089f6 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:647
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:698:9
+   |      0x20008800 0x08008a38 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:637:12
+   |      0x20008800 0x08008a38 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:648:5
    |      0x20008800 0x08008a38 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:79
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:96:9
    |
    |
    +--->   R0 = 0x0800d574   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200087b0
@@ -579,17 +583,17 @@ ID TASK                       GEN PRI STATE
  9 hf                           0   3 recv
    |
    +--->  0x200036b0 0x0801d7f8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20003800 0x0801c286 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20003800 0x0801c286 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20003800 0x0801c286 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20003800 0x0801c286 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20003800 0x0801c296 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20003800 0x0801c296 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20003800 0x0801c296 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20003800 0x0801c296 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20003800 0x0801c296 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:24
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:225:9
    |
    |
    +--->   R0 = 0x200036cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200037e4
@@ -645,11 +649,11 @@ ID TASK                       GEN PRI STATE
 10 ping                        44   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004db0 0x0802afa0 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:130
-   |      0x20004e00 0x0802a098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:56
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:131:5
+   |      0x20004e00 0x0802a0c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:60:10
    |      0x20004e00 0x0802a0c2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:31
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x20004ddc   R1 = 0x20004dd0   R2 = 0x00000000   R3 = 0x00000000
@@ -705,7 +709,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20004f00 0x0802c056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20004f00   R1 = 0x20004f00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.69.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+95)
    |
    +--->  0x20002540 0x08011fc6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20002600 0x080102bc userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20002600 0x080102bc userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20002600 0x080102ce userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20002600 0x080102ce userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
    |      0x20002600 0x080102ce main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:94
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:119:23
    |
    |
    +--->   R0 = 0x08012918   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200025dc
@@ -65,15 +65,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08020e66 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20003c00 0x0802006c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20003c00 0x0802006c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20003c00 0x0802006c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20003c00 0x0802007a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20003c00 0x0802007a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20003c00 0x0802007a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20003c00 0x0802007a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20003c00 0x0802007a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x20003be0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20003be4
@@ -129,17 +131,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc0 0x08023036 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004000 0x0802217c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004000 0x0802217c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004000 0x0802217c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20004000 0x0802217c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004000 0x0802218c userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004000 0x0802218c userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004000 0x0802218c userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20004000 0x0802218c userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20004000 0x0802218c main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:143
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:152:9
    |
    |
    +--->   R0 = 0x20003fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20003fd8
@@ -195,15 +197,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200043c0 0x08024fee userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004400 0x0802418e userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004400 0x0802418e userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004400 0x0802418e userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004400 0x0802419e userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004400 0x0802419e userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004400 0x0802419e userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
    |      0x20004400 0x0802419e main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:48
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:89:9
    |
    |
    +--->   R0 = 0x08025514   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200043d8
@@ -259,17 +261,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b78 0x08015ba0 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20002c00 0x0801442c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20002c00 0x0801442c userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20002c00 0x0801442c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20002c00 0x0801442c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20002c00 0x0801443a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20002c00 0x0801443a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20002c00 0x0801443a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20002c00 0x0801443a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20002c00 0x0801443a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:146
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:175:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -325,15 +327,15 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 recv
    |
    +--->  0x20001370 0x08019968 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x200013e8 0x080183ea userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x200013e8 0x080183ea userlib::hl::recv_from
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:132
-   |      0x200013e8 0x080183ea userlib::hl::recv_from_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:173
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x200013e8 0x080183f2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x200013e8 0x080183f2 userlib::hl::recv_from
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:145:9
+   |      0x200013e8 0x080183f2 userlib::hl::recv_from_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:182:5
    |      0x200013e8 0x080183f2 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:42
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:104:18
    |
    |
    +--->   R0 = 0x200013aa   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x200013c0
@@ -389,17 +391,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200047c8 0x08026ece userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004800 0x08026122 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20004800 0x08026122 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20004800 0x08026122 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20004800 0x08026122 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004800 0x08026130 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004800 0x08026130 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20004800 0x08026130 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20004800 0x08026130 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20004800 0x08026130 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200047cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200047d8
@@ -455,11 +457,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+395)
    |
    +--->  0x20004bb0 0x08028d02 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20004c00 0x080280ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20004c00 0x080280bc userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20004c00 0x080280bc userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
    |      0x20004c00 0x080280bc main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:22:23
    |
    |
    +--->   R0 = 0x20004bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20004bd8
@@ -515,15 +519,15 @@ ID TASK                       GEN PRI STATE
  8 hiffy                        0   3 notif: bit31(T+26)
    |
    +--->  0x20008578 0x0800c02e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
    |      0x20008800 0x08008a38 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:693
-   |      0x20008800 0x08008a14 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:622
-   |      0x20008800 0x080089f6 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:647
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:698:9
+   |      0x20008800 0x08008a38 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:637:12
+   |      0x20008800 0x08008a38 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:648:5
    |      0x20008800 0x08008a38 main
-   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:79
+   |                 @ /home/bmc/hubris/task-hiffy/src/main.rs:96:9
    |
    |
    +--->   R0 = 0x0800d574   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200087b0
@@ -579,17 +583,17 @@ ID TASK                       GEN PRI STATE
  9 hf                           0   3 recv
    |
    +--->  0x200036b0 0x0801d7f8 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:266
-   |      0x20003800 0x0801c286 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:213
-   |      0x20003800 0x0801c286 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:169
-   |      0x20003800 0x0801c286 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:79
-   |      0x20003800 0x0801c286 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:117
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:273:5
+   |      0x20003800 0x0801c296 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:239:5
+   |      0x20003800 0x0801c296 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:173:11
+   |      0x20003800 0x0801c296 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:89:14
+   |      0x20003800 0x0801c296 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:124:5
    |      0x20003800 0x0801c296 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:24
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:225:9
    |
    |
    +--->   R0 = 0x200036cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200037e4
@@ -645,11 +649,11 @@ ID TASK                       GEN PRI STATE
 10 ping                        31   4 wait: reply from usart_driver/gen0
    |
    +--->  0x20004db0 0x0802afa0 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:130
-   |      0x20004e00 0x0802a098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:56
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:131:5
+   |      0x20004e00 0x0802a0c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:60:10
    |      0x20004e00 0x0802a0c2 main
-   |                 @ /home/bmc/hubris/task-ping/src/main.rs:31
+   |                 @ /home/bmc/hubris/task-ping/src/main.rs:40:9
    |
    |
    +--->   R0 = 0x20004ddc   R1 = 0x20004dd0   R2 = 0x00000000   R3 = 0x00000000
@@ -705,7 +709,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 RUNNING
    |
    +--->  0x20004f00 0x0802c056 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20004f00   R1 = 0x20004f00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.7.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -231,17 +233,17 @@ Caused by:
  5 user_leds                    0   2 recv
    |
    +--->  0x200027c8 0x08018e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002800 0x080180d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002800 0x080180d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002800 0x080180d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002800 0x080180d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002800 0x080180e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002800 0x080180e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002800 0x080180e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002800 0x080180e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002800 0x080180e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200027cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200027d8
@@ -281,11 +283,13 @@ Caused by:
  6 pong                         0   3 ready
    |
    +--->  0x20002bb8 0x0801ad36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002c00 0x0801a08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002c00 0x0801a098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20002c00 0x0801a098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x20002bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20002bd8
@@ -325,13 +329,13 @@ Caused by:
  7 adt7420                      0   3 wait: reply from i2c_driver/gen0
    |
    +--->  0x2000ff78 0x0801d880 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:124
-   |      0x20010000 0x0801c330 drv_i2c_api::I2c::read_reg
-   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:168
-   |      0x20010000 0x0801c31c task_adt7420::read_temp
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:83
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:125:5
+   |      0x20010000 0x0801c384 drv_i2c_api::I2c::read_reg
+   |                 @ /home/bmc/hubris/drv/i2c-api/src/lib.rs:184:9
+   |      0x20010000 0x0801c384 task_adt7420::read_temp
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:87:11
    |      0x20010000 0x0801c384 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:141:17
    |
    |
    +--->   R0 = 0x2000ff98   R1 = 0x2000ffc8   R2 = 0x00000002   R3 = 0x00000000
@@ -371,15 +375,15 @@ Caused by:
  8 i2c_debug                    0   3 ready
    |
    +--->  0x20011f78 0x08022be6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20012000 0x08020378 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20012000 0x08020358 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20012000 0x08020342 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20012000 0x08020378 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20012000 0x08020378 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20012000 0x08020378 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x08023db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20011fa0
@@ -419,7 +423,7 @@ Caused by:
  9 idle                         0   5 ready
    |
    +--->  0x20012100 0x08028052 main
-   |                 @ /home/bmc/hubris/task-idle/src/main.rs:9
+   |                 @ /home/bmc/hubris/task-idle/src/main.rs:10:5
    |
    |
    +--->   R0 = 0x20012000   R1 = 0x20012000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.70.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+87)
    |
    +--->  0x20004540 0x0801147c userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004600 0x080102b6 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004600 0x080102b6 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004600 0x080102c8 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004600 0x080102c8 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20004600 0x080102c8 main
-   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:98
+   |                 @ /home/bmc/hubris/task/jefe/src/main.rs:124:23
    |
    |
    +--->   R0 = 0x08011a54   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200045dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200053c8 0x08020d7a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005400 0x08020074 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005400 0x08020074 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005400 0x08020082 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005400 0x08020082 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20005400 0x08020082 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x200053d0   R1 = 0x00000010   R2 = 0x00000000   R3 = 0x200053e0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x200057c8 0x08022f8e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005800 0x08022194 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005800 0x08022194 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005800 0x08022194 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20005800 0x08022194 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005800 0x080221a4 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005800 0x080221a4 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005800 0x080221a4 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20005800 0x080221a4 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20005800 0x080221a4 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x200057d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200057d8
@@ -193,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20005bc0 0x08024e9a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20005c00 0x08024174 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20005c00 0x08024174 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20005c00 0x08024174 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20005c00 0x08024182 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20005c00 0x08024182 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20005c00 0x08024182 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
    |      0x20005c00 0x08024182 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:56
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:97:9
    |
    |
    +--->   R0 = 0x08025404   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20005bd8
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20004b70 0x080158a4 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20004c00 0x08014430 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20004c00 0x08014430 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:192
-   |      0x20004c00 0x08014430 userlib::hl::recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:83
-   |      0x20004c00 0x08014430 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:121
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004c00 0x08014440 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004c00 0x08014440 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20004c00 0x08014440 userlib::hl::recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20004c00 0x08014440 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:128:5
    |      0x20004c00 0x08014440 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20004bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20004bd8
@@ -323,13 +323,13 @@ ID TASK                       GEN PRI STATE
  5 spi_driver                   0   2 RUNNING
    |
    +--->  0x200012d8 0x080199f2 userlib::sys_irq_control_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:651
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:652:5
    |      0x20001360 0x08018ac2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:249:9
    |      0x20001360 0x08018ac2 userlib::sys_recv_closed
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:217
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:222:5
    |      0x20001360 0x08018ac2 drv_stm32h7_spi_server::ServerImpl::ready_writey
-   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:246
+   |                 @ /home/bmc/hubris/drv/stm32h7-spi-server/src/main.rs:420:17
    |      0x200013e8 0x080186dc drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
    |                 @ /home/bmc/hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32h7-spi-server-3ad4d4985d005218/out/server_stub.rs:184
    |      0x200013e8 0x0801851a idol_runtime::dispatch
@@ -391,13 +391,13 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x20005fc0 0x08026e42 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006000 0x08026128 userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
-   |      0x20006000 0x08026128 idol_runtime::dispatch
-   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:137
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006000 0x08026136 userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006000 0x08026136 idol_runtime::dispatch
+   |                 @ /home/bmc/.cargo/git/checkouts/idolatry-1ebf1c2fd2f30300/6d18e14/runtime/src/lib.rs:142:20
    |      0x20006000 0x08026136 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:110
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x20005fc8   R1 = 0x0000000c   R2 = 0x00000000   R3 = 0x20005fd8
@@ -453,11 +453,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 ready
    |
    +--->  0x200063b8 0x08028c0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
-   |      0x20006400 0x080280ac userlib::sys_recv
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:236
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20006400 0x080280ba userlib::sys_recv
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20006400 0x080280ba userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:196:11
    |      0x20006400 0x080280ba main
-   |                 @ /home/bmc/hubris/task/pong/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x200063c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200063d8
@@ -513,11 +515,11 @@ ID TASK                       GEN PRI STATE
  8 ping                      4777   4 ready
    |
    +--->  0x200065b0 0x0802ae84 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
-   |      0x20006600 0x0802a098 task_ping::uart_send
-   |                 @ /home/bmc/hubris/task/ping/src/main.rs:60
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
+   |      0x20006600 0x0802a0c2 task_ping::uart_send
+   |                 @ /home/bmc/hubris/task/ping/src/main.rs:64:10
    |      0x20006600 0x0802a0c2 main
-   |                 @ /home/bmc/hubris/task/ping/src/main.rs:35
+   |                 @ /home/bmc/hubris/task/ping/src/main.rs:44:9
    |
    |
    +--->   R0 = 0x200065dc   R1 = 0x200065d0   R2 = 0x00000000   R3 = 0x00000000
@@ -573,7 +575,7 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20008518 0x0800b696 userlib::sys_send_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:153
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:154:5
    |      0x20008580 0x08008826 userlib::sys_send
    |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:117
    |      0x20008580 0x08008804 drv_spi_api::Spi::exchange
@@ -581,11 +583,11 @@ ID TASK                       GEN PRI STATE
    |      0x20008580 0x08008848 task_hiffy::common::spi_read
    |                 @ /home/bmc/hubris/task/hiffy/src/common.rs:196
    |      0x20008800 0x0800944c hif::execute::function
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:297
-   |      0x20008800 0x080091a8 hif::execute
-   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:259
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:303:13
+   |      0x20008800 0x0800944c hif::execute
+   |                 @ /home/bmc/.cargo/git/checkouts/hif-766e4be28bfdbf05/e512e4c/src/lib.rs:465:38
    |      0x20008800 0x0800944c main
-   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:84
+   |                 @ /home/bmc/hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x2000853c   R1 = 0x00000001   R2 = 0x00000100   R3 = 0x0800bc08
@@ -641,15 +643,15 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 ready
    |
    +--->  0x20002648 0x0801d718 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:288
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:295:5
    |      0x20002688 0x0801d786 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:723
-   |      0x20002688 0x0801d760 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:610
+   |                 @ /home/bmc/hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20002688 0x0801d786 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:625:12
    |      0x20002688 0x0801d786 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:635
+   |                 @ /home/bmc/hubris/sys/userlib/src/hl.rs:636:5
    |      0x20002800 0x0801c230 main
-   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /home/bmc/hubris/drv/gimlet-hf-server/src/main.rs:305:13
    |
    |
    +--->   R0 = 0x0801ddd8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20002650
@@ -705,7 +707,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 ready
    |
    +--->  0x20006700 0x0802c056 main
-   |                 @ /home/bmc/hubris/task/idle/src/main.rs:13
+   |                 @ /home/bmc/hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20006700   R1 = 0x20006700   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.71.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+37)
    |
    +--->  0x20002540 0x0801154c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20002600 0x080102b0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20002600 0x080102b0 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002600 0x080102c2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002600 0x080102c2 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
    |      0x20002600 0x080102c2 main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08011bd4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200025dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x20003bd8 0x08024c86 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20003c00 0x0802406e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20003c00 0x0802406e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20003c00 0x0802407c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20003c00 0x0802407c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20003c00 0x0802407c main
-   |                 @ /hubris//drv/stm32h7-rcc/src/main.rs:120
+   |                 @ /hubris/drv/stm32h7-rcc/src/main.rs:135:9
    |
    |
    +--->   R0 = 0x20003bdc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20003be0
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20003fc8 0x08026ee6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20004000 0x08026194 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20004000 0x08026194 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20004000 0x08026194 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20004000 0x08026194 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20004000 0x080261a4 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20004000 0x080261a4 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20004000 0x080261a4 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20004000 0x080261a4 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20004000 0x080261a4 main
-   |                 @ /hubris//drv/stm32h7-gpio/src/main.rs:155
+   |                 @ /hubris/drv/stm32h7-gpio/src/main.rs:164:9
    |
    |
    +--->   R0 = 0x20003fd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20003fd8
@@ -193,15 +193,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x200103c0 0x08028dee userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20010400 0x08028174 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20010400 0x08028174 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20010400 0x08028174 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010400 0x08028182 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010400 0x08028182 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20010400 0x08028182 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
    |      0x20010400 0x08028182 main
-   |                 @ /hubris//drv/stm32h7-usart/src/main.rs:56
+   |                 @ /hubris/drv/stm32h7-usart/src/main.rs:97:9
    |
    |
    +--->   R0 = 0x080292ec   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200103d8
@@ -257,17 +257,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x20002b58 0x08015814 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20002c00 0x080144aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20002c00 0x080144aa userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:192
-   |      0x20002c00 0x080144aa userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20002c00 0x080144aa userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20002c00 0x080144b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20002c00 0x080144b8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
+   |      0x20002c00 0x080144b8 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20002c00 0x080144b8 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20002c00 0x080144b8 main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:150
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:179:9
    |
    |
    +--->   R0 = 0x20002bd4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20002bd8
@@ -323,15 +323,15 @@ ID TASK                       GEN PRI STATE
  5 spd                          0   2 notif: bit31(T+7)
    |
    +--->  0x20004328 0x08019ef2 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
    |      0x20004400 0x08018d7c userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:723
-   |      0x20004400 0x08018d58 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20004400 0x08018d3c userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20004400 0x08018d7c userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20004400 0x08018d7c userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20004400 0x08018d7c main
-   |                 @ /hubris//task/spd/src/main.rs:197
+   |                 @ /hubris/task/spd/src/main.rs:260:9
    |
    |
    +--->   R0 = 0x0801a670   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200043dc
@@ -387,13 +387,13 @@ ID TASK                       GEN PRI STATE
  6 spi_driver                   0   2 RUNNING
    |
    +--->  0x200012e0 0x0801d97e userlib::sys_irq_control_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:651
+   |                 @ /hubris/sys/userlib/src/lib.rs:652:5
    |      0x20001368 0x0801cc36 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:249:9
    |      0x20001368 0x0801cc36 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:217
+   |                 @ /hubris/sys/userlib/src/lib.rs:222:5
    |      0x20001368 0x0801cc36 drv_stm32h7_spi_server::ServerImpl::ready_writey
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:247
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:446:13
    |      0x200013e8 0x0801c6e2 drv_stm32h7_spi_server::<impl idol_runtime::Server<drv_stm32h7_spi_server::SpiOperation> for (core::marker::PhantomData<drv_stm32h7_spi_server::SpiOperation>,&mut S)>::handle
    |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32h7-spi-server-82a2839ad0491a1a/out/server_stub.rs:197
    |      0x200013e8 0x0801c520 idol_runtime::dispatch
@@ -455,13 +455,13 @@ ID TASK                       GEN PRI STATE
  7 user_leds                    0   2 recv
    |
    +--->  0x200107c8 0x0802ad5e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20010800 0x0802a124 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20010800 0x0802a124 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:137
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010800 0x0802a132 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010800 0x0802a132 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/a3dfa36/runtime/src/lib.rs:142:20
    |      0x20010800 0x0802a132 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:110
+   |                 @ /hubris/drv/user-leds/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x200107cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200107d8
@@ -517,11 +517,13 @@ ID TASK                       GEN PRI STATE
  8 pong                         0   3 ready
    |
    +--->  0x20010bb8 0x0802cb1e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
-   |      0x20010c00 0x0802c0ac userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
+   |      0x20010c00 0x0802c0ba userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:262:8
+   |      0x20010c00 0x0802c0ba userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:196:11
    |      0x20010c00 0x0802c0ba main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x20010bc4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20010bd8
@@ -577,17 +579,17 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 wait: reply from spi_driver/gen0
    |
    +--->  0x20008530 0x0800b7f2 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:153
-   |      0x20008580 0x08008968 drv_spi_api::Spi::write
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:86
+   |                 @ /hubris/sys/userlib/src/lib.rs:154:5
+   |      0x20008580 0x080089a2 drv_spi_api::Spi::write
+   |                 @ /build/drv-spi-api-c1937eaa0b37cf39/out/client_stub.rs:125:12
    |      0x20008580 0x080089a2 task_hiffy::common::spi_write
-   |                 @ /hubris//task/hiffy/src/common.rs:241
+   |                 @ /hubris/task/hiffy/src/common.rs:256:14
    |      0x20008800 0x080094f4 hif::execute::function
-   |                 @ /git/hif-766e4be28bfdbf05/b5abd26/src/lib.rs:306
-   |      0x20008800 0x08009238 hif::execute
-   |                 @ /git/hif-766e4be28bfdbf05/b5abd26/src/lib.rs:268
+   |                 @ /git/hif-766e4be28bfdbf05/b5abd26/src/lib.rs:312:13
+   |      0x20008800 0x080094f4 hif::execute
+   |                 @ /git/hif-766e4be28bfdbf05/b5abd26/src/lib.rs:492:38
    |      0x20008800 0x080094f4 main
-   |                 @ /hubris//task/hiffy/src/main.rs:84
+   |                 @ /hubris/task/hiffy/src/main.rs:133:18
    |
    |
    +--->   R0 = 0x20008548   R1 = 0x00000002   R2 = 0x0800bdac   R3 = 0x00000084
@@ -643,15 +645,15 @@ ID TASK                       GEN PRI STATE
 10 hf                           0   3 ready
    |
    +--->  0x20003658 0x08021658 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:288
+   |                 @ /hubris/sys/userlib/src/lib.rs:295:5
    |      0x20003698 0x080216c6 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:723
-   |      0x20003698 0x080216a0 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:728:9
+   |      0x20003698 0x080216c6 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20003698 0x080216c6 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20003800 0x08020222 main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:36
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:302:13
    |
    |
    +--->   R0 = 0x08021c88   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20003660
@@ -707,7 +709,7 @@ ID TASK                       GEN PRI STATE
 11 idle                         0   5 ready
    |
    +--->  0x20010d00 0x0802e056 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20010d00   R1 = 0x20010d00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.8.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015902 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x080142f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x080142f2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x080142f2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080142f2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x08014300 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x08014300 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x08014300 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x08014300 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x08014300 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:267:9
    |
    |
    +--->   R0 = 0x200023d0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023d8
@@ -245,13 +247,13 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f60 0x080197ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20002f80 0x08018650 drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:112
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:114:6
    |      0x20002fe0 0x080180d0 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:323
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:356:17
    |      0x20003000 0x08018630 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:185:5
    |
    |
    +--->   R0 = 0x08019d40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002f64
@@ -291,17 +293,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -341,11 +343,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+29)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -385,15 +389,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 notif: bit31(T+29)
    |
    +--->  0x20005f78 0x08022be6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x08020378 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020358 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x08020342 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x08020378 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x08020378 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x08020378 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x08023db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fa0
@@ -433,15 +437,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 notif: bit31(T+29)
    |
    +--->  0x2000ff78 0x0802984e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010000 0x08028276 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20010000 0x0802825a userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20010000 0x08028244 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20010000 0x08028276 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20010000 0x08028276 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010000 0x08028276 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:137:9
    |
    |
    +--->   R0 = 0x08029ec4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff98
@@ -481,7 +485,7 @@ ID TASK                       GEN PRI STATE
 10 max31790                     0   3 notif: bit31(T+30)
    |
    +--->  0x200103b0 0x0802d1da userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010400 0x0802c3be userlib::sys_get_timer
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
    |      0x20010400 0x0802c3a4 userlib::hl::sleep_until

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.ouray.9.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0
    |
    +--->  0x20001318 0x08009cda userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001400 0x080081ca userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001400 0x080081c2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001400 0x080081da userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001400 0x080081da userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20001400 0x080081da main
-   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:80
+   |                 @ /home/bmc/hubris/task-jefe/src/main.rs:87:23
    |
    |
    +--->   R0 = 0x0800a450   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x200013d4
@@ -49,15 +49,17 @@ ID TASK                       GEN PRI STATE
  1 rcc_driver                   0   1 recv
    |
    +--->  0x200017d8 0x0800cf0a userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001800 0x0800c06c userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001800 0x0800c06c userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001800 0x0800c06c userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001800 0x0800c07a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001800 0x0800c07a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001800 0x0800c07a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001800 0x0800c07a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001800 0x0800c07a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:108
+   |                 @ /home/bmc/hubris/drv/stm32h7-rcc/src/main.rs:122:9
    |
    |
    +--->   R0 = 0x200017e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200017e4
@@ -97,17 +99,17 @@ ID TASK                       GEN PRI STATE
  2 gpio_driver                  0   2 recv
    |
    +--->  0x20001bc8 0x0800efc2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20001c00 0x0800e12a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20001c00 0x0800e12a userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20001c00 0x0800e12a userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20001c00 0x0800e12a userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20001c00 0x0800e13a userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20001c00 0x0800e13a userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20001c00 0x0800e13a userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20001c00 0x0800e13a main
-   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:149
+   |                 @ /home/bmc/hubris/drv/stm32h7-gpio/src/main.rs:158:9
    |
    |
    +--->   R0 = 0x20001bd0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20001bd8
@@ -147,15 +149,15 @@ ID TASK                       GEN PRI STATE
  3 usart_driver                 0   2 recv, notif: bit0(irq39)
    |
    +--->  0x20001fc0 0x080111c2 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002000 0x08010138 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002000 0x08010138 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002000 0x08010138 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002000 0x08010146 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002000 0x08010146 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002000 0x08010146 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
    |      0x20002000 0x08010146 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:61
+   |                 @ /home/bmc/hubris/drv/stm32h7-usart/src/main.rs:102:9
    |
    |
    +--->   R0 = 0x080116f8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20001fd8
@@ -195,17 +197,17 @@ ID TASK                       GEN PRI STATE
  4 i2c_driver                   0   2 recv
    |
    +--->  0x200023a8 0x08015902 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20002400 0x080142f2 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20002400 0x080142f2 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20002400 0x080142f2 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20002400 0x080142f2 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20002400 0x08014300 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20002400 0x08014300 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20002400 0x08014300 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20002400 0x08014300 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20002400 0x08014300 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:248
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-server/src/main.rs:267:9
    |
    |
    +--->   R0 = 0x200023d0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200023d8
@@ -245,13 +247,13 @@ ID TASK                       GEN PRI STATE
  5 i2c_target                   0   2 notif: bit1(irq33/irq34)
    |
    +--->  0x20002f60 0x080197ea userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20002f80 0x08018650 drv_stm32h7_i2c_target_server::main::{{closure}}
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:112
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:114:6
    |      0x20002fe0 0x080180d0 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:323
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c/src/lib.rs:356:17
    |      0x20003000 0x08018630 main
-   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:98
+   |                 @ /home/bmc/hubris/drv/stm32h7-i2c-target-server/src/main.rs:185:5
    |
    |
    +--->   R0 = 0x08019d40   R1 = 0x00000000   R2 = 0x00000002   R3 = 0x20002f64
@@ -291,17 +293,17 @@ ID TASK                       GEN PRI STATE
  6 user_leds                    0   2 recv
    |
    +--->  0x200033c8 0x0801ceae userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003400 0x0801c0d4 userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
-   |      0x20003400 0x0801c0d4 userlib::sys_recv_open
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:163
-   |      0x20003400 0x0801c0d4 userlib::hl::recv
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:78
-   |      0x20003400 0x0801c0d4 userlib::hl::recv_without_notification
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:116
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003400 0x0801c0e2 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
+   |      0x20003400 0x0801c0e2 userlib::hl::recv
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:88:14
+   |      0x20003400 0x0801c0e2 userlib::hl::recv_without_notification
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:123:5
    |      0x20003400 0x0801c0e2 main
-   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:69
+   |                 @ /home/bmc/hubris/drv/user-leds/src/main.rs:76:9
    |
    |
    +--->   R0 = 0x200033cc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200033d8
@@ -341,11 +343,13 @@ ID TASK                       GEN PRI STATE
  7 pong                         0   3 recv, notif: bit0(T+173)
    |
    +--->  0x200037b8 0x0801ed36 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
-   |      0x20003800 0x0801e08a userlib::sys_recv
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:207
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
+   |      0x20003800 0x0801e098 userlib::sys_recv
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:233:5
+   |      0x20003800 0x0801e098 userlib::sys_recv_open
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:167:11
    |      0x20003800 0x0801e098 main
-   |                 @ /home/bmc/hubris/task-pong/src/main.rs:7
+   |                 @ /home/bmc/hubris/task-pong/src/main.rs:20:23
    |
    |
    +--->   R0 = 0x200037c4   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x200037d8
@@ -385,15 +389,15 @@ ID TASK                       GEN PRI STATE
  8 i2c_debug                    0   3 notif: bit31(T+673)
    |
    +--->  0x20005f78 0x08022be6 userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20006000 0x08020378 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20006000 0x08020358 userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20006000 0x08020342 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20006000 0x08020378 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20006000 0x08020378 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20006000 0x08020378 main
-   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:143
+   |                 @ /home/bmc/hubris/task-i2c/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x08023db4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20005fa0
@@ -433,15 +437,15 @@ ID TASK                       GEN PRI STATE
  9 adt7420                      0   3 notif: bit31(T+673)
    |
    +--->  0x2000ff78 0x0802984e userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010000 0x08028276 userlib::sys_get_timer
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
-   |      0x20010000 0x0802825a userlib::hl::sleep_until
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:469
-   |      0x20010000 0x08028244 userlib::hl::sleep_for
-   |                 @ /home/bmc/hubris/userlib/src/hl.rs:494
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:692:9
+   |      0x20010000 0x08028276 userlib::hl::sleep_until
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:484:12
+   |      0x20010000 0x08028276 userlib::hl::sleep_for
+   |                 @ /home/bmc/hubris/userlib/src/hl.rs:495:5
    |      0x20010000 0x08028276 main
-   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:121
+   |                 @ /home/bmc/hubris/task-adt7420/src/main.rs:137:9
    |
    |
    +--->   R0 = 0x08029ec4   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x2000ff98
@@ -481,7 +485,7 @@ ID TASK                       GEN PRI STATE
 10 max31790                     0   3 notif: bit31(T+674)
    |
    +--->  0x200103b0 0x0802d1da userlib::sys_recv_stub
-   |                 @ /home/bmc/hubris/userlib/src/lib.rs:260
+   |                 @ /home/bmc/hubris/userlib/src/lib.rs:267:5
    |      0x20010400 0x0802c3be userlib::sys_get_timer
    |                 @ /home/bmc/hubris/userlib/src/lib.rs:687
    |      0x20010400 0x0802c3a4 userlib::hl::sleep_until

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.spoopy.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+36)
    |
    +--->  0x20014538 0x0805d54c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20014600 0x0805c2b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20014600 0x0805c2b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20014600 0x0805c2ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20014600 0x0805c2ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20014600 0x0805c2ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x0805dbf4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200145dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   2 recv, notif: bit0(irq61) bit1(T+179)
    |
    +--->  0x200028a8 0x0802e7f8 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20002ed8 0x080257ee userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20002ed8 0x080257ee idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20002ed8 0x080257fe userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20002ed8 0x080257fe idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:250:20
    |      0x20002ed8 0x080257fe main
-   |                 @ /hubris//task/net/src/main.rs:99
+   |                 @ /hubris/task/net/src/main.rs:180:13
    |
    |
    +--->   R0 = 0x20002c98   R1 = 0x0000001c   R2 = 0x00000003   R3 = 0x20002d38
@@ -127,13 +127,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x20017b50 0x080625d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20017b80 0x08062090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20017b80 0x08062090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20017b80 0x0806209e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20017b80 0x0806209e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20017b80 0x0806209e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20017b58   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20017b60
@@ -189,13 +189,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   2 recv
    |
    +--->  0x20014ae8 0x08041c30 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20014b68 0x08040684 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20014b68 0x08040684 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20014b68 0x0804069e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20014b68 0x0804069e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20014b68 0x0804069e main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20014b02   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20014b04
@@ -251,13 +251,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   2 recv
    |
    +--->  0x200152e0 0x08045d58 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015368 0x08044656 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015368 0x08044656 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015368 0x08044670 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015368 0x08044670 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20015368 0x08044670 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x20015302   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x20015304
@@ -313,17 +313,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   2 recv
    |
    +--->  0x20015a58 0x0804a06c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015b80 0x0804868e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015b80 0x0804868e userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20015b80 0x0804868e userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20015b80 0x0804868e userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015b80 0x0804869e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015b80 0x0804869e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x20015b80 0x0804869e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20015b80 0x0804869e userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20015b80 0x0804869e main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:148
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:177:9
    |
    |
    +--->   R0 = 0x20015b48   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20015b58
@@ -379,13 +379,13 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x20004250 0x0804deee userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20004270 0x0804c674 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/ops/function.rs:227:5
    |      0x200042a8 0x0804c444 drv_stm32h7_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:743
+   |                 @ /hubris/drv/stm32h7-i2c/src/lib.rs:905:17
    |      0x20004380 0x0804ce46 main
-   |                 @ /hubris//task/spd/src/main.rs:194
+   |                 @ /hubris/task/spd/src/main.rs:414:5
    |
    |
    +--->   R0 = 0x0804e58c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20004254
@@ -441,13 +441,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   3 recv, notif: bit0(T+943)
    |
    +--->  0x200166c0 0x0805f512 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20016780 0x0805e1fa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20016780 0x0805e1fa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20016780 0x0805e20c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20016780 0x0805e20c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:250:20
    |      0x20016780 0x0805e20c main
-   |                 @ /hubris//task/thermal/src/main.rs:212
+   |                 @ /hubris/task/thermal/src/main.rs:245:9
    |
    |
    +--->   R0 = 0x2001675e   R1 = 0x00000002   R2 = 0x00000001   R3 = 0x20016760
@@ -503,15 +503,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   3 notif: bit31(T+618)
    |
    +--->  0x200123c8 0x0805229e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20012800 0x08050322 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20012800 0x08050300 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
-   |      0x20012800 0x080502de userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20012800 0x08050322 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
+   |      0x20012800 0x08050322 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20012800 0x08050322 main
-   |                 @ /hubris//task/power/src/main.rs:232
+   |                 @ /hubris/task/power/src/main.rs:239:9
    |
    |
    +--->   R0 = 0x08052b9c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200127d8
@@ -567,19 +567,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   3 notif: bit31(T+172)
    |
    +--->  0x20008140 0x0800b672 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20008180 0x0800b6e2 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20008180 0x0800b6bc userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20008180 0x0800b6e2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008180 0x0800b6e2 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:636:5
    |      0x20008400 0x0800911c core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008400 0x0800911c core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008400 0x0800911c main
-   |                 @ /hubris//task/hiffy/src/main.rs:99
+   |                 @ /hubris/task/hiffy/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x0800c77c   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008148
@@ -635,13 +635,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   3 recv
    |
    +--->  0x200134f0 0x080135da userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20013640 0x0801088c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20013640 0x0801088c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20013640 0x0801089c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20013640 0x0801089c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20013640 0x0801089c main
-   |                 @ /hubris//drv/gimlet-seq-server/src/main.rs:58
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:297:9
    |
    |
    +--->   R0 = 0x20013517   R1 = 0x00000001   R2 = 0x00000000   R3 = 0x20013530
@@ -697,13 +697,13 @@ ID TASK                       GEN PRI STATE
 11 hf                           0   3 recv
    |
    +--->  0x20016df8 0x0805582c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20016f80 0x0805436e userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20016f80 0x0805436e idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20016f80 0x0805437e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20016f80 0x0805437e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:174:20
    |      0x20016f80 0x0805437e main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:145:9
    |
    |
    +--->   R0 = 0x20016e30   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x20016f60
@@ -759,13 +759,13 @@ ID TASK                       GEN PRI STATE
 12 sensor                       0   3 recv, notif: bit0(T+936)
    |
    +--->  0x20017388 0x08060bbe userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20017780 0x080600aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20017780 0x080600aa idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:242
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20017780 0x080600b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20017780 0x080600b8 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/4e12855/runtime/src/lib.rs:250:20
    |      0x20017780 0x080600b8 main
-   |                 @ /hubris//task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x20017768   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x20017580
@@ -821,11 +821,11 @@ ID TASK                       GEN PRI STATE
 13 udpecho                      0   3 notif: bit0
    |
    +--->  0x20010e08 0x0805957e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20011000 0x080587e4 core::result::Result<T,E>::unwrap
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1296
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/result.rs:1297:9
    |      0x20011000 0x080587e4 main
-   |                 @ /hubris//task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:36:17
    |
    |
    +--->   R0 = 0x08059b2c   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20010fdc
@@ -881,7 +881,7 @@ ID TASK                       GEN PRI STATE
 14 idle                         0   5 RUNNING
    |
    +--->  0x20017d00 0x08062856 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20017d00   R1 = 0x20017d00   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.sprot_status.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.sprot_status.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+94)
    |
    +--->  0x240374f8 0x080a5736 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24037600 0x080a430c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24037600 0x080a430c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24037600 0x080a431a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24037600 0x080a431a idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24037600 0x080a431a main
-   |                 @ /hubris/task/jefe/src/main.rs:120
+   |                 @ /hubris/task/jefe/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24037598   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x240375b8
@@ -61,13 +61,13 @@ ID TASK                       GEN PRI STATE
  1 net                        518   5 recv, notif: bit0(irq61) bit2(T+60)
    |
    +--->  0x24008ab0 0x08030830 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24008d30 0x08020106 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24008d30 0x0802011a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
    |      0x24008d30 0x0802011a idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24009798 0x08028916 main
-   |                 @ /hubris/task/net/src/main.rs:151
+   |                 @ /hubris/task/net/src/main.rs:275:13
    |
    |
    +--->   R0 = 0x24009560   R1 = 0x00000020   R2 = 0x00000005   R3 = 0x24008bc8
@@ -119,13 +119,13 @@ ID TASK                       GEN PRI STATE
  2 sys                          0   1 recv
    |
    +--->  0x24039b48 0x080ae632 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039b80 0x080ae18c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039b80 0x080ae18c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039b80 0x080ae19a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039b80 0x080ae19a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24039b80 0x080ae19a main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x24039b50   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x24039b58
@@ -177,13 +177,13 @@ ID TASK                       GEN PRI STATE
  3 spi4_driver                  0   3 recv
    |
    +--->  0x24037b00 0x08081d6e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24037b68 0x080805fe userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24037b68 0x080805fe idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24037b68 0x08080618 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24037b68 0x08080618 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24037b68 0x08080618 main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x24037b1a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x24037b1c
@@ -235,13 +235,13 @@ ID TASK                       GEN PRI STATE
  4 spi2_driver                  0   3 recv
    |
    +--->  0x24038300 0x08085eb2 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24038368 0x080845c0 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24038368 0x080845c0 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24038368 0x080845da userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24038368 0x080845da idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24038368 0x080845da main
-   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2403831a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2403831c
@@ -293,17 +293,17 @@ ID TASK                       GEN PRI STATE
  5 i2c_driver                   0   3 recv
    |
    +--->  0x24038a58 0x0808a604 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24038b80 0x080887b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24038b80 0x080887b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:237
-   |      0x24038b80 0x080887b8 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
-   |      0x24038b80 0x080887b8 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:118
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24038b80 0x080887c8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24038b80 0x080887c8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:241:11
+   |      0x24038b80 0x080887c8 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
+   |      0x24038b80 0x080887c8 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:125:5
    |      0x24038b80 0x080887c8 main
-   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:200
+   |                 @ /hubris/drv/stm32xx-i2c-server/src/main.rs:229:9
    |
    |
    +--->   R0 = 0x24038b44   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24038b58
@@ -355,19 +355,19 @@ ID TASK                       GEN PRI STATE
  6 spd                          0   2 notif: bit0(irq31/irq32)
    |
    +--->  0x24004290 0x0808e36c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x240042b0 0x0808c7f4 core::ops::function::FnOnce::call_once
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ops/function.rs:251:5
    |      0x240042e8 0x0808c118 core::ptr::read_volatile
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1496
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/ptr/mod.rs:1503:9
    |      0x240042e8 0x0808c118 vcell::VolatileCell<T>::get
-   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:30
+   |                 @ /crates.io/vcell-0.1.3/src/lib.rs:33:18
    |      0x240042e8 0x0808c118 stm32h7::generic::Reg<REG>::modify
-   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:159
+   |                 @ /crates.io/stm32h7-0.14.0/src/generic.rs:163:20
    |      0x240042e8 0x0808c118 drv_stm32xx_i2c::I2cController::operate_as_target
-   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:774
+   |                 @ /hubris/drv/stm32xx-i2c/src/lib.rs:823:17
    |      0x24004380 0x0808d074 main
-   |                 @ /hubris/task/spd/src/main.rs:203
+   |                 @ /hubris/task/spd/src/main.rs:420:5
    |
    |
    +--->   R0 = 0x0808eaa4   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x24004294
@@ -419,13 +419,13 @@ ID TASK                       GEN PRI STATE
  7 thermal                      0   5 recv, notif: bit0(T+172)
    |
    +--->  0x24002738 0x0800b0ae userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24003198 0x0800900a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24003198 0x0800900a idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24003198 0x08009018 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24003198 0x08009018 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24003198 0x08009018 main
-   |                 @ /hubris/task/thermal/src/main.rs:275
+   |                 @ /hubris/task/thermal/src/main.rs:301:9
    |
    |
    +--->   R0 = 0x24002bcc   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x24002be8
@@ -477,15 +477,15 @@ ID TASK                       GEN PRI STATE
  8 power                        0   6 notif: bit31(T+45)
    |
    +--->  0x24030390 0x08062c82 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x240303e8 0x08060282 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x240303e8 0x08060248 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
-   |      0x240303e8 0x0806021e userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x240303e8 0x08060282 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x240303e8 0x08060282 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x240303e8 0x08060282 main
-   |                 @ /hubris/task/power/src/main.rs:419
+   |                 @ /hubris/task/power/src/main.rs:429:9
    |
    |
    +--->   R0 = 0x08063ed8   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240303c0
@@ -537,19 +537,19 @@ ID TASK                       GEN PRI STATE
  9 hiffy                        0   5 notif: bit31(T+223)
    |
    +--->  0x24010228 0x0806d31c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24010270 0x0806d398 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24010270 0x0806d35e userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24010270 0x0806d398 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
    |      0x24010270 0x0806d398 userlib::hl::sleep_for
-   |                 @ /hubris/sys/userlib/src/hl.rs:451
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24010400 0x0806a426 core::sync::atomic::atomic_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3033
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:3041:23
    |      0x24010400 0x0806a426 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2371
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/sync/atomic.rs:2373:26
    |      0x24010400 0x0806a426 main
-   |                 @ /hubris/task/hiffy/src/main.rs:125
+   |                 @ /hubris/task/hiffy/src/main.rs:142:9
    |
    |
    +--->   R0 = 0x0806ed18   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x24010234
@@ -601,13 +601,13 @@ ID TASK                       GEN PRI STATE
 10 gimlet_seq                   0   4 recv, notif: bit0
    |
    +--->  0x240314d8 0x080132da userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24031640 0x08010a70 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24031640 0x08010a70 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24031640 0x08010a82 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24031640 0x08010a82 idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24031640 0x08010a82 main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:354:9
    |
    |
    +--->   R0 = 0x24031507   R1 = 0x00000001   R2 = 0x00000001   R3 = 0x24031520
@@ -659,13 +659,13 @@ ID TASK                       GEN PRI STATE
 11 hash_driver                  0   2 recv
    |
    +--->  0x24032540 0x080917ba userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24032800 0x080902dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24032800 0x080902dc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24032800 0x080902ec userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24032800 0x080902ec idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24032800 0x080902ec main
-   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:40
+   |                 @ /hubris/drv/stm32h7-hash-server/src/main.rs:53:9
    |
    |
    +--->   R0 = 0x2403255c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240327d4
@@ -717,13 +717,13 @@ ID TASK                       GEN PRI STATE
 12 hf                           0   3 recv
    |
    +--->  0x240395c8 0x08095eac userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039780 0x08094376 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039780 0x08094376 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039780 0x08094386 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039780 0x08094386 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24039780 0x08094386 main
-   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:78
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x24039610   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x24039730
@@ -775,13 +775,13 @@ ID TASK                       GEN PRI STATE
 13 update_server                0   3 recv
    |
    +--->  0x240333b8 0x0809961e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24033800 0x0809821c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24033800 0x0809821c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24033800 0x0809822a userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24033800 0x0809822a idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24033800 0x0809822a main
-   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:406
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:416:9
    |
    |
    +--->   R0 = 0x240333dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240333e0
@@ -833,13 +833,13 @@ ID TASK                       GEN PRI STATE
 14 sensor                       0   4 recv, notif: bit0(T+994)
    |
    +--->  0x24034660 0x080a6ed0 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24034ed8 0x080a60ae userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24034ed8 0x080a60ae idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24034ed8 0x080a60bc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24034ed8 0x080a60bc idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24034ed8 0x080a60bc main
-   |                 @ /hubris/task/sensor/src/main.rs:95
+   |                 @ /hubris/task/sensor/src/main.rs:111:9
    |
    |
    +--->   R0 = 0x24034ec0   R1 = 0x00000008   R2 = 0x00000001   R3 = 0x24034a98
@@ -891,13 +891,13 @@ ID TASK                       GEN PRI STATE
 15 host_sp_comms                0   7 recv, notif: bit0(irq82) bit1 bit2(T+14) bit3
    |
    +--->  0x24018620 0x08073626 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24018800 0x08070d6c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24018800 0x08070d6c idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24018800 0x08070d7c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24018800 0x08070d7c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24018800 0x08070d7c main
-   |                 @ /hubris/task/host-sp-comms/src/main.rs:136
+   |                 @ /hubris/task/host-sp-comms/src/main.rs:146:9
    |
    |
    +--->   R0 = 0x24018710   R1 = 0x00000008   R2 = 0x0000000f   R3 = 0x24018748
@@ -949,13 +949,13 @@ ID TASK                       GEN PRI STATE
 16 udpecho                      0   6 notif: bit0
    |
    +--->  0x2402ce40 0x080a9724 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402d000 0x080a85e2 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402d000 0x080a85e2 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402d000 0x080a85f0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402d000 0x080a85f0 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x2402d000 0x080a85f0 main
-   |                 @ /hubris/task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:52:17
    |
    |
    +--->   R0 = 0x080a9dac   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2402cf90
@@ -1007,13 +1007,15 @@ ID TASK                       GEN PRI STATE
 17 udpbroadcast               518   6 notif: bit31(T+87)
    |
    +--->  0x24035750 0x080ab3fe userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
    |      0x24035800 0x080aa1b2 userlib::sys_get_timer
-   |                 @ /hubris/sys/userlib/src/lib.rs:1056
-   |      0x24035800 0x080aa174 userlib::hl::sleep_until
-   |                 @ /hubris/sys/userlib/src/hl.rs:421
+   |                 @ /hubris/sys/userlib/src/lib.rs:1061:9
+   |      0x24035800 0x080aa1b2 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:437:12
+   |      0x24035800 0x080aa1b2 userlib::hl::sleep_for
+   |                 @ /hubris/sys/userlib/src/hl.rs:463:5
    |      0x24035800 0x080aa1b2 main
-   |                 @ /hubris/task/udpbroadcast/src/main.rs:15
+   |                 @ /hubris/task/udpbroadcast/src/main.rs:47:9
    |
    |
    +--->   R0 = 0x080aba14   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x240357ac
@@ -1065,13 +1067,13 @@ ID TASK                       GEN PRI STATE
 18 udprpc                       0   6 notif: bit0
    |
    +--->  0x2402e668 0x0809de18 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x2402f000 0x0809c236 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x2402f000 0x0809c236 userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:262
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x2402f000 0x0809c246 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x2402f000 0x0809c246 userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:267:5
    |      0x2402f000 0x0809c246 main
-   |                 @ /hubris/task/udprpc/src/main.rs:46
+   |                 @ /hubris/task/udprpc/src/main.rs:149:17
    |
    |
    +--->   R0 = 0x0809e640   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x2402efb0
@@ -1123,13 +1125,13 @@ ID TASK                       GEN PRI STATE
 19 control_plane_agent          0   6 recv, notif: bit0 bit1(irq37) bit2
    |
    +--->  0x24028bd0 0x0804c534 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24029000 0x080470bc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24029000 0x080470bc idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24029000 0x080470cc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24029000 0x080470cc idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:269:20
    |      0x24029000 0x080470cc main
-   |                 @ /hubris/task/control-plane-agent/src/main.rs:148
+   |                 @ /hubris/task/control-plane-agent/src/main.rs:154:9
    |
    |
    +--->   R0 = 0x24028dc4   R1 = 0x00000029   R2 = 0x00000007   R3 = 0x24028df0
@@ -1181,13 +1183,13 @@ ID TASK                       GEN PRI STATE
 20 sprot                        0   4 recv
    |
    +--->  0x240234c8 0x0807ba0c userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24024000 0x08078472 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24024000 0x08078472 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24024000 0x08078482 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24024000 0x08078482 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24024000 0x08078482 main
-   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:151
+   |                 @ /hubris/drv/stm32h7-sprot-server/src/main.rs:168:9
    |
    |
    +--->   R0 = 0x24023530   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24023dc8
@@ -1239,13 +1241,13 @@ ID TASK                       GEN PRI STATE
 21 validate                     0   5 recv
    |
    +--->  0x240363b0 0x080a1d1a userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x240363e8 0x080a0248 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x240363e8 0x080a0248 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x240363e8 0x080a0258 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x240363e8 0x080a0258 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x240363e8 0x080a0258 main
-   |                 @ /hubris/task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x240363b4   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x240363c0
@@ -1297,13 +1299,13 @@ ID TASK                       GEN PRI STATE
 22 vpd                          0   4 recv
    |
    +--->  0x24039e08 0x080ad400 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x24039f20 0x080ac07a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x24039f20 0x080ac07a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:188
+   |                 @ /hubris/sys/userlib/src/lib.rs:388:13
+   |      0x24039f20 0x080ac088 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x24039f20 0x080ac088 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/b2f4c9e/runtime/src/lib.rs:193:20
    |      0x24039f20 0x080ac088 main
-   |                 @ /hubris/task/vpd/src/main.rs:115
+   |                 @ /hubris/task/vpd/src/main.rs:120:9
    |
    |
    +--->   R0 = 0x24039e40   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x24039e50
@@ -1355,7 +1357,7 @@ ID TASK                       GEN PRI STATE
 23 idle                         0   8 RUNNING
    |
    +--->  0x2403a100 0x080ae852 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x2403a100   R1 = 0x2403a100   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.0.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 wait: send to jefe/gen0
    |
    +--->  0x20013538 0x0803554c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20013600 0x080342b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20013600 0x080342b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20013600 0x080342ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20013600 0x080342ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20013600 0x080342ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08035bf4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,23 +65,23 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20015330 0x0803e60a userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:990
-   |      0x20015338 0x0803e610 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x20015338 0x0803e618 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x20015338 0x0803e618 rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1445
+   |                 @ /hubris/sys/userlib/src/lib.rs:1446:5
    |      0x20015340 0x0803e47c core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x20015348 0x0803e486 core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20015350 0x0803e46c drv_stm32xx_sys::idl::InOrderSysImpl::closed_recv_fail
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32xx-sys-c6d586730361d51c/out/server_stub.rs:244
-   |      0x20015380 0x0803e402 drv_stm32xx_sys::idl::<impl idol_runtime::Server<drv_stm32xx_sys::idl::SysOperation> for (core::marker::PhantomData<drv_stm32xx_sys::idl::SysOperation>,&mut S)>::closed_recv_fail
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32xx-sys-c6d586730361d51c/out/server_stub.rs:308
-   |      0x20015380 0x0803e090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /build/drv-stm32xx-sys-c6d586730361d51c/out/server_stub.rs:245:9
+   |      0x20015380 0x0803e406 drv_stm32xx_sys::idl::<impl idol_runtime::Server<drv_stm32xx_sys::idl::SysOperation> for (core::marker::PhantomData<drv_stm32xx_sys::idl::SysOperation>,&mut S)>::closed_recv_fail
+   |                 @ /build/drv-stm32xx-sys-c6d586730361d51c/out/server_stub.rs:309:9
+   |      0x20015380 0x0803e406 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:177:13
    |      0x20015380 0x0803e406 main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x0803e674   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20015360
@@ -140,15 +140,15 @@ ID TASK                       GEN PRI STATE
  2 i2c_driver                   0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20013a48 0x0802995a userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:990
-   |      0x20013a80 0x08029992 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x20013a80 0x08029996 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x20013a80 0x08029996 rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1298
+   |                 @ /hubris/sys/userlib/src/lib.rs:1437:5
    |      0x20013a98 0x08028e62 core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x20013ac0 0x080291d4 core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20013b80 0x08028af8 main
    |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:149
    |
@@ -209,15 +209,15 @@ ID TASK                       GEN PRI STATE
  3 spi_driver                   0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20014278 0x0802dcaa userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:990
-   |      0x200142b0 0x0802dce2 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x200142b0 0x0802dce6 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x200142b0 0x0802dce6 rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1298
+   |                 @ /hubris/sys/userlib/src/lib.rs:1437:5
    |      0x200142c8 0x0802d272 core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x200142f0 0x0802d626 core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20014370 0x0802c3bc main
    |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
    |
@@ -278,21 +278,21 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 FAULT: illegal instruction (was: ready)
    |
    +--->  0x200156f0 0x0803ebf2 userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:990
-   |      0x200156f8 0x0803ebf8 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x200156f8 0x0803ec00 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x200156f8 0x0803ec00 rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1445
+   |                 @ /hubris/sys/userlib/src/lib.rs:1446:5
    |      0x20015700 0x0803eaa8 core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x20015708 0x0803eab2 core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20015740 0x0803eb42 drv_stm32xx_sys_api::Sys::gpio_set_reset
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32xx-sys-api-8f1eaa8811658a88/out/client_stub.rs:316
-   |      0x20015780 0x0803e86a drv_user_leds::enable_led_pins
-   |                 @ /hubris//drv/user-leds/src/main.rs:397
+   |                 @ /build/drv-stm32xx-sys-api-8f1eaa8811658a88/out/client_stub.rs:367:13
+   |      0x20015780 0x0803e8a2 drv_user_leds::enable_led_pins
+   |                 @ /hubris/drv/user-leds/src/main.rs:405:9
    |      0x20015780 0x0803e8a2 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:111
+   |                 @ /hubris/drv/user-leds/src/main.rs:112:5
    |
    |
    +--->   R0 = 0x0803ec8a   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x00000004
@@ -351,15 +351,15 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 FAULT: illegal instruction (was: ready)
    |
    +--->  0x20015b20 0x0803f1fa userlib::sys_panic_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:990
-   |      0x20015b28 0x0803f200 userlib::sys_panic
-   |                 @ /hubris//sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x20015b28 0x0803f208 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x20015b28 0x0803f208 rust_begin_unwind
-   |                 @ /hubris//sys/userlib/src/lib.rs:1445
+   |                 @ /hubris/sys/userlib/src/lib.rs:1446:5
    |      0x20015b30 0x0803f160 core::panicking::panic_fmt
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:88
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:103:14
    |      0x20015b38 0x0803f16a core::panicking::panic
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c//library/core/src/panicking.rs:39
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/panicking.rs:50:5
    |      0x20015b80 0x0803f132 main
    |                 @ /hubris//task/pong/src/main.rs:13
    |
@@ -420,17 +420,17 @@ ID TASK                       GEN PRI STATE
  6 uartecho                     0   3 RUNNING
    |
    +--->  0x20010728 0x080372ae userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:154
-   |      0x20010800 0x0803621c drv_stm32xx_sys_api::Sys::enable_clock_raw
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/drv-stm32xx-sys-api-f1c4139af0e99a98/out/client_stub.rs:30
-   |      0x20010800 0x0803621c drv_stm32xx_sys_api::Sys::enable_clock
-   |                 @ /hubris//drv/stm32xx-sys-api/src/lib.rs:43
-   |      0x20010800 0x0803621c drv_stm32h7_usart::Usart::turn_on
-   |                 @ /hubris//drv/stm32h7-usart/src/lib.rs:39
-   |      0x20010800 0x080361fa task_uartecho::configure_uart_device
-   |                 @ /hubris//task/uartecho/src/main.rs:167
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
+   |      0x20010800 0x08036244 drv_stm32xx_sys_api::Sys::enable_clock_raw
+   |                 @ /build/drv-stm32xx-sys-api-f1c4139af0e99a98/out/client_stub.rs:64:12
+   |      0x20010800 0x08036244 drv_stm32xx_sys_api::Sys::enable_clock
+   |                 @ /hubris/drv/stm32xx-sys-api/src/lib.rs:46:9
+   |      0x20010800 0x08036244 drv_stm32h7_usart::Usart::turn_on
+   |                 @ /hubris/drv/stm32h7-usart/src/lib.rs:48:9
+   |      0x20010800 0x08036244 task_uartecho::configure_uart_device
+   |                 @ /hubris/task/uartecho/src/main.rs:243:5
    |      0x20010800 0x08036244 main
-   |                 @ /hubris//task/uartecho/src/main.rs:44
+   |                 @ /hubris/task/uartecho/src/main.rs:45:16
    |
    |
    +--->   R0 = 0x20010778   R1 = 0x000003fe   R2 = 0x00000000   R3 = 0x00000000
@@ -486,7 +486,7 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   4 ready
    |
    +--->  0x20008800 0x08008001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -542,7 +542,7 @@ ID TASK                       GEN PRI STATE
  8 hf                           0   3 ready
    |
    +--->  0x20014f80 0x08030001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -598,7 +598,7 @@ ID TASK                       GEN PRI STATE
  9 net                          0   3 ready
    |
    +--->  0x200050e0 0x08010001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -654,7 +654,7 @@ ID TASK                       GEN PRI STATE
 10 udpecho                      0   4 ready
    |
    +--->  0x20003000 0x08038001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -710,7 +710,7 @@ ID TASK                       GEN PRI STATE
 11 validate                     0   3 ready
    |
    +--->  0x20011400 0x08020001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -766,7 +766,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x20015f00 0x0803f401 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -822,7 +822,7 @@ ID TASK                       GEN PRI STATE
 13 rng_driver                   0   3 ready
    |
    +--->  0x20015d00 0x0803a001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000
@@ -878,7 +878,7 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 ready
    |
    +--->  0x20012800 0x0803c001 _start
-   |                 @ /hubris//sys/userlib/src/lib.rs:1167
+   |                 @ /hubris/sys/userlib/src/lib.rs:1225:13
    |
    |
    +--->   R0 = 0x00000000   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.static-tasks.1.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: bit0 bit1(T+54)
    |
    +--->  0x20013538 0x0803554c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20013600 0x080342b8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20013600 0x080342b8 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20013600 0x080342ca userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20013600 0x080342ca userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20013600 0x080342ca main
-   |                 @ /hubris//task/jefe/src/main.rs:106
+   |                 @ /hubris/task/jefe/src/main.rs:132:23
    |
    |
    +--->   R0 = 0x08035bf4   R1 = 0x00000000   R2 = 0x00000003   R3 = 0x200135dc
@@ -65,13 +65,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x20015350 0x0803e5d6 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015380 0x0803e090 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015380 0x0803e090 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015380 0x0803e09e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015380 0x0803e09e idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20015380 0x0803e09e main
-   |                 @ /hubris//drv/stm32xx-sys/src/main.rs:73
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:131:9
    |
    |
    +--->   R0 = 0x20015358   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x20015360
@@ -127,17 +127,17 @@ ID TASK                       GEN PRI STATE
  2 i2c_driver                   0   2 recv
    |
    +--->  0x20013ac0 0x08029898 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20013b80 0x080284b4 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20013b80 0x080284b4 userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
-   |      0x20013b80 0x080284b4 userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:83
-   |      0x20013b80 0x080284b4 userlib::hl::recv_without_notification
-   |                 @ /hubris/sys/userlib/src/hl.rs:121
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20013b80 0x080284c2 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20013b80 0x080284c2 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
+   |      0x20013b80 0x080284c2 userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:93:14
+   |      0x20013b80 0x080284c2 userlib::hl::recv_without_notification
+   |                 @ /hubris/sys/userlib/src/hl.rs:128:5
    |      0x20013b80 0x080284c2 main
-   |                 @ /hubris//drv/stm32h7-i2c-server/src/main.rs:149
+   |                 @ /hubris/drv/stm32h7-i2c-server/src/main.rs:178:9
    |
    |
    +--->   R0 = 0x20013b54   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20013b58
@@ -193,13 +193,13 @@ ID TASK                       GEN PRI STATE
  3 spi_driver                   0   2 recv
    |
    +--->  0x200142f0 0x0802dc34 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20014370 0x0802c686 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20014370 0x0802c686 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20014370 0x0802c6a0 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20014370 0x0802c6a0 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20014370 0x0802c6a0 main
-   |                 @ /hubris//drv/stm32h7-spi-server/src/main.rs:59
+   |                 @ /hubris/drv/stm32h7-spi-server/src/main.rs:119:9
    |
    |
    +--->   R0 = 0x2001430a   R1 = 0x00000002   R2 = 0x00000000   R3 = 0x2001430c
@@ -255,13 +255,13 @@ ID TASK                       GEN PRI STATE
  4 user_leds                    0   2 recv
    |
    +--->  0x20015740 0x0803eb60 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015780 0x0803e920 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015780 0x0803e920 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015780 0x0803e930 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015780 0x0803e930 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20015780 0x0803e930 main
-   |                 @ /hubris//drv/user-leds/src/main.rs:111
+   |                 @ /hubris/drv/user-leds/src/main.rs:118:9
    |
    |
    +--->   R0 = 0x2001574c   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x20015758
@@ -317,13 +317,13 @@ ID TASK                       GEN PRI STATE
  5 pong                         0   3 recv, notif: bit0(T+154)
    |
    +--->  0x20015b38 0x0803f198 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015b80 0x0803f0aa userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015b80 0x0803f0aa userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:236
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015b80 0x0803f0b8 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015b80 0x0803f0b8 userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:240:11
    |      0x20015b80 0x0803f0b8 main
-   |                 @ /hubris//task/pong/src/main.rs:13
+   |                 @ /hubris/task/pong/src/main.rs:26:23
    |
    |
    +--->   R0 = 0x20015b44   R1 = 0x00000010   R2 = 0x00000001   R3 = 0x20015b58
@@ -379,13 +379,13 @@ ID TASK                       GEN PRI STATE
  6 uartecho                     0   3 notif: bit0(irq38)
    |
    +--->  0x20010728 0x08037292 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20010800 0x0803637c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20010800 0x0803637c userlib::sys_recv_closed
-   |                 @ /hubris/sys/userlib/src/lib.rs:261
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20010800 0x0803638c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:293:9
+   |      0x20010800 0x0803638c userlib::sys_recv_closed
+   |                 @ /hubris/sys/userlib/src/lib.rs:266:5
    |      0x20010800 0x0803638c main
-   |                 @ /hubris//task/uartecho/src/main.rs:44
+   |                 @ /hubris/task/uartecho/src/main.rs:54:17
    |
    |
    +--->   R0 = 0x08037aa8   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20010778
@@ -441,19 +441,19 @@ ID TASK                       GEN PRI STATE
  7 hiffy                        0   4 notif: bit31(T+175)
    |
    +--->  0x20008540 0x0800bd62 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20008580 0x0800bdde userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20008580 0x0800bdb8 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20008580 0x0800bdde userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20008580 0x0800bdde userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
+   |                 @ /hubris/sys/userlib/src/hl.rs:647:5
    |      0x20008800 0x08009554 core::sync::atomic::atomic_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2401
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:2409:23
    |      0x20008800 0x08009554 core::sync::atomic::AtomicU32::fetch_sub
-   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1772
+   |                 @ /rustc/ac2d9fc509e36d1b32513744adf58c34bcc4f43c/library/core/src/sync/atomic.rs:1774:26
    |      0x20008800 0x08009554 main
-   |                 @ /hubris//task/hiffy/src/main.rs:99
+   |                 @ /hubris/task/hiffy/src/main.rs:117:9
    |
    |
    +--->   R0 = 0x0800d1bc   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x20008548
@@ -509,13 +509,13 @@ ID TASK                       GEN PRI STATE
  8 hf                           0   3 recv
    |
    +--->  0x20014e08 0x080317b4 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20014f80 0x0803030c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20014f80 0x0803030c idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20014f80 0x0803031c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20014f80 0x0803031c idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20014f80 0x0803031c main
-   |                 @ /hubris//drv/gimlet-hf-server/src/main.rs:70
+   |                 @ /hubris/drv/gimlet-hf-server/src/main.rs:145:9
    |
    |
    +--->   R0 = 0x20014e30   R1 = 0x00000008   R2 = 0x00000000   R3 = 0x20014f60
@@ -571,19 +571,19 @@ ID TASK                       GEN PRI STATE
  9 net                          0   3 notif: bit31(T+2)
    |
    +--->  0x200047e0 0x0801b68c userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
    |      0x20004820 0x0801b706 userlib::sys_get_timer
-   |                 @ /hubris//sys/userlib/src/lib.rs:1055
-   |      0x20004820 0x0801b6e0 userlib::hl::sleep_until
-   |                 @ /hubris//sys/userlib/src/hl.rs:610
+   |                 @ /hubris/sys/userlib/src/lib.rs:1060:9
+   |      0x20004820 0x0801b706 userlib::hl::sleep_until
+   |                 @ /hubris/sys/userlib/src/hl.rs:625:12
    |      0x20004820 0x0801b706 userlib::hl::sleep_for
-   |                 @ /hubris//sys/userlib/src/hl.rs:635
-   |      0x200050e0 0x08011058 drv_stm32h7_eth::crappy_spin_until
-   |                 @ /hubris//drv/stm32h7-eth/src/lib.rs:49
-   |      0x200050e0 0x08011056 drv_stm32h7_eth::Ethernet::new
-   |                 @ /hubris//drv/stm32h7-eth/src/lib.rs:66
+   |                 @ /hubris/sys/userlib/src/hl.rs:647:5
+   |      0x200050e0 0x08011066 drv_stm32h7_eth::crappy_spin_until
+   |                 @ /hubris/drv/stm32h7-eth/src/lib.rs:51:9
+   |      0x200050e0 0x08011066 drv_stm32h7_eth::Ethernet::new
+   |                 @ /hubris/drv/stm32h7-eth/src/lib.rs:80:9
    |      0x200050e0 0x08011066 main
-   |                 @ /hubris//task/net/src/main.rs:99
+   |                 @ /hubris/task/net/src/main.rs:128:15
    |
    |
    +--->   R0 = 0x0801d668   R1 = 0x00000000   R2 = 0x80000000   R3 = 0x200047e8
@@ -639,13 +639,13 @@ ID TASK                       GEN PRI STATE
 10 udpecho                      0   4 wait: send to net/gen0
    |
    +--->  0x20002dd0 0x08039726 userlib::sys_send_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:154
-   |      0x20003000 0x08038114 userlib::sys_send
-   |                 @ /hubris/sys/userlib/src/lib.rs:118
-   |      0x20003000 0x080380bc task_net_api::Net::recv_packet
-   |                 @ /hubris/target/thumbv7em-none-eabihf/release/build/task-net-api-4ffcac6de28e7694/out/client_stub.rs:26
+   |                 @ /hubris/sys/userlib/src/lib.rs:194:13
+   |      0x20003000 0x08038134 userlib::sys_send
+   |                 @ /hubris/sys/userlib/src/lib.rs:135:14
+   |      0x20003000 0x08038134 task_net_api::Net::recv_packet
+   |                 @ /build/task-net-api-4ffcac6de28e7694/out/client_stub.rs:54:25
    |      0x20003000 0x08038134 main
-   |                 @ /hubris//task/udpecho/src/main.rs:14
+   |                 @ /hubris/task/udpecho/src/main.rs:23:15
    |
    |
    +--->   R0 = 0x20002fbc   R1 = 0x00000001   R2 = 0x20002fc0   R3 = 0x08039be4
@@ -701,13 +701,13 @@ ID TASK                       GEN PRI STATE
 11 validate                     0   3 recv
    |
    +--->  0x200113d8 0x08020bda userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20011400 0x0802011a userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20011400 0x0802011a idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20011400 0x08020128 userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20011400 0x08020128 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20011400 0x08020128 main
-   |                 @ /hubris//task/validate/src/main.rs:56
+   |                 @ /hubris/task/validate/src/main.rs:61:9
    |
    |
    +--->   R0 = 0x200113e0   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200113e4
@@ -763,7 +763,7 @@ ID TASK                       GEN PRI STATE
 12 idle                         0   5 ready
    |
    +--->  0x20015f00 0x0803f456 main
-   |                 @ /hubris//task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:14:5
    |
    |
    +--->   R0 = 0x20015f00   R1 = 0x20015f00   R2 = 0x00000000   R3 = 0x00000000
@@ -819,13 +819,13 @@ ID TASK                       GEN PRI STATE
 13 rng_driver                   0   3 recv
    |
    +--->  0x20015cc0 0x0803ae7e userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20015d00 0x0803a1dc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20015d00 0x0803a1dc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20015d00 0x0803a1ea userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20015d00 0x0803a1ea idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20015d00 0x0803a1ea main
-   |                 @ /hubris//drv/stm32h7-rng/src/main.rs:136
+   |                 @ /hubris/drv/stm32h7-rng/src/main.rs:144:9
    |
    |
    +--->   R0 = 0x20015cf7   R1 = 0x00000000   R2 = 0x00000000   R3 = 0x20015cd8
@@ -881,13 +881,13 @@ ID TASK                       GEN PRI STATE
 14 update_server                0   3 recv
    |
    +--->  0x200123c0 0x0803d046 userlib::sys_recv_stub
-   |                 @ /hubris//sys/userlib/src/lib.rs:332
-   |      0x20012800 0x0803c1cc userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:280
-   |      0x20012800 0x0803c1cc idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:169
+   |                 @ /hubris/sys/userlib/src/lib.rs:387:13
+   |      0x20012800 0x0803c1dc userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:306:8
+   |      0x20012800 0x0803c1dc idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/add88a5/runtime/src/lib.rs:174:20
    |      0x20012800 0x0803c1dc main
-   |                 @ /hubris//drv/stm32h7-update-server/src/main.rs:315
+   |                 @ /hubris/drv/stm32h7-update-server/src/main.rs:325:9
    |
    |
    +--->   R0 = 0x200123dc   R1 = 0x00000004   R2 = 0x00000000   R3 = 0x200123e0

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.task.net.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.task.net.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  1 net                          0   5 FAULT: panicked at 'MAC RX watchdog', task/net/src/main.rs:268:41 (was: ready)
    |
    +--->  0x24008cd0 0x0803038a userlib::sys_panic_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:990
-   |      0x24008d08 0x080303c0 userlib::sys_panic
-   |                 @ /hubris/sys/userlib/src/lib.rs:982
+   |                 @ /hubris/sys/userlib/src/lib.rs:1017:13
+   |      0x24008d08 0x080303c4 userlib::sys_panic
+   |                 @ /hubris/sys/userlib/src/lib.rs:983:14
    |      0x24008d08 0x080303c4 rust_begin_unwind
-   |                 @ /hubris/sys/userlib/src/lib.rs:1298
+   |                 @ /hubris/sys/userlib/src/lib.rs:1437:5
    |      0x24008d28 0x08028ac6 core::panicking::panic_fmt
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:50
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:65:14
    |      0x24009798 0x080270b2 main
    |                 @ /hubris/task/net/src/main.rs:147
    |

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.task.power.stdout
@@ -5,37 +5,37 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x24044040 0x08088a20 core::fmt::write
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1209:17
    |      0x24044090 0x08088a20 core::fmt::write
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1209:17
    |      0x240440e0 0x0808a8e8 <core::panic::panic_info::PanicInfo as core::fmt::Display>::fmt
    |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panic/panic_info.rs:152
    |      0x240440e0 0x0808a93c <&T as core::fmt::Display>::fmt
    |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:2373
    |      0x24044130 0x08088a20 core::fmt::write
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1195
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:1209:17
    |      0x24044168 0x0808a9c8 core::fmt::Write::write_fmt
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:191
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/fmt/mod.rs:193:6
    |      0x240441a0 0x0808abbc rust_begin_unwind
-   |                 @ /hubris/sys/userlib/src/lib.rs:1298
+   |                 @ /hubris/sys/userlib/src/lib.rs:1434:24
    |      0x240441c0 0x08087fca core::panicking::panic_fmt
-   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:50
+   |                 @ /rustc/95a3a7277b44bbd2dd3485703d9a05f64652b60e/library/core/src/panicking.rs:65:14
    |      0x240441e8 0x080895dc drv_i2c_api::I2cDevice::response_code
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:128
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:131:17
    |      0x24044240 0x080897b6 drv_i2c_api::I2cDevice::read_reg
-   |                 @ /hubris/drv/i2c-api/src/lib.rs:158
-   |      0x240449c8 0x08084a86 <drv_i2c_devices::bmr491::Bmr491 as drv_i2c_devices::TempSensor<drv_i2c_devices::bmr491::Error>>::read_temperature
-   |                 @ /hubris/drv/i2c-devices/src/bmr491.rs:95
-   |      0x240449c8 0x08084a86 task_power::Device::read_temperature
-   |                 @ /hubris/task/power/src/main.rs:101
-   |      0x240449c8 0x08084958 task_power::ServerImpl::handle_timer_fired
-   |                 @ /hubris/task/power/src/main.rs:439
-   |      0x240449c8 0x08084958 <task_power::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
-   |                 @ /hubris/task/power/src/main.rs:627
-   |      0x240449c8 0x08084906 idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/f86afe0/runtime/src/lib.rs:228
+   |                 @ /hubris/drv/i2c-api/src/lib.rs:179:6
+   |      0x240449c8 0x08084a90 <drv_i2c_devices::bmr491::Bmr491 as drv_i2c_devices::TempSensor<drv_i2c_devices::bmr491::Error>>::read_temperature
+   |                 @ /hubris/drv/i2c-devices/src/bmr491.rs:96:20
+   |      0x240449c8 0x08084a90 task_power::Device::read_temperature
+   |                 @ /hubris/task/power/src/main.rs:103:36
+   |      0x240449c8 0x08084a90 task_power::ServerImpl::handle_timer_fired
+   |                 @ /hubris/task/power/src/main.rs:459:23
+   |      0x240449c8 0x08084a90 <task_power::ServerImpl as idol_runtime::NotificationHandler>::handle_notification
+   |                 @ /hubris/task/power/src/main.rs:628:9
+   |      0x240449c8 0x08084a90 idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/f86afe0/runtime/src/lib.rs:255:13
    |      0x240449c8 0x08084a90 main
-   |                 @ /hubris/task/power/src/main.rs:411
+   |                 @ /hubris/task/power/src/main.rs:427:9
    |
    |
    +-----------> 0x240009d0 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.u16-ringbuf.stdout
@@ -5,10 +5,13 @@ ID TASK                       GEN PRI STATE
    guessing at stack trace using saved frame pointer
    |
    +--->  0x240480c0 0x0807afd4 drv_gimlet_seq_server::ringbuf_entry_v3p3_sys_a0_vout
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:1398
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:1398:0
    |      0x240482b0 0x0807a4c0 drv_gimlet_seq_server::ServerImpl<S>::set_state_internal
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:675:19
+   |      0x24048640 0x08079c2a drv_gimlet_seq_server::ServerImpl<S>::init
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:491:9
    |      0x24048640 0x08079c2a main
-   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:145
+   |                 @ /hubris/drv/gimlet-seq-server/src/main.rs:150:11
    |
    |
    +-----------> 0x24000b20 Task {

--- a/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
+++ b/humility-bin/tests/cmd/tasks-slvr/tasks-slvr.v6.stdout
@@ -3,13 +3,13 @@ ID TASK                       GEN PRI STATE
  0 jefe                         0   0 recv, notif: timer(T+74) fault
    |
    +--->  0x200008b8 0x08005a98 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x20000960 0x080051f8 userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x20000960 0x080051f8 idol_runtime::dispatch_n
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/fe16102/runtime/src/lib.rs:270
+   |                 @ /hubris/sys/userlib/src/lib.rs:342:13
+   |      0x20000960 0x0800520c userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x20000960 0x0800520c idol_runtime::dispatch_n
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/fe16102/runtime/src/lib.rs:278:20
    |      0x20000960 0x0800520c main
-   |                 @ /hubris/task/jefe/src/main.rs:116
+   |                 @ /hubris/task/jefe/src/main.rs:139:9
    |
    |
    +--->   R0 = 0x20000908   R1 = 0x00000008   R2 = 0x00000003   R3 = 0x20000928
@@ -45,13 +45,13 @@ ID TASK                       GEN PRI STATE
  1 sys                          0   1 recv
    |
    +--->  0x200007b8 0x08004d64 userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x20000800 0x080048de userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x20000800 0x080048de idol_runtime::dispatch
-   |                 @ /git/idolatry-1ebf1c2fd2f30300/fe16102/runtime/src/lib.rs:197
+   |                 @ /hubris/sys/userlib/src/lib.rs:342:13
+   |      0x20000800 0x080048ee userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x20000800 0x080048ee idol_runtime::dispatch
+   |                 @ /git/idolatry-1ebf1c2fd2f30300/fe16102/runtime/src/lib.rs:202:20
    |      0x20000800 0x080048ee main
-   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:80
+   |                 @ /hubris/drv/stm32xx-sys/src/main.rs:143:9
    |
    |
    +--->   R0 = 0x200007d0   R1 = 0x00000005   R2 = 0x00000000   R3 = 0x200007d8
@@ -87,15 +87,15 @@ ID TASK                       GEN PRI STATE
  2 usart_driver                 0   2 recv, notif: usart-irq(irq27)
    |
    +--->  0x20000ab8 0x0800633e userlib::sys_recv_stub
-   |                 @ /hubris/sys/userlib/src/lib.rs:333
-   |      0x20000b00 0x0800614c userlib::sys_recv
-   |                 @ /hubris/sys/userlib/src/lib.rs:281
-   |      0x20000b00 0x0800614c userlib::sys_recv_open
-   |                 @ /hubris/sys/userlib/src/lib.rs:237
-   |      0x20000b00 0x0800614c userlib::hl::recv
-   |                 @ /hubris/sys/userlib/src/hl.rs:82
+   |                 @ /hubris/sys/userlib/src/lib.rs:342:13
+   |      0x20000b00 0x0800615e userlib::sys_recv
+   |                 @ /hubris/sys/userlib/src/lib.rs:307:8
+   |      0x20000b00 0x0800615e userlib::sys_recv_open
+   |                 @ /hubris/sys/userlib/src/lib.rs:241:11
+   |      0x20000b00 0x0800615e userlib::hl::recv
+   |                 @ /hubris/sys/userlib/src/hl.rs:92:14
    |      0x20000b00 0x0800615e main
-   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:55
+   |                 @ /hubris/drv/stm32g0-usart/src/main.rs:98:9
    |
    |
    +--->   R0 = 0x08006480   R1 = 0x00000000   R2 = 0x00000001   R3 = 0x20000ad8
@@ -131,11 +131,11 @@ ID TASK                       GEN PRI STATE
  3 idle                         0   5 RUNNING
    |
    +--->  0x200006c0 0x080046c0 cortex_m::asm::inline::__wfi
-   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:190
+   |                 @ /crates.io/cortex-m-0.7.5/src/../asm/inline.rs:191:5
    |      0x200006c0 0x080046c0 cortex_m::asm::wfi
-   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:54
+   |                 @ /crates.io/cortex-m-0.7.5/src/asm.rs:55:5
    |      0x200006c0 0x080046c0 main
-   |                 @ /hubris/task/idle/src/main.rs:13
+   |                 @ /hubris/task/idle/src/main.rs:28:13
    |
    |
    +--->   R0 = 0x200006c0   R1 = 0x200006c0   R2 = 0x00000000   R3 = 0x00000000

--- a/humility-bin/tests/cmd/version.trycmd
+++ b/humility-bin/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.12.7 
+humility 0.12.8 
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.12.7 
+humility 0.12.8 
 
 ```

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
+addr2line.workspace = true
 anyhow.workspace = true
 bitfield.workspace = true
 clap.workspace = true

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4266,7 +4266,10 @@ impl HubrisObjectLoader {
         elf: &goblin::elf::Elf,
     ) -> Result<()> {
         // Load all of the sections. This "load" operation just gets the data in
-        // RAM -- since we've already loaded the Elf file, this can't fail.
+        // RAM -- since we've already loaded the Elf file, this can't fail.  We
+        // do end up copying the data into an `EndianArcSlice`, because the
+        // DWARF info needs to persist in the `addr2line::Context` (so it can't
+        // be borrowed from ourself).
         let loader = |id: gimli::SectionId| -> Result<_> {
             // Load the normal DWARF section(s) from our Elf image.
             let sec_result = elf.section_headers.iter().find(|sh| {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -596,7 +596,6 @@ impl Namespaces {
     }
 }
 
-#[derive(Debug)]
 pub struct HubrisArchive {
     // the entire archive
     archive: Vec<u8>,
@@ -637,6 +636,12 @@ pub struct HubrisArchive {
 
     // DWARF call frame debugging sections: task to raw bytes
     frames: HashMap<HubrisTask, Vec<u8>>,
+
+    /// addr2line contexts
+    addr2line: HashMap<
+        HubrisTask,
+        addr2line::Context<gimli::EndianArcSlice<gimli::LittleEndian>>,
+    >,
 
     // DWARF source code: goff to file/line
     src: HashMap<HubrisGoff, HubrisSrc>,
@@ -731,6 +736,7 @@ impl HubrisArchive {
             structs: HashMap::new(),
             structs_byname: MultiMap::new(),
             enums: HashMap::new(),
+            addr2line: HashMap::new(),
             enums_byname: MultiMap::new(),
             arrays: HashMap::new(),
             variables: MultiMap::new(),
@@ -1432,6 +1438,7 @@ impl HubrisArchive {
         self.structs_byname.extend(loader.structs_byname);
         self.arrays.extend(loader.arrays);
         self.basetypes.extend(loader.basetypes);
+        self.addr2line.extend(loader.addr2line);
         self.basetypes_byname.extend(loader.basetypes_byname);
         self.ptrtypes.extend(loader.ptrtypes);
         self.inlined.extend(loader.inlined);
@@ -2903,6 +2910,49 @@ impl HubrisArchive {
             let mut ctx = gimli::UnwindContext::new();
             let pc = *frameregs.get(&ARMRegister::PC).unwrap();
 
+            // Look up the `addr2line` info for the current pc
+            let mut pos = vec![];
+            let mut pos_valid = true;
+            match self.addr2line[&task].find_frames(u64::from(pc)) {
+                addr2line::LookupResult::Load { .. } => {
+                    warn!("addr2line wants to load extern data");
+                    pos_valid = false;
+                }
+                addr2line::LookupResult::Output(Ok(mut v)) => {
+                    while let Ok(Some(f)) = v.next() {
+                        // Record a position if we have func + file:line:col
+                        if let (Some(loc), Some(func)) =
+                            (&f.location, &f.function)
+                        {
+                            if let (
+                                Some(file),
+                                Some(line),
+                                Some(col),
+                                Some(func),
+                            ) = (
+                                loc.file,
+                                loc.line,
+                                loc.column,
+                                func.demangle().ok(),
+                            ) {
+                                pos.push(HubrisSrcPosition {
+                                    file: file.to_string(),
+                                    func: func.to_string(),
+                                    line,
+                                    col,
+                                });
+                            }
+                        }
+                    }
+                }
+                addr2line::LookupResult::Output(Err(e)) => {
+                    warn!("addr2line lookup failed: {e}");
+                    pos_valid = false;
+                }
+            }
+            let pos =
+                if pos.is_empty() || !pos_valid { None } else { Some(pos) };
+
             //
             // Now we want to iterate up our frames
             //
@@ -3002,6 +3052,7 @@ impl HubrisArchive {
                 cfa,
                 sym,
                 inlined,
+                pos,
                 registers: frameregs.clone(),
             });
 
@@ -3761,6 +3812,12 @@ struct HubrisObjectLoader {
     // DWARF call frame debugging sections: task to raw bytes
     frames: HashMap<HubrisTask, Vec<u8>>,
 
+    /// addr2line contexts
+    addr2line: HashMap<
+        HubrisTask,
+        addr2line::Context<gimli::EndianArcSlice<gimli::LittleEndian>>,
+    >,
+
     // loaded regions
     loaded: BTreeMap<u32, HubrisRegion>,
 
@@ -3848,6 +3905,7 @@ impl HubrisObjectLoader {
             enums: HashMap::new(),
             enums_byname: MultiMap::new(),
             frames: HashMap::new(),
+            addr2line: HashMap::new(),
             inlined: BTreeMap::new(),
             instrs: HashMap::new(),
             loaded: BTreeMap::new(),
@@ -4095,7 +4153,7 @@ impl HubrisObjectLoader {
             }
         }
 
-        self.load_object_dwarf(buffer, &elf)
+        self.load_object_dwarf(task, buffer, &elf)
             .context(format!("{}: failed to load DWARF", object))?;
 
         self.load_object_frames(task, buffer, &elf)
@@ -4203,12 +4261,13 @@ impl HubrisObjectLoader {
 
     fn load_object_dwarf(
         &mut self,
+        task: HubrisTask,
         buffer: &[u8],
         elf: &goblin::elf::Elf,
     ) -> Result<()> {
         // Load all of the sections. This "load" operation just gets the data in
         // RAM -- since we've already loaded the Elf file, this can't fail.
-        let loader = |id: gimli::SectionId| {
+        let loader = |id: gimli::SectionId| -> Result<_> {
             // Load the normal DWARF section(s) from our Elf image.
             let sec_result = elf.section_headers.iter().find(|sh| {
                 if let Some(name) = elf.shdr_strtab.get_at(sh.sh_name) {
@@ -4220,18 +4279,22 @@ impl HubrisObjectLoader {
             if let Some(sec) = sec_result {
                 let offset = sec.sh_offset as usize;
                 let size = sec.sh_size as usize;
-                buffer.get(offset..offset + size).ok_or_else(|| {
+                let s = buffer.get(offset..offset + size).ok_or_else(|| {
                     anyhow!("bad offset/size for ELF section {}", id.name())
-                })
+                })?;
+                Ok(gimli::EndianArcSlice::new(
+                    std::sync::Arc::from(s),
+                    gimli::LittleEndian,
+                ))
             } else {
-                Ok([].as_slice())
+                Ok(gimli::EndianArcSlice::new(
+                    std::sync::Arc::from([].as_slice()),
+                    gimli::LittleEndian,
+                ))
             }
         };
 
-        let dwarf_sections = gimli::DwarfSections::load(loader)?;
-        let dwarf: gimli::Dwarf<_> = dwarf_sections.borrow(|section| {
-            gimli::EndianSlice::new(section, gimli::LittleEndian)
-        });
+        let dwarf = gimli::Dwarf::load(loader)?;
 
         // Iterate over the compilation units.
         let mut iter = dwarf.units();
@@ -4393,6 +4456,8 @@ impl HubrisObjectLoader {
                 bail!("missing subrange for array {}", array);
             }
         }
+
+        self.addr2line.insert(task, addr2line::Context::from_dwarf(dwarf)?);
 
         Ok(())
     }
@@ -4572,10 +4637,7 @@ impl HubrisObjectLoader {
     fn dwarf_goff<R: gimli::Reader<Offset = usize>>(
         &self,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> HubrisGoff {
         let goff = match entry.offset().to_unit_section_offset(unit) {
             gimli::UnitSectionOffset::DebugInfoOffset(o) => o.0,
@@ -4587,12 +4649,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_union<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
@@ -4631,12 +4690,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_member<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         parent: HubrisGoff,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
@@ -4738,10 +4794,7 @@ impl HubrisObjectLoader {
     fn dwarf_value_goff<R: gimli::Reader<Offset = usize>>(
         &self,
         unit: &gimli::Unit<R>,
-        value: &gimli::AttributeValue<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        value: &gimli::AttributeValue<R, usize>,
     ) -> Option<HubrisGoff> {
         let goff = match value {
             gimli::AttributeValue::UnitRef(offs) => {
@@ -4764,10 +4817,7 @@ impl HubrisObjectLoader {
     fn dwarf_variant<R: gimli::Reader<Offset = usize>>(
         &mut self,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         parent: HubrisGoff,
     ) -> Result<()> {
         let goff = self.dwarf_goff(unit, entry);
@@ -4799,10 +4849,7 @@ impl HubrisObjectLoader {
     fn dwarf_enum<R: gimli::Reader<Offset = usize>>(
         &mut self,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         goff: HubrisGoff,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
@@ -4848,12 +4895,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_enum_variant<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         parent: HubrisGoff,
     ) -> Result<()> {
         let goff = self.dwarf_goff(unit, entry);
@@ -4908,12 +4952,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_const_enum<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         goff: HubrisGoff,
         namespace: Option<NamespaceId>,
     ) -> Result<()> {
@@ -4966,10 +5007,7 @@ impl HubrisObjectLoader {
     fn dwarf_array<R: gimli::Reader<Offset = usize>>(
         &mut self,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         parent: HubrisGoff,
         array: Option<HubrisGoff>,
     ) -> Result<()> {
@@ -4997,12 +5035,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_basetype<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
@@ -5053,7 +5088,7 @@ impl HubrisObjectLoader {
         }
 
         if let Some(name) = name {
-            self.basetypes_byname.insert(String::from(name), goff);
+            self.basetypes_byname.insert(name, goff);
         }
 
         Ok(())
@@ -5061,12 +5096,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_ptrtype<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
@@ -5085,7 +5117,7 @@ impl HubrisObjectLoader {
             }
         }
 
-        let name = name.unwrap_or("<UNNAMED>").to_string();
+        let name = name.unwrap_or_else(|| "<UNNAMED>".to_string());
 
         if let Some(underlying) = underlying {
             self.ptrtypes.insert(goff, (name, underlying));
@@ -5094,13 +5126,10 @@ impl HubrisObjectLoader {
         Ok(())
     }
 
-    fn dwarf_namespace(
+    fn dwarf_namespace<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        dwarf: &gimli::Dwarf<R>,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         depth: isize,
         namespace: &mut Vec<(NamespaceId, isize)>,
     ) -> Result<()> {
@@ -5115,7 +5144,7 @@ impl HubrisObjectLoader {
                 if let Some(name) = dwarf_name(dwarf, attr.value()) {
                     namespace.push((
                         self.namespaces.allocate(
-                            name,
+                            &name,
                             namespace.last().map(|(id, _)| *id),
                         ),
                         depth,
@@ -5133,10 +5162,7 @@ impl HubrisObjectLoader {
         &mut self,
         dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
         let mut file = None;
@@ -5206,12 +5232,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_struct<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         namespace: Option<NamespaceId>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
@@ -5257,10 +5280,7 @@ impl HubrisObjectLoader {
         &mut self,
         dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
         depth: isize,
     ) -> Result<()> {
         //
@@ -5350,12 +5370,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_subprogram<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut name = None;
         let mut linkage_name = None;
@@ -5392,7 +5409,7 @@ impl HubrisObjectLoader {
 
         if let Some(name) = name {
             let demangled_name = if let Some(ln) = linkage_name {
-                demangle_name(ln)
+                demangle_name(&ln)
             } else {
                 name.to_string()
             };
@@ -5404,7 +5421,7 @@ impl HubrisObjectLoader {
                     self.dsyms.insert(
                         addr as u32,
                         HubrisSymbol {
-                            name: name.to_string(),
+                            name,
                             demangled_name,
                             size: len as u32,
                             addr: addr as u32,
@@ -5423,12 +5440,9 @@ impl HubrisObjectLoader {
 
     fn dwarf_variable<R: gimli::Reader<Offset = usize>>(
         &mut self,
-        dwarf: &gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
+        dwarf: &gimli::Dwarf<R>,
         unit: &gimli::Unit<R>,
-        entry: &gimli::DebuggingInformationEntry<
-            gimli::EndianSlice<gimli::LittleEndian>,
-            usize,
-        >,
+        entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
         let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
@@ -5570,21 +5584,21 @@ impl HubrisObjectLoader {
         }
 
         if let (Some(name), Some(tgoff)) = (name, tgoff) {
-            let linkage = linkage_name.unwrap_or(name);
+            let linkage = linkage_name.as_ref().unwrap_or(&name);
 
             if let Some(syms) = self.esyms_byname.get_vec(linkage) {
                 for &(addr, size) in syms {
                     if let btree_map::Entry::Vacant(e) = self.dsyms.entry(addr)
                     {
                         e.insert(HubrisSymbol {
-                            name: String::from(name),
-                            demangled_name: demangle_name(name),
+                            name: name.clone(),
+                            demangled_name: demangle_name(&name),
                             size,
                             addr,
                             goff,
                         });
                         self.variables.insert(
-                            String::from(name),
+                            name.clone(),
                             HubrisVariable {
                                 goff: tgoff,
                                 addr,
@@ -5614,14 +5628,14 @@ impl HubrisObjectLoader {
                 );
                 if let btree_map::Entry::Vacant(e) = self.dsyms.entry(addr) {
                     e.insert(HubrisSymbol {
-                        name: String::from(name),
-                        demangled_name: demangle_name(name),
+                        name: name.clone(),
+                        demangled_name: demangle_name(&name),
                         size,
                         addr,
                         goff,
                     });
                     self.variables.insert(
-                        String::from(name),
+                        name.clone(),
                         HubrisVariable {
                             goff: tgoff,
                             addr,
@@ -5644,7 +5658,7 @@ impl HubrisObjectLoader {
                     );
                 }
             } else {
-                self.definitions.insert(String::from(name), tgoff);
+                self.definitions.insert(name, tgoff);
             }
         }
 
@@ -6360,11 +6374,24 @@ pub struct HubrisStackSymbol<'a> {
 }
 
 #[derive(Clone, Debug)]
+pub struct HubrisSrcPosition {
+    pub file: String,
+    pub func: String,
+    pub line: u32,
+    pub col: u32,
+}
+
+#[derive(Clone, Debug)]
 pub struct HubrisStackFrame<'a> {
     /// Canonical frame address
     pub cfa: u32,
+    /// Symbol for the relevant function
     pub sym: Option<HubrisStackSymbol<'a>>,
+    /// Position as decoded by `addr2line` (empty if unknown)
+    pub pos: Option<Vec<HubrisSrcPosition>>,
+    /// Register state at this point in the stack
     pub registers: BTreeMap<ARMRegister, u32>,
+    /// Inlined functions in the stack
     pub inlined: Option<Vec<HubrisInlined<'a>>>,
 }
 
@@ -6676,15 +6703,14 @@ fn try_scoped<'a>(
     }
 }
 
-fn dwarf_name<'a>(
-    dwarf: &'a gimli::Dwarf<gimli::EndianSlice<gimli::LittleEndian>>,
-    value: gimli::AttributeValue<gimli::EndianSlice<gimli::LittleEndian>>,
-) -> Option<&'a str> {
+fn dwarf_name<R: gimli::Reader<Offset = usize>>(
+    dwarf: &gimli::Dwarf<R>,
+    value: gimli::AttributeValue<R>,
+) -> Option<String> {
     match value {
         gimli::AttributeValue::DebugStrRef(strref) => {
             let dstring = dwarf.debug_str.get_str(strref).ok()?;
-            let ddstring = str::from_utf8(dstring.slice()).ok()?;
-            Some(ddstring)
+            dstring.to_string().ok().map(|s| s.to_string())
         }
         _ => None,
     }

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -28,7 +28,6 @@ enum State {
     ResultsConsumed,
 }
 
-#[derive(Debug)]
 pub struct HiffyContext<'a> {
     hubris: &'a HubrisArchive,
     ready: &'a HubrisVariable,

--- a/humility-idol/src/lib.rs
+++ b/humility-idol/src/lib.rs
@@ -16,7 +16,6 @@ use indexmap::IndexMap;
 use serde::Serialize;
 use std::fmt;
 
-#[derive(Debug)]
 pub struct IdolOperation<'a> {
     hubris: &'a HubrisArchive,
     pub name: (String, String),

--- a/humility-jefe/src/lib.rs
+++ b/humility-jefe/src/lib.rs
@@ -10,7 +10,6 @@ use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
-#[derive(Debug)]
 pub struct JefeVariables<'a> {
     #[allow(unused)]
     hubris: &'a HubrisArchive,

--- a/humility-stack/Cargo.toml
+++ b/humility-stack/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 humility.workspace = true
 humility-arch-arm.workspace = true
+regex.workspace = true

--- a/humility-stack/src/lib.rs
+++ b/humility-stack/src/lib.rs
@@ -32,46 +32,61 @@ impl StackPrinter {
         for (ndx, frame) in stack.iter().enumerate() {
             let pc = frame.registers.get(&ARMRegister::PC).unwrap();
 
-            if let Some(ref inlined) = frame.inlined {
-                for inline in inlined {
-                    println!(
-                        "0x{:08x} 0x{:08x} {}",
-                        frame.cfa, inline.addr, inline.name
-                    );
-
-                    print_indent();
-
+            if let Some(pos) = &frame.pos {
+                for (i, p) in pos.iter().enumerate() {
+                    println!("0x{:08x} 0x{:08x} {}", frame.cfa, *pc, p.func);
                     if self.line {
-                        if let Some(src) = hubris.lookup_src(inline.origin) {
-                            println!(
-                                "{:11}@ {}:{}",
-                                "",
-                                src.fullpath(),
-                                src.line
-                            );
-                            print_indent();
+                        print_indent();
+                        println!("{:11}@ {}:{}:{}", "", p.file, p.line, p.col);
+                    }
+                    if ndx + 1 < stack.len() || i + 1 < pos.len() {
+                        print_indent();
+                    }
+                }
+            } else {
+                if let Some(ref inlined) = frame.inlined {
+                    for inline in inlined {
+                        println!(
+                            "0x{:08x} 0x{:08x} {}",
+                            frame.cfa, inline.addr, inline.name
+                        );
+                        print_indent();
+
+                        if self.line {
+                            if let Some(src) = hubris.lookup_src(inline.origin)
+                            {
+                                println!(
+                                    "{:11}@ {}:{}",
+                                    "",
+                                    src.fullpath(),
+                                    src.line
+                                );
+                                print_indent();
+                            }
                         }
                     }
                 }
-            }
 
-            if let Some(sym) = &frame.sym {
-                println!("0x{:08x} 0x{:08x} {}", frame.cfa, *pc, sym.name);
+                if let Some(sym) = &frame.sym {
+                    println!("0x{:08x} 0x{:08x} {}", frame.cfa, *pc, sym.name);
+                } else {
+                    println!("0x{:08x} 0x{:08x}", frame.cfa, *pc);
+                }
 
                 if self.line {
-                    if let Some(src) =
-                        sym.goff.and_then(|g| hubris.lookup_src(g))
+                    if let Some(src) = frame
+                        .sym
+                        .as_ref()
+                        .and_then(|s| s.goff)
+                        .and_then(|g| hubris.lookup_src(g))
                     {
                         print_indent();
                         println!("{:11}@ {}:{}", "", src.fullpath(), src.line);
                     }
                 }
-            } else {
-                println!("0x{:08x} 0x{:08x}", frame.cfa, *pc);
-            }
-
-            if ndx + 1 < stack.len() {
-                print_indent();
+                if ndx + 1 < stack.len() {
+                    print_indent();
+                }
             }
         }
 

--- a/humility-stack/src/lib.rs
+++ b/humility-stack/src/lib.rs
@@ -29,6 +29,12 @@ impl StackPrinter {
             print!("{:indent$}{}{:right$}", "", bar, "");
         };
 
+        // Generated code has long paths; we'll patch them up here
+        let pattern =
+            regex::Regex::new(r"/hubris/target/[a-zA-Z0-9\-]+/release/build/")
+                .unwrap();
+        let fixup_file = |input| pattern.replace_all(input, "/build/");
+
         for (ndx, frame) in stack.iter().enumerate() {
             let pc = frame.registers.get(&ARMRegister::PC).unwrap();
 
@@ -37,7 +43,13 @@ impl StackPrinter {
                     println!("0x{:08x} 0x{:08x} {}", frame.cfa, *pc, p.func);
                     if self.line {
                         print_indent();
-                        println!("{:11}@ {}:{}:{}", "", p.file, p.line, p.col);
+                        println!(
+                            "{:11}@ {}:{}:{}",
+                            "",
+                            fixup_file(&p.file),
+                            p.line,
+                            p.col
+                        );
                     }
                     if ndx + 1 < stack.len() || i + 1 < pos.len() {
                         print_indent();


### PR DESCRIPTION
(staged on top of #556)

This PR switches stack printing to use [`addr2line`](https://docs.rs/addr2line/latest/addr2line/).  Stack _unwinding_ remains the same, using our own code, but now we pass each PC in the stack to `addr2line` to get a more precise backtrace.

## Before
```
ID TASK                       GEN PRI STATE
24 hf                           0   5 wait: send to spartan7_loader/gen0
   |
   +--->  0x24056d28 0x0801ec7e userlib::sys_send_stub
                     @ /hubris/sys/userlib/src/lib.rs:157
          0x24056fa0 0x0801bc60 userlib::sys_send
                     @ /hubris/sys/userlib/src/lib.rs:121
          0x24056fa0 0x0801bc78 main
                     @ /hubris/drv/cosmo-hf/src/main.rs:47
```
## After
```
ID TASK                       GEN PRI STATE
24 hf                           0   5 wait: send to spartan7_loader/gen0
   |
   +--->  0x24056d28 0x0801ec7e userlib::sys_send_stub
                     @ /hubris/sys/userlib/src/lib.rs:197:13
          0x24056fa0 0x0801bc78 userlib::sys_send
                     @ /hubris/sys/userlib/src/lib.rs:138:14
          0x24056fa0 0x0801bc78 drv_spartan7_loader_api::Spartan7Loader::ping
                     @ /build/drv-spartan7-loader-api-81382492354c304f/out/client_stub.rs:50:29
          0x24056fa0 0x0801bc78 drv_spartan7_loader_api::Spartan7Loader::get_token
                     @ /hubris/drv/spartan7-loader-api/src/lib.rs:19:9
          0x24056fa0 0x0801bc78 main
                     @ /hubris/drv/cosmo-hf/src/main.rs:54:38
```

There are three noticeable improvements:

- We get both lines and columns
- The lines represent the actual call site, not the beginning of the function!
- We get a more accurate set of calls for inlined functions (note that `main`, `get_token`, `ping`, and `sys_send` are all at the same stack frame!)

--------------------------------------------------------------------------------

This changes a zillion files in the test suite, because we now use `addr2line` data instead of unwind frames when possible.

One noticeable change is that we now show the same PC address (starting with `0x080...` in the example above) for all frames in an inlined stack.  Previously, we used the `addr` of each symbol, which is a slightly different behavior; I think it represents the start of the inlined function.

I did a spot check, and the new results seem reasonable.

Here's an example diff:

```diff
    SP = 0x20002b70 <- i2c_driver: 0x20002800+0x370
         |
         +--->  0x20002b80 0x08015ac8 userlib::sys_irq_control_stub
-               0x20002c00 0x080148e2 drv_stm32h7_i2c::I2cController::write_read
-               0x20002c00 0x08014658 drv_stm32h7_i2c_server::main::{{closure}}
-               0x20002c00 0x08014658 userlib::hl::recv_without_notification::{{closure}}
-               0x20002c00 0x080142d4 userlib::hl::recv
-               0x20002c00 0x080142d4 userlib::hl::recv_without_notification
+               0x20002c00 0x08014920 drv_stm32h7_i2c::I2cController::write_read
+               0x20002c00 0x08014920 drv_stm32h7_i2c_server::main::{{closure}}
+               0x20002c00 0x08014920 userlib::hl::recv_without_notification::{{closure}}
+               0x20002c00 0x08014920 userlib::hl::recv
+               0x20002c00 0x08014920 userlib::hl::recv_without_notification
                0x20002c00 0x08014920 main
                0x20002c00 0x0801404e _start
```

I extracted the I2C driver code, then disassembled it to see what these actually addresses represent.

```
humility -d humility-bin/tests/cmd/cores/hubris.core.kiowa.4 extract elf/task/i2c_driver > i2c
arm-none-eabi-objdump -d i2c | bat -p -ls
```

The new dissassembly puts everything at 0x8014920, which is
```
 801491c:   f7ff fba8   bl  8014070 <_ZN4core3ops8function6FnOnce9call_once17hb574483a6f289883E>
 8014920:   9908        ldr r1, [sp, #32]
```
That certainly is a function call! (to be pedantic, it's the return address _after_ the function call)

The old trace includes the following addresses:
```
 80142cc:	f10d 0b58 	add.w	fp, sp, #88	; 0x58
 80142d0:	f64f 74ff 	movw	r4, #65535	; 0xffff
 80142d4:	4630      	mov	r0, r6 ; <-- here
 80142d6:	2104      	movs	r1, #4
```
```
 8014654:	2400      	movs	r4, #0
 8014656:	9805      	ldr	r0, [sp, #20]
 8014658:	6885      	ldr	r5, [r0, #8] <-- here
 801465a:	6841      	ldr	r1, [r0, #4]
```
```
 80148da:	f040 0001 	orr.w	r0, r0, #1
 80148de:	6020      	str	r0, [r4, #0]
 80148e0:	e51f      	b.n	8014322 <main+0x202>
 80148e2:	2010      	movs	r0, #16 <-- here
 80148e4:	2603      	movs	r6, #3
 80148e6:	e7df      	b.n	80148a8 <main+0x788>
 80148e8:	2010      	movs	r0, #16
```

None of these are function calls or values of the PC on the stack.  They may be the beginning of inlined functions, but it's awfully hard to tell what's going on, so I think it's fine to discard this information.
