### PR TITLE
openocd: strip leading '0x' from hex numbers returned by openocd

### DIFF
--- a/humility-probes-core/src/openocd.rs
+++ b/humility-probes-core/src/openocd.rs
@@ -74,7 +74,14 @@ impl Core for OpenOCDCore {
 
     fn read_word_32(&mut self, addr: u32) -> Result<u32> {
         let result = self.sendcmd(&format!("mrw 0x{:x}", addr))?;
-        Ok(result.parse::<u32>()?)
+        let rval = if let Some(hex_val) =
+            result.strip_prefix("0x").or(result.strip_prefix("0X"))
+        {
+            u32::from_str_radix(hex_val, 16)?
+        } else {
+            result.parse::<u32>()?
+        };
+        Ok(rval)
     }
 
     fn read_8(&mut self, addr: u32, data: &mut [u8]) -> Result<()> {
@@ -136,7 +143,14 @@ impl Core for OpenOCDCore {
                 }
 
                 Some(idx) => {
-                    data[idx] = val.parse::<u8>()?;
+                    let dval = if let Some(hex_val) =
+                        val.strip_prefix("0x").or(val.strip_prefix("0X"))
+                    {
+                        u8::from_str_radix(hex_val, 16)?
+                    } else {
+                        val.parse::<u8>()?
+                    };
+                    data[idx] = dval;
                     index = None;
                 }
             }


### PR DESCRIPTION
This patch strips leading '0x' from hex numbers (if present) returned by openocd for commands like `mem2array` and `mrw`.

Fixes: #560

With this patch, the issue described by #560 does not happen:
```
$ cargo xtask humility app/demo-stm32h7-nucleo/app-h753.toml -- tasks
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.18s
     Running `target/debug/xtask humility app/demo-stm32h7-nucleo/app-h753.toml -- tasks`
humility: attached via OpenOCD
system time = 6695667
ID TASK                       GEN PRI STATE    
 0 jefe                         0   0 recv, notif: fault timer(T+33)
 1 sys                          0   1 recv, notif: exti-wildcard-irq(irq6/irq7/irq8/irq9/irq10/irq23/irq40)
 2 i2c_driver                   0   2 recv
 3 packrat                      0   2 recv
 4 spi_driver                   0   2 recv
 5 net                          0   2 recv, notif: eth-irq(irq61) wake-timer
 6 user_leds                    0   2 recv, notif: timer(T+334)
 7 user_button                  0   3 notif: button
 8 udpecho                      0   3 notif: socket
 9 udpbroadcast                 0   3 notif: bit31(T+1026)
10 udprpc                       0   3 notif: socket
11 hiffy                        0   5 notif: bit31(T+512)
12 hf                           0   4 notif: bit31(T+1037)
13 hash_driver                  0   3 recv
14 idle                         0   7 RUNNING
15 rng_driver                   0   3 recv
16 dump_agent                   0   4 recv
```