### PR TITLE
Update test data to account for change task `name` member

### DIFF
--- a/humility-bin/tests/cmd/extract/extract.chilly.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.chilly.0.stdout
@@ -49,7 +49,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -58,7 +58,7 @@ stacksize = 1536
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 3800
 priority = 2
 features = ["mgmt", "h753", "gimlet"]
@@ -73,7 +73,7 @@ task-slots = ["sys", "rcc_driver",
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -82,7 +82,7 @@ start = true
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -97,7 +97,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -112,7 +112,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -130,7 +130,7 @@ task-slots = ["sys"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -144,7 +144,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753", "gimlet"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -154,7 +154,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -164,7 +164,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -174,7 +174,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -188,7 +188,7 @@ register_defs = "gimlet_regs.json"
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -200,7 +200,7 @@ task-slots = ["sys"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -209,7 +209,7 @@ start = true
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -218,7 +218,7 @@ task-slots = ["net"]
 
 [tasks.validate]
 path = "../../task/validate"
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 requires = {flash = 8192, ram = 4096 }
 stacksize = 1000 
@@ -227,7 +227,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.control_plane_agent.overflow.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.control_plane_agent.overflow.0.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -80,7 +80,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -92,7 +92,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -110,7 +110,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -124,7 +124,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -132,7 +132,7 @@ task-slots = []
 features = ["gimlet"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -142,7 +142,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -152,7 +152,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer", "external_badness"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -161,7 +161,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -176,7 +176,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -186,7 +186,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -198,7 +198,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -210,7 +210,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -221,14 +221,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -240,7 +240,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -250,7 +250,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -260,7 +260,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -292,7 +292,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -304,7 +304,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -312,7 +312,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -320,7 +320,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -329,7 +329,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -340,7 +340,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -348,7 +348,7 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.counters.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.counters.0.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 2048 }
@@ -167,7 +167,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -191,7 +191,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -202,7 +202,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -211,7 +211,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -223,7 +223,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -243,7 +243,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -273,7 +273,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -285,7 +285,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -293,7 +293,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -301,7 +301,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -310,7 +310,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
 start = true
@@ -321,7 +321,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -329,14 +329,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.duplicate_HostFlash_hash_REPLY.stdout
+++ b/humility-bin/tests/cmd/extract/extract.duplicate_HostFlash_hash_REPLY.stdout
@@ -21,7 +21,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -37,7 +37,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "mgmt_gateway"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
@@ -49,7 +49,7 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -86,7 +86,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -103,7 +103,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -116,7 +116,7 @@ task-slots = ["sys", "i2c_driver"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096 }
@@ -134,7 +134,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -143,7 +143,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -156,7 +156,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -167,7 +167,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -178,7 +178,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -187,7 +187,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
@@ -195,7 +195,7 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -204,7 +204,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -213,7 +213,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -222,7 +222,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.mgmt_gateway]
-name = "task-mgmt-gateway"
+bin-crate = "task-mgmt-gateway"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
 stacksize = 2048
@@ -236,7 +236,7 @@ features = ["gimlet", "usart1", "vlan"]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -244,7 +244,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -252,7 +252,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.extern-regions.stdout
+++ b/humility-bin/tests/cmd/extract/extract.extern-regions.stdout
@@ -17,7 +17,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -37,7 +37,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -50,7 +50,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -59,7 +59,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -71,7 +71,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -89,7 +89,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -103,7 +103,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -112,7 +112,7 @@ task-slots = []
 features = ["gimlet"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -122,7 +122,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -132,7 +132,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -141,7 +141,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -156,7 +156,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -168,7 +168,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -180,7 +180,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -191,7 +191,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -200,7 +200,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -212,7 +212,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -222,7 +222,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -232,7 +232,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -242,7 +242,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -272,7 +272,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -284,7 +284,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -292,7 +292,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 5 
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -300,7 +300,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -308,7 +308,7 @@ start = true
 task-slots = ["sys"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192 }
 start = true
@@ -319,7 +319,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -327,7 +327,7 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.flash-ram-mismatch.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.flash-ram-mismatch.0.stdout
@@ -20,7 +20,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -33,7 +33,7 @@ on-state-change = {net = {bit-number = 3}}
 reset-reason-owner = "sys"
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
@@ -45,7 +45,7 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -54,7 +54,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -68,7 +68,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -82,7 +82,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -112,7 +112,7 @@ task-slots = ["sys", "i2c_driver"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -121,7 +121,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096 }
@@ -130,7 +130,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -139,7 +139,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -152,7 +152,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -163,7 +163,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -174,7 +174,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
@@ -182,7 +182,7 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -191,7 +191,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -200,7 +200,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -208,7 +208,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.gimlet-c-dev-image-default-v1.0.2.zip.stdout
+++ b/humility-bin/tests/cmd/extract/extract.gimlet-c-dev-image-default-v1.0.2.zip.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -169,7 +169,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -181,7 +181,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -192,7 +192,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -201,7 +201,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -213,7 +213,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -223,7 +223,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -263,7 +263,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -275,7 +275,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -283,7 +283,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -291,7 +291,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -300,7 +300,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
 start = true
@@ -311,7 +311,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -319,14 +319,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.gimlet-rot-c-image-b.zip.stdout
+++ b/humility-bin/tests/cmd/extract/extract.gimlet-rot-c-image-b.zip.stdout
@@ -13,7 +13,7 @@ requires = {flash = 51712, ram = 4096}
 features = ["dice-self"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -25,7 +25,7 @@ notifications = ["fault", "timer"]
 request_reset = ["update_server"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 6
 features = ["lpc55", "gpio", "spctrl", "update"]
 max-sizes = {flash = 32768, ram = 16384 }
@@ -34,14 +34,14 @@ start = true
 task-slots = ["gpio_driver", "swd", "update_server"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.update_server]
-name = "lpc55-update-server"
+bin-crate = "lpc55-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096, usbsram = 4096}
 stacksize = 2048
@@ -53,7 +53,7 @@ interrupts = {"flash_controller.irq" = "flash-irq", "hash_crypt.irq" = "hashcryp
 task-slots = [{"syscon" = "syscon_driver"}, "jefe"]
 
 [tasks.syscon_driver]
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -61,7 +61,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.gpio_driver]
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
@@ -69,7 +69,7 @@ start = true
 task-slots = ["syscon_driver"]
 
 [tasks.sprot]
-name = "drv-lpc55-sprot-server"
+bin-crate = "drv-lpc55-sprot-server"
 priority = 6
 max-sizes = {flash = 32768, ram = 32768}
 uses = ["flexcomm8", "bootrom"]
@@ -97,7 +97,7 @@ pins = [
 ]
 
 [tasks.swd]
-name = "drv-lpc55-swd"
+bin-crate = "drv-lpc55-swd"
 priority = 4
 max-sizes = {flash = 16384, ram = 4096}
 uses = ["flexcomm5", "iocon"]
@@ -130,7 +130,7 @@ pins = [
 spi_num = 5
 
 [tasks.dumper]
-name = "task-dumper"
+bin-crate = "task-dumper"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
 start = true
@@ -140,7 +140,7 @@ task-slots = ["swd"]
 # We intentionally do not start this task to avoid conflicts with the SP
 # debug connection.
 [tasks.sp_measure]
-name = "task-sp-measure"
+bin-crate = "task-sp-measure"
 priority = 6
 max-sizes = {flash = 131072, ram = 8192}
 task-slots = ["swd"]

--- a/humility-bin/tests/cmd/extract/extract.host-panic.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.host-panic.0.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 2048 }
@@ -167,7 +167,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -191,7 +191,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -202,7 +202,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -211,7 +211,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -223,7 +223,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -243,7 +243,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -275,7 +275,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -287,7 +287,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -295,7 +295,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -303,7 +303,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -312,7 +312,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
 start = true
@@ -323,7 +323,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -331,14 +331,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.host-panic.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.host-panic.1.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 2048 }
@@ -167,7 +167,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -191,7 +191,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -202,7 +202,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -211,7 +211,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -223,7 +223,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -243,7 +243,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -275,7 +275,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -287,7 +287,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -295,7 +295,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -303,7 +303,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -312,7 +312,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
 start = true
@@ -323,7 +323,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -331,14 +331,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.host-panic.2.stdout
+++ b/humility-bin/tests/cmd/extract/extract.host-panic.2.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 2048 }
@@ -167,7 +167,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -191,7 +191,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -202,7 +202,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = []
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -211,7 +211,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -223,7 +223,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -243,7 +243,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -275,7 +275,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -287,7 +287,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -295,7 +295,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -303,7 +303,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -312,7 +312,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
 start = true
@@ -323,7 +323,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -331,14 +331,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.host-panic.3.stdout
+++ b/humility-bin/tests/cmd/extract/extract.host-panic.3.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -80,7 +80,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -92,7 +92,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -110,7 +110,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -124,7 +124,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -132,7 +132,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -142,7 +142,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -152,7 +152,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer", "external_badness"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -161,7 +161,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -176,7 +176,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -186,7 +186,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -198,7 +198,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -210,7 +210,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -221,14 +221,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -240,7 +240,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -250,7 +250,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -260,7 +260,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -292,7 +292,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -304,7 +304,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -312,7 +312,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -320,7 +320,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -329,7 +329,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -340,7 +340,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -348,14 +348,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.host-panic.4.stdout
+++ b/humility-bin/tests/cmd/extract/extract.host-panic.4.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -80,7 +80,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -92,7 +92,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -110,7 +110,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -124,7 +124,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -132,7 +132,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -142,7 +142,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -152,7 +152,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer", "external_badness"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -161,7 +161,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -176,7 +176,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -186,7 +186,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -198,7 +198,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -210,7 +210,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -221,14 +221,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -240,7 +240,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -250,7 +250,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -260,7 +260,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -292,7 +292,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -304,7 +304,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -312,7 +312,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -320,7 +320,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -329,7 +329,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -340,7 +340,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -348,14 +348,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.idol-returns-an-enum.stdout
+++ b/humility-bin/tests/cmd/extract/extract.idol-returns-an-enum.stdout
@@ -17,7 +17,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -37,7 +37,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -50,7 +50,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -59,7 +59,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -71,7 +71,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -89,7 +89,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -103,7 +103,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -112,7 +112,7 @@ task-slots = []
 features = ["gimlet"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -122,7 +122,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -132,7 +132,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -141,7 +141,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -156,7 +156,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -168,7 +168,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -180,7 +180,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -191,7 +191,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -200,7 +200,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -212,7 +212,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -222,7 +222,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -232,7 +232,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -242,7 +242,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -272,7 +272,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -284,7 +284,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -292,7 +292,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 5 
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -300,7 +300,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -308,7 +308,7 @@ start = true
 task-slots = ["sys"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192 }
 start = true
@@ -319,7 +319,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -327,7 +327,7 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.igor.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.igor.0.stdout
@@ -21,7 +21,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -39,7 +39,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
@@ -51,7 +51,7 @@ interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -74,7 +74,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -105,7 +105,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -118,7 +118,7 @@ task-slots = ["sys", "i2c_driver", "jefe"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -127,7 +127,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -136,7 +136,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -145,7 +145,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -158,7 +158,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -169,7 +169,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -180,7 +180,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -189,7 +189,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
@@ -197,7 +197,7 @@ stacksize = 3800        # Sensor data is stored on the stack
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
@@ -208,7 +208,7 @@ start = true
 task-slots = ["sys", "gimlet_seq", "hf"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -217,7 +217,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -226,7 +226,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -235,7 +235,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
 stacksize = 2048
@@ -257,7 +257,7 @@ features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -265,7 +265,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -273,7 +273,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.in_bootloader.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.in_bootloader.0.stdout
@@ -20,7 +20,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -33,7 +33,7 @@ on-state-change = {net = {bit-number = 3}}
 reset-reason-owner = "sys"
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4640
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan"]
@@ -45,7 +45,7 @@ interrupts = {"eth.irq" = 0b1}
 task-slots = ["sys", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -54,7 +54,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -68,7 +68,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -82,7 +82,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -112,7 +112,7 @@ task-slots = ["sys", "i2c_driver"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -121,7 +121,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096 }
@@ -130,7 +130,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -139,7 +139,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -152,7 +152,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -163,7 +163,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -174,7 +174,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
@@ -182,7 +182,7 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -191,7 +191,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -200,7 +200,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -208,7 +208,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 7
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.inheritance.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.inheritance.0.stdout
@@ -12,7 +12,7 @@ features = ["g070", "panic-halt"]
 stacksize = 640
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -20,7 +20,7 @@ features = ["log-null"]
 stacksize = 352
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64

--- a/humility-bin/tests/cmd/extract/extract.ipc-counts.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ipc-counts.0.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac", "client-counters"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "client-counters"]
 priority = 1
 max-sizes = {flash = 2048, ram = 2048}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753", "client-counters"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "client-counters"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -90,7 +90,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "client-counters"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -104,7 +104,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -113,7 +113,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet", "client-counters"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -123,7 +123,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet", "client-counters"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot", "client-counters"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753", "client-counters","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -157,7 +157,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan", "client-counters"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -167,7 +167,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753", "client-counters"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash", "client-counters"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -191,7 +191,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 features = ["client-counters"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
@@ -203,7 +203,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["client-counters"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -212,7 +212,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet", "client-counters"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -224,7 +224,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -234,7 +234,7 @@ features = ["vlan", "client-counters"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -244,7 +244,7 @@ features = ["vlan", "client-counters"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -277,7 +277,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -289,7 +289,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 features = ["client-counters"]
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
@@ -298,7 +298,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 features = ["client-counters"]
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
@@ -307,7 +307,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7", "client-counters"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -316,7 +316,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -327,7 +327,7 @@ notifications = ["socket"]
 features = ["net", "vlan", "client-counters"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 features = ["client-counters"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
@@ -336,14 +336,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.kernel-panic.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kernel-panic.0.stdout
@@ -49,7 +49,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -58,7 +58,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -67,7 +67,7 @@ start = true
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -81,7 +81,7 @@ task-slots = ["sys"]
 
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi1", "h753"]
@@ -96,7 +96,7 @@ global_config = "spi1"
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 3800
 priority = 2
 requires = {flash = 131072, ram = 8192, sram1 = 32768}
@@ -109,7 +109,7 @@ task-slots = ["sys"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -118,7 +118,7 @@ task-slots = ["sys"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = []
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -127,7 +127,7 @@ task-slots = [{peer = "pong"}]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -135,7 +135,7 @@ task-slots = ["user_leds"]
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 requires = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -144,7 +144,7 @@ task-slots = ["net"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash"]
 priority = 5
 requires = {flash = 32768, ram = 32768 }
@@ -154,7 +154,7 @@ task-slots = ["sys", "i2c_driver", "hf", "hash_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 4
 requires = {flash = 16384, ram = 4096 }
@@ -166,7 +166,7 @@ task-slots = ["sys", "hash_driver"]
 
 [tasks.hash_driver]
 path = "../../drv/stm32h7-hash-server"
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 8192, ram=4096 }
@@ -178,7 +178,7 @@ task-slots = ["sys"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 6
 requires = {flash = 128, ram = 256}
 stacksize = 256
@@ -188,7 +188,7 @@ start = true
 features = ["h753"]
 path = "../../drv/stm32h7-rng"
 priority = 3
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 requires = {flash = 8192, ram = 512}
 stacksize = 256
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kernel-panic.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kernel-panic.1.stdout
@@ -10,7 +10,7 @@ name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -31,7 +31,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -43,7 +43,7 @@ interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -52,7 +52,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -66,7 +66,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -80,7 +80,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -97,7 +97,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -110,7 +110,7 @@ task-slots = ["sys", "i2c_driver", "jefe"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -119,7 +119,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -137,7 +137,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -150,7 +150,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -161,7 +161,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -172,7 +172,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -181,7 +181,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -189,7 +189,7 @@ stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
@@ -200,7 +200,7 @@ start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -209,7 +209,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -218,7 +218,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -227,7 +227,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 16384}
 stacksize = 4096
@@ -258,7 +258,7 @@ features = [
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -267,7 +267,7 @@ task-slots = ["sys", {spi_driver = "spi4_driver"}]
 features = ["sink_test"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -275,7 +275,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -283,7 +283,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.0.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
 path = "../test-runner"
-name = "test-runner"
+bin-crate = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
 start = true
@@ -46,14 +46,14 @@ features = ["itm"]
 
 [tasks.suite]
 path = "../test-suite"
-name = "test-suite"
+bin-crate = "test-suite"
 priority = 2
 requires = {flash = 32768, ram = 4096}
 start = true
 
 [tasks.assist]
 path = "../test-assist"
-name = "test-assist"
+bin-crate = "test-assist"
 priority = 1
 requires = {flash = 8192, ram = 4096}
 start = true
@@ -61,7 +61,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kiowa.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.1.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c"
-name = "drv-stm32h7-i2c"
+bin-crate = "drv-stm32h7-i2c"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -81,7 +81,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -89,14 +89,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 8192, ram = 32768 }
@@ -112,7 +112,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kiowa.10.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.10.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -164,7 +164,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.11.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.11.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -68,7 +68,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 #
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3", "h743"]
@@ -114,7 +114,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -131,7 +131,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -141,7 +141,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -151,7 +151,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h743"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -163,7 +163,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.12.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.12.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -164,7 +164,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.13.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.13.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -164,7 +164,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.14.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.14.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -143,7 +143,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -174,7 +174,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -183,7 +183,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.15.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.15.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -143,7 +143,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -174,7 +174,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -183,7 +183,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.16.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.16.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -143,7 +143,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -174,7 +174,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -183,7 +183,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.17.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.17.stdout
@@ -27,7 +27,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -36,7 +36,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -45,7 +45,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -55,7 +55,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1", "semihosting"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -66,7 +66,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -75,7 +75,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -83,7 +83,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -93,14 +93,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.18.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.18.stdout
@@ -27,7 +27,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -36,7 +36,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -45,7 +45,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -55,7 +55,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1", "semihosting"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -66,7 +66,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -75,7 +75,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -83,7 +83,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -93,14 +93,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.19.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.19.stdout
@@ -27,7 +27,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -36,7 +36,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -45,7 +45,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -55,7 +55,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1", "semihosting"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -66,7 +66,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -75,7 +75,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -83,7 +83,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -93,14 +93,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.2.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.2.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c"
-name = "drv-stm32h7-i2c"
+bin-crate = "drv-stm32h7-i2c"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -81,7 +81,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -89,14 +89,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -104,7 +104,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kiowa.20.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.20.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -82,7 +82,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -98,7 +98,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -116,7 +116,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -130,7 +130,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -150,7 +150,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -159,7 +159,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -169,7 +169,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -181,7 +181,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -190,7 +190,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.21.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.21.stdout
@@ -27,7 +27,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -36,7 +36,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -45,7 +45,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -55,7 +55,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1", "semihosting"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -66,7 +66,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -75,7 +75,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -83,7 +83,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -93,14 +93,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 32768, ram = 16384 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.22.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.22.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -68,7 +68,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 #
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3", "h743"]
@@ -114,7 +114,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -133,7 +133,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -141,7 +141,7 @@ task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -151,7 +151,7 @@ task-slots = ["gpio_driver", "i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.23.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.23.stdout
@@ -28,7 +28,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 512}
 start = true
@@ -37,7 +37,7 @@ stacksize = 352
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 1024, ram = 1024}
@@ -46,7 +46,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 4096, ram = 1024}
@@ -56,7 +56,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -76,7 +76,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -84,7 +84,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -94,14 +94,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 16384, ram = 8192 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 128}
 stacksize = 128

--- a/humility-bin/tests/cmd/extract/extract.kiowa.24.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.24.stdout
@@ -28,7 +28,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 512}
 start = true
@@ -37,7 +37,7 @@ stacksize = 352
 
 [tasks.rcc_driver]
 path = "../../drv/stm32g0-rcc"
-name = "drv-stm32g0-rcc"
+bin-crate = "drv-stm32g0-rcc"
 features = ["g0b1"]
 priority = 1
 requires = {flash = 1024, ram = 1024}
@@ -46,7 +46,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32g0-gpio"
-name = "drv-stm32g0-gpio"
+bin-crate = "drv-stm32g0-gpio"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 4096, ram = 1024}
@@ -56,7 +56,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32g0-usart"
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g0b1"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -76,7 +76,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -84,7 +84,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -94,14 +94,14 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 16384, ram = 8192 }
 start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 128}
 stacksize = 128

--- a/humility-bin/tests/cmd/extract/extract.kiowa.25.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.25.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -82,7 +82,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -98,7 +98,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -116,7 +116,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -130,7 +130,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -150,7 +150,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -159,7 +159,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -169,7 +169,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -181,7 +181,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -190,7 +190,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.26.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.26.stdout
@@ -51,7 +51,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -60,7 +60,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h743"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -69,7 +69,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -80,7 +80,7 @@ task-slots = ["sys"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -94,7 +94,7 @@ task-slots = ["sys"]
 
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi1", "h743"]
@@ -109,7 +109,7 @@ global_config = "spi1"
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 3800
 priority = 2
 requires = {flash = 65536, ram = 8192, sram1 = 32768}
@@ -121,7 +121,7 @@ task-slots = ["sys"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -130,7 +130,7 @@ task-slots = ["sys"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -139,7 +139,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -147,7 +147,7 @@ task-slots = ["user_leds"]
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -156,7 +156,7 @@ task-slots = ["net"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -166,7 +166,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.27.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.27.stdout
@@ -64,7 +64,7 @@ imagea-ram-size = 0x18000
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -73,7 +73,7 @@ stacksize = 1536
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 features = ["lpc55", "gpio"]
 requires = {flash = 16384, ram = 16384 }
@@ -83,7 +83,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -91,7 +91,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 4096, ram = 2048}
 uses = ["syscon", "anactrl", "pmc"]
@@ -100,7 +100,7 @@ stacksize = 1000
 
 [tasks.gpio_driver]
 path = "../../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 8192, ram = 2048}
 uses = ["gpio", "iocon"]
@@ -110,7 +110,7 @@ task-slots = ["syscon_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 8192, ram = 2048}
@@ -120,7 +120,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 8192, ram = 2048}
 uses = ["flexcomm0"]
@@ -131,7 +131,7 @@ task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 8192, ram = 2048}
 uses = ["flexcomm4"]
@@ -141,7 +141,7 @@ task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.rng_driver]
 path = "../../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 8192, ram = 2048}
 uses = ["rng", "pmc"]
@@ -151,7 +151,7 @@ task-slots = ["syscon_driver"]
 
 [tasks.spi0_driver]
 path = "../../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi0"]
@@ -163,7 +163,7 @@ task-slots = ["gpio_driver", "syscon_driver"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -173,7 +173,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 2048}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kiowa.28.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.28.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -73,7 +73,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -106,7 +106,7 @@ task-slots = ["sys"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -120,7 +120,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -130,7 +130,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -150,7 +150,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -160,7 +160,7 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -172,7 +172,7 @@ task-slots = ["sys"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -181,7 +181,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.29.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.29.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -73,7 +73,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -106,7 +106,7 @@ task-slots = ["sys"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -120,7 +120,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -130,7 +130,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -150,7 +150,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -160,7 +160,7 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -172,7 +172,7 @@ task-slots = ["sys"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -181,7 +181,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.30.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.30.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -73,7 +73,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -106,7 +106,7 @@ task-slots = ["sys"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -120,7 +120,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -130,7 +130,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -140,7 +140,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -150,7 +150,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -160,7 +160,7 @@ task-slots = ["sys", "i2c_driver", {spi_driver = "spi2_driver"}, "hf"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -172,7 +172,7 @@ task-slots = ["sys"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -181,7 +181,7 @@ start = true
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.31.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.31.stdout
@@ -28,7 +28,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 4096, ram = 512}
 start = true
@@ -37,7 +37,7 @@ stacksize = 368
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 priority = 1
 requires = {flash = 2048, ram = 256}
 uses = ["rcc", "gpio"]
@@ -47,7 +47,7 @@ stacksize = 256
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 4
 requires = {flash = 1024, ram = 256}
 start = true
@@ -56,7 +56,7 @@ stacksize = 256
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32g0"]
 priority = 3
 requires = {flash = 2048, ram = 256}
@@ -66,7 +66,7 @@ stacksize = 256
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 4
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -76,7 +76,7 @@ features = ["stm32g0", "gpio", "micro"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 64}
 stacksize = 64

--- a/humility-bin/tests/cmd/extract/extract.kiowa.4.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.4.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {37 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -87,7 +87,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -95,14 +95,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -111,7 +111,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -120,7 +120,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.49.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.49.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.5.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.5.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 8192, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.kiowa.50.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.50.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.51.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.51.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.52.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.52.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.53.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.53.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.6.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.6.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {37 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -87,7 +87,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -95,14 +95,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -111,7 +111,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -120,7 +120,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.7.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.7.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {37 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -87,7 +87,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -95,14 +95,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -111,7 +111,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -120,7 +120,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.8.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.8.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {37 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h7b3"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -87,7 +87,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -95,14 +95,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -111,7 +111,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -120,7 +120,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.9.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.9.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -142,7 +142,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "i2c_driver", {spi_driver = "spi2_driver"}]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -164,7 +164,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.idol.qpsi.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.idol.qpsi.1.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -91,7 +91,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -109,7 +109,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver", "i2c_driver", "rcc_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -133,7 +133,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -143,7 +143,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 32768, ram = 1024 }
@@ -153,7 +153,7 @@ task-slots = ["gpio_driver", {spi_driver = "spi2_driver"}]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -165,7 +165,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.rick.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.rick.0.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -118,7 +118,7 @@ i2c_driver = "i2c_driver"
 #
 [tasks.spi2_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2"]
@@ -129,7 +129,7 @@ stacksize = 1000
 
 [tasks.spi4_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4"]
@@ -140,7 +140,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -148,14 +148,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -164,7 +164,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -173,7 +173,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -182,7 +182,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.kiowa.stm32h743-nucleo.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.kiowa.stm32h743-nucleo.0.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -78,7 +78,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -101,7 +101,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 #
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3", "h743"]
@@ -113,7 +113,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -122,7 +122,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -130,7 +130,7 @@ task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -140,7 +140,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h743"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -152,7 +152,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.new-ringbuf.stdout
+++ b/humility-bin/tests/cmd/extract/extract.new-ringbuf.stdout
@@ -21,7 +21,7 @@ requires = {flash = 22776, ram = 6256}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -33,7 +33,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -42,7 +42,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi1_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi1"]
@@ -56,7 +56,7 @@ task-slots = ["sys"]
 global_config = "spi1"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi2"]
@@ -70,7 +70,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.spi3_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 4096}
 features = ["h753", "spi3"]
@@ -84,7 +84,7 @@ task-slots = ["sys"]
 global_config = "spi3"
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -98,7 +98,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi5_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
 features = ["h753", "spi5"]
@@ -112,7 +112,7 @@ task-slots = ["sys"]
 global_config = "spi5"
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -121,7 +121,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -132,7 +132,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac"]
@@ -146,7 +146,7 @@ task-slots = ["sys", "i2c_driver",
               { seq = "sequencer" }]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 65536, ram = 8192}
 stacksize = 2560
@@ -168,7 +168,7 @@ task-slots = [
 features = ["sidecar", "vlan", "auxflash"]
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -177,7 +177,7 @@ task-slots = ["sys", {spi_driver = "spi4_driver"}]
 features = ["sink_test"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -186,7 +186,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -195,7 +195,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -204,7 +204,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.monorail]
-name = "task-monorail-server"
+bin-crate = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 8192}
 features = ["mgmt", "sidecar", "vlan"]
@@ -215,7 +215,7 @@ task-slots = ["sys", "net", "ecp5_front_io",
               { seq = "sequencer" }]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
@@ -234,7 +234,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "spi", "stm32h7", "itm", "i2c", "gpio"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -243,7 +243,7 @@ start = true
 task-slots = ["sys", "i2c_driver"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
@@ -251,7 +251,7 @@ stacksize = 1920        # Sensor data is stored on the stack
 start = true
 
 [tasks.ecp5_mainboard]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["mainboard"]
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
@@ -260,7 +260,7 @@ start = true
 task-slots = ["sys", {spi_driver = "spi5_driver"}]
 
 [tasks.ecp5_front_io]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["front_io"]
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
@@ -269,7 +269,7 @@ start = true
 task-slots = ["sys", "i2c_driver", {spi_driver = "spi1_driver"}]
 
 [tasks.transceivers]
-name = "drv-transceivers-server"
+bin-crate = "drv-transceivers-server"
 features = ["vlan"]
 priority = 6
 max-sizes = {flash = 65536, ram = 8192}
@@ -283,7 +283,7 @@ task-slots = [
     {seq = "sequencer"}]
 
 [tasks.sequencer]
-name = "drv-sidecar-seq-server"
+bin-crate = "drv-sidecar-seq-server"
 features = []
 priority = 4
 stacksize = 4096
@@ -296,7 +296,7 @@ task-slots = [
     {front_io = "ecp5_front_io"}]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "sidecar"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -305,7 +305,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "sidecar"]
 priority = 6
 max-sizes = {flash = 16384, ram = 4096 }
@@ -314,7 +314,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "sequencer"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -322,7 +322,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.ignition]
-name = "drv-ignition-server"
+bin-crate = "drv-ignition-server"
 features = ["sequencer"]
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
@@ -331,7 +331,7 @@ start = true
 task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.new-sensors.stdout
+++ b/humility-bin/tests/cmd/extract/extract.new-sensors.stdout
@@ -23,7 +23,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -31,14 +31,14 @@ features = ["itm"]
 stacksize = 1536
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 9
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [[config.sensor.devices]]
-name = "xcvr30"
+bin-crate = "xcvr30"
 device = "qsfp"
 description = "QSFP transceiver 30"
 sensors.temperature = 3

--- a/humility-bin/tests/cmd/extract/extract.nightly-2022-11-01.stdout
+++ b/humility-bin/tests/cmd/extract/extract.nightly-2022-11-01.stdout
@@ -21,7 +21,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -39,7 +39,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -74,7 +74,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -105,7 +105,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -118,7 +118,7 @@ task-slots = ["sys", "i2c_driver", "jefe"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -127,7 +127,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -136,7 +136,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -145,7 +145,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -158,7 +158,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -169,7 +169,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -180,7 +180,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -189,7 +189,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
@@ -197,7 +197,7 @@ stacksize = 3800        # Sensor data is stored on the stack
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
@@ -208,7 +208,7 @@ start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -217,7 +217,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -226,7 +226,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -235,7 +235,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
 stacksize = 2560
@@ -257,7 +257,7 @@ features = ["gimlet", "usart1", "vlan", "baud_rate_3M", "hardware_flow_control"]
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -266,7 +266,7 @@ task-slots = ["sys", {spi_driver = "spi4_driver"}]
 features = ["sink_test"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -274,7 +274,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -282,7 +282,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.0.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -85,7 +85,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -93,14 +93,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -108,7 +108,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -116,7 +116,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.1.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 8192, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.10.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.10.stdout
@@ -37,7 +37,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 1024}
 start = true
@@ -45,7 +45,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32f4-rcc"
-name = "drv-stm32f4-rcc"
+bin-crate = "drv-stm32f4-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -53,7 +53,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32f4-usart"
-name = "drv-stm32f4-usart"
+bin-crate = "drv-stm32f4-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
@@ -62,7 +62,7 @@ interrupts = {38 = 1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -71,7 +71,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -80,14 +80,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.11.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.11.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -47,7 +47,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -55,7 +55,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -63,7 +63,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -73,7 +73,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -90,7 +90,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -103,7 +103,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -111,14 +111,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -126,7 +126,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 16384, ram = 32768 }
@@ -134,7 +134,7 @@ start = true
 
 [tasks.max31790]
 path = "../task-max31790"
-name = "task-max31790"
+bin-crate = "task-max31790"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -142,7 +142,7 @@ start = true
 
 [tasks.ds2482]
 path = "../task-ds2482"
-name = "task-ds2482"
+bin-crate = "task-ds2482"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -150,7 +150,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.12.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.12.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -47,7 +47,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -55,7 +55,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -63,7 +63,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -73,7 +73,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -90,7 +90,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -103,7 +103,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -111,14 +111,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -126,7 +126,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -135,7 +135,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.13.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.13.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ requires = {flash = 8192, ram = 2048}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.14.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.14.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ requires = {flash = 8192, ram = 2048}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.15.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.15.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.16.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.16.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.17.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.17.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.18.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.18.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.19.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.19.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.2.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.2.stdout
@@ -36,7 +36,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 1024}
 start = true
@@ -44,7 +44,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32f4-rcc"
-name = "drv-stm32f4-rcc"
+bin-crate = "drv-stm32f4-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -52,7 +52,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32f4-usart"
-name = "drv-stm32f4-usart"
+bin-crate = "drv-stm32f4-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
@@ -61,7 +61,7 @@ interrupts = {38 = 1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -70,7 +70,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart", "defmt-trace"]
 priority = 4
 requires = {flash = 8192, ram = 4096}
@@ -78,14 +78,14 @@ start = true
 
 [tasks.log]
 path = "../task-log"
-name = "task-log"
+bin-crate = "task-log"
 priority = 3
 requires = {flash = 32768, ram = 4096}
 start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 features = ["defmt-trace"]
 priority = 3
 requires = {flash = 8192, ram = 4096}
@@ -93,7 +93,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.20.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.20.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm", "external-max7358"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.21.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.21.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.22.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.22.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.23.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.23.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.24.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.24.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.25.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.25.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.26.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.26.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.27.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.27.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.29.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.29.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.3.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.3.stdout
@@ -36,7 +36,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 1024}
 start = true
@@ -44,7 +44,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32f4-rcc"
-name = "drv-stm32f4-rcc"
+bin-crate = "drv-stm32f4-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -52,7 +52,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32f4-usart"
-name = "drv-stm32f4-usart"
+bin-crate = "drv-stm32f4-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
@@ -61,7 +61,7 @@ interrupts = {38 = 1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -70,7 +70,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -78,14 +78,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.30.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.30.stdout
@@ -47,7 +47,7 @@ dma = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -56,7 +56,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -72,7 +72,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -82,7 +82,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -99,7 +99,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -112,7 +112,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -122,7 +122,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -130,7 +130,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -138,14 +138,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -162,7 +162,7 @@ start = true
 
 [tasks.net]
 path = "../task-net"
-name = "task-net"
+bin-crate = "task-net"
 priority = 2
 requires = {flash = 16384, ram = 2048, sram1 = 32768}
 sections = {eth_bulk = "sram1"}
@@ -172,7 +172,7 @@ interrupts = {61 = 0b1}
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.33.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.33.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.35.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.35.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.36.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.36.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.37.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.37.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.38.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.38.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.39.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.39.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.4.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.4.stdout
@@ -36,7 +36,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 1024}
 start = true
@@ -44,7 +44,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32f4-rcc"
-name = "drv-stm32f4-rcc"
+bin-crate = "drv-stm32f4-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -52,7 +52,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32f4-usart"
-name = "drv-stm32f4-usart"
+bin-crate = "drv-stm32f4-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["usart2", "gpioa"]
@@ -61,7 +61,7 @@ interrupts = {38 = 1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -70,7 +70,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -78,14 +78,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.40.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.40.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.41.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.41.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.42.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.42.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.43.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.43.stdout
@@ -32,7 +32,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -40,7 +40,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -48,7 +48,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -73,7 +73,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm0"]
@@ -82,7 +82,7 @@ interrupts = {14 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm4"]
@@ -90,7 +90,7 @@ start = true
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -98,7 +98,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["iocon", "flexcomm8"]
@@ -107,7 +107,7 @@ interrupts = {59 = 1}
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -115,7 +115,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 uses = ["iocon"]
@@ -123,7 +123,7 @@ start = true
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.44.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.44.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1000
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -131,14 +131,14 @@ start = false
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -146,7 +146,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -155,7 +155,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.45.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.45.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -47,7 +47,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -55,7 +55,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -63,7 +63,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -73,7 +73,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -90,7 +90,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -103,7 +103,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -113,7 +113,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -121,7 +121,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -129,14 +129,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -144,7 +144,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -153,7 +153,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.46.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.46.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.runner]
 path = "../test-runner"
-name = "test-runner"
+bin-crate = "test-runner"
 priority = 0
 requires = {flash = 16384, ram = 4096}
 start = true
@@ -47,7 +47,7 @@ features = ["itm"]
 
 [tasks.suite]
 path = "../test-suite"
-name = "test-suite"
+bin-crate = "test-suite"
 priority = 2
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -55,7 +55,7 @@ features = ["itm"]
 
 [tasks.assist]
 path = "../test-assist"
-name = "test-assist"
+bin-crate = "test-assist"
 priority = 1
 requires = {flash = 16384, ram = 4096}
 start = true
@@ -63,7 +63,7 @@ features = ["itm"]
 
 [tasks.idle]
 path = "../../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 3
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.47.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.47.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -101,7 +101,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -109,7 +109,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -117,14 +117,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -132,7 +132,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.48.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.48.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -101,7 +101,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -109,7 +109,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -117,14 +117,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -132,7 +132,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.49.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.49.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.5.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.5.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 8192, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.50.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.50.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.51.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.51.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.52.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.52.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.53.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.53.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -145,7 +145,7 @@ start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -154,7 +154,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -163,7 +163,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -172,7 +172,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.54.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.54.stdout
@@ -37,7 +37,7 @@ execute = true
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 2048}
 start = true
@@ -46,7 +46,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32fx-rcc"
-name = "drv-stm32fx-rcc"
+bin-crate = "drv-stm32fx-rcc"
 features = ["stm32f4"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -55,7 +55,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32fx-usart"
-name = "drv-stm32fx-usart"
+bin-crate = "drv-stm32fx-usart"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -65,7 +65,7 @@ interrupts = {38 = 1}
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32f4"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -74,7 +74,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -83,14 +83,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 requires = {flash = 32768, ram = 8192 }
 stacksize = 2048
@@ -98,7 +98,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.55.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.55.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -104,7 +104,7 @@ start = true
 
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["spi2", "spi4"]
@@ -114,7 +114,7 @@ stacksize = 1000
 
 [tasks.spi]
 path = "../task-spi"
-name = "task-spi"
+bin-crate = "task-spi"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048}
@@ -122,7 +122,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -130,14 +130,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -146,7 +146,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -155,7 +155,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c", "gpio"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -164,7 +164,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.6.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.6.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 16384, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.61.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.61.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384 }
@@ -113,7 +113,7 @@ start = true
 #
 [tasks.spi2_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2"]
@@ -124,7 +124,7 @@ stacksize = 1000
 
 [tasks.spi4_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4"]
@@ -135,7 +135,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -143,14 +143,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -159,7 +159,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -168,7 +168,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -177,7 +177,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.62.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.62.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -96,7 +96,7 @@ start = true
 #
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3"]
@@ -107,7 +107,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -115,14 +115,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -131,7 +131,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -140,7 +140,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.63.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.63.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -96,7 +96,7 @@ start = true
 #
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3"]
@@ -107,7 +107,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -115,14 +115,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -131,7 +131,7 @@ start = true
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -140,7 +140,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.64.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.64.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384 }
@@ -113,7 +113,7 @@ start = true
 #
 [tasks.spi2_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2"]
@@ -124,7 +124,7 @@ stacksize = 1000
 
 [tasks.spi4_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4"]
@@ -135,7 +135,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -143,14 +143,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -159,7 +159,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -168,7 +168,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -177,7 +177,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.65.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.65.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -64,7 +64,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -74,7 +74,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -91,7 +91,7 @@ start = true
 
 [tasks.spd]
 path = "../task-spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384 }
@@ -113,7 +113,7 @@ start = true
 #
 [tasks.spi2_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi2"]
@@ -124,7 +124,7 @@ stacksize = 1000
 
 [tasks.spi4_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4"]
@@ -135,7 +135,7 @@ stacksize = 1000
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -143,14 +143,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.thermal]
 path = "../task-thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -159,7 +159,7 @@ start = true
 
 [tasks.power]
 path = "../task-power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm"]
 priority = 3
 requires = {flash = 65536, ram = 8192 }
@@ -168,7 +168,7 @@ start = true
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["itm", "i2c", "gpio", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 16384 }
@@ -177,7 +177,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.66.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.66.stdout
@@ -63,7 +63,7 @@ imagea-ram-size = 0x18000
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -72,7 +72,7 @@ stacksize = 1536
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 features = ["lpc55", "gpio"]
 requires = {flash = 32768, ram = 16384 }
@@ -84,7 +84,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -92,7 +92,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -101,7 +101,7 @@ stacksize = 1000
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -113,7 +113,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -125,7 +125,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm0"]
@@ -139,7 +139,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm4"]
@@ -152,7 +152,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -164,7 +164,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm8"]
@@ -178,7 +178,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -191,7 +191,7 @@ usart_driver = "usart_driver"
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -202,7 +202,7 @@ user_leds = "user_leds"
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.67.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.67.stdout
@@ -63,7 +63,7 @@ imagea-ram-size = 0x18000
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 32768, ram = 4096}
 start = true
@@ -72,7 +72,7 @@ stacksize = 1536
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 priority = 3
 features = ["lpc55", "gpio"]
 requires = {flash = 32768, ram = 16384 }
@@ -84,7 +84,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256
@@ -92,7 +92,7 @@ start = true
 
 [tasks.syscon_driver]
 path = "../drv/lpc55-syscon"
-name = "drv-lpc55-syscon"
+bin-crate = "drv-lpc55-syscon"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["syscon", "anactrl", "pmc"]
@@ -101,7 +101,7 @@ stacksize = 1000
 
 [tasks.gpio_driver]
 path = "../drv/lpc55-gpio"
-name = "drv-lpc55-gpio"
+bin-crate = "drv-lpc55-gpio"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["gpio", "iocon"]
@@ -113,7 +113,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["lpc55"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -125,7 +125,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.usart_driver]
 path = "../drv/lpc55-usart"
-name = "drv-lpc55-usart"
+bin-crate = "drv-lpc55-usart"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm0"]
@@ -139,7 +139,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.i2c_driver]
 path = "../drv/lpc55-i2c"
-name = "drv-lpc55-i2c"
+bin-crate = "drv-lpc55-i2c"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm4"]
@@ -152,7 +152,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.rng_driver]
 path = "../drv/lpc55-rng"
-name = "drv-lpc55-rng"
+bin-crate = "drv-lpc55-rng"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["rng", "pmc"]
@@ -164,7 +164,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.spi_driver]
 path = "../drv/lpc55-spi-server"
-name = "drv-lpc55-spi-server"
+bin-crate = "drv-lpc55-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 1024}
 uses = ["flexcomm8"]
@@ -178,7 +178,7 @@ syscon_driver = "syscon_driver"
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 1024}
@@ -191,7 +191,7 @@ usart_driver = "usart_driver"
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -202,7 +202,7 @@ user_leds = "user_leds"
 
 [tasks.spam]
 path = "../task-spam2"
-name = "task-spam"
+bin-crate = "task-spam"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 stacksize = 1000

--- a/humility-bin/tests/cmd/extract/extract.ouray.68.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.68.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -67,7 +67,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -81,7 +81,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -107,7 +107,7 @@ rcc_driver = "rcc_driver"
 #
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3"]
@@ -122,7 +122,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -133,7 +133,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -143,7 +143,7 @@ user_leds = "user_leds"
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["stm32h7", "itm", "i2c", "gpio", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -157,7 +157,7 @@ i2c_driver = "i2c_driver"
 
 [tasks.hf]
 path = "../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = []
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -172,7 +172,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -185,7 +185,7 @@ usart_driver = "usart_driver"
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.69.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.69.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -56,7 +56,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -67,7 +67,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -81,7 +81,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -107,7 +107,7 @@ rcc_driver = "rcc_driver"
 #
 [tasks.spi_driver]
 path = "../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3"]
@@ -122,7 +122,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -133,7 +133,7 @@ gpio_driver = "gpio_driver"
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -143,7 +143,7 @@ user_leds = "user_leds"
 
 [tasks.hiffy]
 path = "../task-hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["stm32h7", "itm", "i2c", "gpio", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -157,7 +157,7 @@ i2c_driver = "i2c_driver"
 
 [tasks.hf]
 path = "../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = []
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -172,7 +172,7 @@ rcc_driver = "rcc_driver"
 
 [tasks.ping]
 path = "../task-ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -185,7 +185,7 @@ usart_driver = "usart_driver"
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.7.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.7.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -85,7 +85,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -93,7 +93,7 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -108,7 +108,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h7b3", "itm"]
 priority = 3
 requires = {flash = 16384, ram = 32768 }
@@ -116,7 +116,7 @@ start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -124,7 +124,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.70.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.70.stdout
@@ -40,7 +40,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -49,7 +49,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h743"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -58,7 +58,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -68,7 +68,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -79,7 +79,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 #
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi3", "h743"]
@@ -114,7 +114,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -123,7 +123,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -131,7 +131,7 @@ task-slots = ["user_leds"]
 
 [tasks.ping]
 path = "../../task/ping"
-name = "task-ping"
+bin-crate = "task-ping"
 features = ["uart"]
 priority = 4
 requires = {flash = 8192, ram = 512}
@@ -141,7 +141,7 @@ task-slots = [{peer = "pong"}, "usart_driver"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h743", "stm32h7", "itm", "i2c", "gpio", "qspi", "spi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -151,7 +151,7 @@ task-slots = ["gpio_driver", "hf", "i2c_driver"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h743"]
 priority = 3
 requires = {flash = 16384, ram = 8192 }
@@ -163,7 +163,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.71.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.71.stdout
@@ -39,7 +39,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 2048}
 start = true
@@ -48,7 +48,7 @@ stacksize = 1536
 
 [tasks.rcc_driver]
 path = "../../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 features = ["h753"]
 priority = 1
 requires = {flash = 8192, ram = 1024}
@@ -57,7 +57,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 features = ["h753"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -67,7 +67,7 @@ task-slots = ["rcc_driver"]
 
 [tasks.usart_driver]
 path = "../../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h753"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -78,7 +78,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm", "target-enable"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -94,7 +94,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -117,7 +117,7 @@ task-slots = ["gpio_driver", "rcc_driver", "i2c_driver"]
 #
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 4096}
 features = ["spi4", "h753"]
@@ -132,7 +132,7 @@ global_config = "spi4"
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -141,7 +141,7 @@ task-slots = ["gpio_driver"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
@@ -149,7 +149,7 @@ task-slots = ["user_leds"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -159,7 +159,7 @@ task-slots = ["hf", "gpio_driver", "i2c_driver", "user_leds"]
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -171,7 +171,7 @@ task-slots = ["gpio_driver", "rcc_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.ouray.8.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.8.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 16384, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.max31790]
 path = "../task-max31790"
-name = "task-max31790"
+bin-crate = "task-max31790"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 1024 }
@@ -141,7 +141,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.ouray.9.stdout
+++ b/humility-bin/tests/cmd/extract/extract.ouray.9.stdout
@@ -38,7 +38,7 @@ execute = false  # let's assume XN until proven otherwise
 
 [tasks.jefe]
 path = "../task-jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 16384, ram = 1024}
 start = true
@@ -46,7 +46,7 @@ features = ["itm"]
 
 [tasks.rcc_driver]
 path = "../drv/stm32h7-rcc"
-name = "drv-stm32h7-rcc"
+bin-crate = "drv-stm32h7-rcc"
 priority = 1
 requires = {flash = 8192, ram = 1024}
 uses = ["rcc"]
@@ -54,7 +54,7 @@ start = true
 
 [tasks.gpio_driver]
 path = "../drv/stm32h7-gpio"
-name = "drv-stm32h7-gpio"
+bin-crate = "drv-stm32h7-gpio"
 priority = 2
 requires = {flash = 8192, ram = 1024}
 uses = ["gpios1", "gpios2", "gpios3"]
@@ -62,7 +62,7 @@ start = true
 
 [tasks.usart_driver]
 path = "../drv/stm32h7-usart"
-name = "drv-stm32h7-usart"
+bin-crate = "drv-stm32h7-usart"
 features = ["h743"]
 priority = 2
 requires = { flash = 8192, ram = 1024}
@@ -72,7 +72,7 @@ interrupts = {39 = 1}
 
 [tasks.i2c_driver]
 path = "../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 1024}
@@ -89,7 +89,7 @@ start = true
 
 [tasks.i2c_target]
 path = "../drv/stm32h7-i2c-target-server"
-name = "drv-stm32h7-i2c-target-server"
+bin-crate = "drv-stm32h7-i2c-target-server"
 features = ["h743", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -102,7 +102,7 @@ start = true
 
 [tasks.user_leds]
 path = "../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 8192, ram = 1024}
@@ -110,14 +110,14 @@ start = true
 
 [tasks.pong]
 path = "../task-pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 8192, ram = 1024}
 start = true
 
 [tasks.i2c_debug]
 path = "../task-i2c"
-name = "task-i2c"
+bin-crate = "task-i2c"
 features = ["itm"]
 priority = 3
 requires = {flash = 32768, ram = 8192 }
@@ -125,7 +125,7 @@ start = true
 
 [tasks.adt7420]
 path = "../task-adt7420"
-name = "task-adt7420"
+bin-crate = "task-adt7420"
 features = ["h743", "itm"]
 priority = 3
 requires = {flash = 16384, ram = 32768 }
@@ -133,7 +133,7 @@ start = true
 
 [tasks.max31790]
 path = "../task-max31790"
-name = "task-max31790"
+bin-crate = "task-max31790"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 1024 }
@@ -141,7 +141,7 @@ start = true
 
 [tasks.idle]
 path = "../task-idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 256, ram = 256}
 start = true

--- a/humility-bin/tests/cmd/extract/extract.panic-on-boot.stdout
+++ b/humility-bin/tests/cmd/extract/extract.panic-on-boot.stdout
@@ -10,7 +10,7 @@ name = "gimlet"
 requires = {flash = 32768, ram = 8192}
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -31,7 +31,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -43,7 +43,7 @@ interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -52,7 +52,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -66,7 +66,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -80,7 +80,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -97,7 +97,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -110,7 +110,7 @@ task-slots = ["sys", "i2c_driver", "jefe"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -119,7 +119,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -128,7 +128,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -137,7 +137,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -150,7 +150,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -161,7 +161,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -172,7 +172,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -181,7 +181,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -189,7 +189,7 @@ stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
@@ -200,7 +200,7 @@ start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -209,7 +209,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -218,7 +218,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -227,7 +227,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 16384}
 stacksize = 4096
@@ -258,7 +258,7 @@ features = [
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -267,7 +267,7 @@ task-slots = ["sys", {spi_driver = "spi4_driver"}]
 features = ["sink_test"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -275,7 +275,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -283,7 +283,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.sidecar-b-image-default.zip.stdout
+++ b/humility-bin/tests/cmd/extract/extract.sidecar-b-image-default.zip.stdout
@@ -17,7 +17,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -31,7 +31,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent", "udprpc"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -40,7 +40,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -51,7 +51,7 @@ notifications = ["flash-irq"]
 interrupts = {"flash_controller.irq" = "flash-irq"}
 
 [tasks.auxflash]
-name = "drv-auxflash-server"
+bin-crate = "drv-auxflash-server"
 priority = 3
 max-sizes = {flash = 32768, ram = 4096}
 features = ["h753"]
@@ -63,7 +63,7 @@ stacksize = 3504
 task-slots = ["sys"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "sidecar", "vlan", "vpd-mac", "use-spi-core", "spi3"]
@@ -80,7 +80,7 @@ task-slots = ["sys", "packrat", { seq = "sequencer" }]
 "spi3.irq" = "spi-irq"
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 7
 max-sizes = {flash = 131072, ram = 16384}
 stacksize = 6144
@@ -105,7 +105,7 @@ features = ["sidecar", "vlan", "auxflash"]
 notifications = ["socket", "usart-irq", "timer"]
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -117,7 +117,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -127,7 +127,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -137,7 +137,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -147,7 +147,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.monorail]
-name = "task-monorail-server"
+bin-crate = "task-monorail-server"
 priority = 6
 max-sizes = {flash = 262144, ram = 8192}
 features = ["mgmt", "sidecar", "vlan", "use-spi-core", "h753", "spi2"]
@@ -159,7 +159,7 @@ notifications = ["spi-irq", "wake-timer"]
 interrupts = {"spi2.irq" = "spi-irq"}
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 2048}
@@ -179,7 +179,7 @@ task-slots = ["sys"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -188,7 +188,7 @@ start = true
 task-slots = ["sys", "i2c_driver", "sprot"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
@@ -197,7 +197,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.ecp5_mainboard]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["mainboard", "use-spi-core", "h753", "spi5"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -209,7 +209,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi5.irq" = "spi-irq"}
 
 [tasks.ecp5_front_io]
-name = "drv-fpga-server"
+bin-crate = "drv-fpga-server"
 features = ["front_io", "use-spi-core", "h753", "spi1"]
 priority = 3
 max-sizes = {flash = 32768, ram = 8192}
@@ -221,7 +221,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi1.irq" = "spi-irq"}
 
 [tasks.transceivers]
-name = "drv-transceivers-server"
+bin-crate = "drv-transceivers-server"
 features = ["vlan"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384}
@@ -238,7 +238,7 @@ task-slots = [
 notifications = ["socket", "timer"]
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -246,7 +246,7 @@ start = true
 task-slots = []
 
 [tasks.sequencer]
-name = "drv-sidecar-seq-server"
+bin-crate = "drv-sidecar-seq-server"
 priority = 4
 stacksize = 4096
 start = true
@@ -260,7 +260,7 @@ task-slots = [
 notifications = ["timer"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "sidecar"]
 priority = 5
 max-sizes = {flash = 32768, ram = 16384 }
@@ -270,7 +270,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "sidecar"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -280,7 +280,7 @@ task-slots = ["i2c_driver", "sensor", "sequencer"]
 notifications = ["timer"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -288,7 +288,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.ignition]
-name = "drv-ignition-server"
+bin-crate = "drv-ignition-server"
 features = ["sequencer"]
 priority = 5
 max-sizes = {flash = 16384, ram = 4096}
@@ -298,7 +298,7 @@ task-slots = [{fpga = "ecp5_mainboard"}, "sequencer"]
 notifications = ["timer"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 3
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -306,7 +306,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192 }
 start = true
@@ -317,7 +317,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.spoopy.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.spoopy.0.stdout
@@ -49,7 +49,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -58,7 +58,7 @@ stacksize = 1536
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 3800
 priority = 2
 features = ["mgmt", "h753", "gimlet"]
@@ -73,7 +73,7 @@ task-slots = ["sys", "rcc_driver",
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -82,7 +82,7 @@ start = true
 
 [tasks.spi4_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -97,7 +97,7 @@ global_config = "spi4"
 
 [tasks.spi2_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -112,7 +112,7 @@ global_config = "spi2"
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -130,7 +130,7 @@ task-slots = ["sys"]
 
 [tasks.spd]
 path = "../../task/spd"
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 16384}
@@ -144,7 +144,7 @@ task-slots = ["sys", "i2c_driver"]
 
 [tasks.thermal]
 path = "../../task/thermal"
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -154,7 +154,7 @@ task-slots = ["i2c_driver", "sensor"]
 
 [tasks.power]
 path = "../../task/power"
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "h753"]
 priority = 3
 requires = {flash = 16384, ram = 4096 }
@@ -164,7 +164,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi"]
 priority = 3
 requires = {flash = 32768, ram = 32768 }
@@ -174,7 +174,7 @@ task-slots = ["sys", "hf", "i2c_driver"]
 
 [tasks.gimlet_seq]
 path = "../../drv/gimlet-seq-server"
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 65536, ram = 4096 }
@@ -188,7 +188,7 @@ register_defs = "gimlet_regs.json"
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048 }
@@ -200,7 +200,7 @@ task-slots = ["sys"]
 
 [tasks.sensor]
 path = "../../task/sensor"
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 3
 requires = {flash = 8192, ram = 2048 }
@@ -209,7 +209,7 @@ start = true
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 3
 requires = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -218,7 +218,7 @@ task-slots = ["net"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.sprot_status.stdout
+++ b/humility-bin/tests/cmd/extract/extract.sprot_status.stdout
@@ -21,7 +21,7 @@ requires = {flash = 32768, ram = 8192}
 features = ["itm"]
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -39,7 +39,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ interrupts = {"eth.irq" = 0b1, "tim16.irq" = 0b10}
 task-slots = ["sys", "i2c_driver", { spi_driver = "spi2_driver" }, "jefe"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi4_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -74,7 +74,7 @@ task-slots = ["sys"]
 global_config = "spi4"
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
 features = ["spi2", "h753"]
@@ -88,7 +88,7 @@ task-slots = ["sys"]
 global_config = "spi2"
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -105,7 +105,7 @@ task-slots = ["sys"]
 "i2c4.error" = 0b0000_1000
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -118,7 +118,7 @@ task-slots = ["sys", "i2c_driver", "jefe"]
 "i2c1.error" = 0b0000_0001
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -127,7 +127,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -136,7 +136,7 @@ start = true
 task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -145,7 +145,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 4096 }
@@ -158,7 +158,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -169,7 +169,7 @@ interrupts = {"hash.irq" = 1}
 task-slots = ["sys"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048 }
@@ -180,7 +180,7 @@ interrupts = {"quadspi.irq" = 1}
 task-slots = ["sys", "hash_driver"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -189,7 +189,7 @@ uses = ["flash_controller", "bank2"]
 interrupts = {"flash_controller.irq" = 0b1}
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 4096 }
@@ -197,7 +197,7 @@ stacksize = 3800        # Sensor data is stored on the stack
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = 0b01}
@@ -208,7 +208,7 @@ start = true
 task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -217,7 +217,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -226,7 +226,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -235,7 +235,7 @@ task-slots = ["net"]
 features = ["vlan"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 16384}
 stacksize = 4096
@@ -266,7 +266,7 @@ features = [
 interrupts = {"usart1.irq" = 0b10}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -275,7 +275,7 @@ task-slots = ["sys", {spi_driver = "spi4_driver"}]
 features = ["sink_test"]
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -283,7 +283,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -291,7 +291,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.static-tasks.0.stdout
+++ b/humility-bin/tests/cmd/extract/extract.static-tasks.0.stdout
@@ -49,7 +49,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -58,7 +58,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -67,7 +67,7 @@ start = true
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -85,7 +85,7 @@ task-slots = ["sys"]
 
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -100,7 +100,7 @@ global_config = "spi4"
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -109,7 +109,7 @@ task-slots = ["sys"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -117,7 +117,7 @@ task-slots = ["user_leds"]
 
 [tasks.uartecho]
 path = "../../task/uartecho"
-name = "task-uartecho"
+bin-crate = "task-uartecho"
 features = ["stm32h743", "usart2"]
 uses = ["usart2"]
 interrupts = {"usart2.irq" = 1}
@@ -129,7 +129,7 @@ task-slots = ["sys"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "rng", "update"]
 priority = 4
 requires = {flash = 32768, ram = 32768}
@@ -139,7 +139,7 @@ task-slots = ["hf", "sys", "i2c_driver", "user_leds", "rng_driver", "update_serv
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048}
@@ -151,7 +151,7 @@ task-slots = ["sys"]
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4320
 priority = 3
 features = ["h753", "h7-vlan", "gimletlet-nic"]
@@ -164,7 +164,7 @@ task-slots = ["sys", "spi_driver" ]
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 4
 requires = {flash = 8192, ram = 8192}
 stacksize = 4096
@@ -174,7 +174,7 @@ features = ["vlan"]
 
 [tasks.validate]
 path = "../../task/validate"
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 requires = {flash = 32768, ram = 4096}
 stacksize = 1024 
@@ -183,7 +183,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
@@ -192,7 +192,7 @@ start = true
 [tasks.rng_driver]
 features = ["h753"]
 path = "../../drv/stm32h7-rng"
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 3
 requires = {flash = 8192, ram = 512}
 uses = ["rng"]
@@ -202,7 +202,7 @@ task-slots = ["sys", "user_leds"]
 
 [tasks.update_server]
 path = "../../drv/stm32h7-update-server"
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 requires = {flash = 8192, ram = 4096}
 stacksize = 2048

--- a/humility-bin/tests/cmd/extract/extract.static-tasks.1.stdout
+++ b/humility-bin/tests/cmd/extract/extract.static-tasks.1.stdout
@@ -46,7 +46,7 @@ dma = true
 
 [tasks.jefe]
 path = "../../task/jefe"
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 requires = {flash = 8192, ram = 2048}
 start = true
@@ -55,7 +55,7 @@ stacksize = 1536
 
 [tasks.sys]
 path = "../../drv/stm32xx-sys"
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 requires = {flash = 2048, ram = 1024}
@@ -64,7 +64,7 @@ start = true
 
 [tasks.i2c_driver]
 path = "../../drv/stm32h7-i2c-server"
-name = "drv-stm32h7-i2c-server"
+bin-crate = "drv-stm32h7-i2c-server"
 features = ["h753", "itm"]
 priority = 2
 requires = {flash = 16384, ram = 2048}
@@ -82,7 +82,7 @@ task-slots = ["sys"]
 
 [tasks.spi_driver]
 path = "../../drv/stm32h7-spi-server"
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 2
 requires = {flash = 16384, ram = 2048}
 features = ["spi4", "h753"]
@@ -97,7 +97,7 @@ global_config = "spi4"
 
 [tasks.user_leds]
 path = "../../drv/user-leds"
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 requires = {flash = 2048, ram = 1024}
@@ -106,7 +106,7 @@ task-slots = ["sys"]
 
 [tasks.pong]
 path = "../../task/pong"
-name = "task-pong"
+bin-crate = "task-pong"
 priority = 3
 requires = {flash = 1024, ram = 1024}
 start = true
@@ -114,7 +114,7 @@ task-slots = ["user_leds"]
 
 [tasks.uartecho]
 path = "../../task/uartecho"
-name = "task-uartecho"
+bin-crate = "task-uartecho"
 features = ["stm32h743", "usart2"]
 uses = ["usart2"]
 interrupts = {"usart2.irq" = 1}
@@ -126,7 +126,7 @@ task-slots = ["sys"]
 
 [tasks.hiffy]
 path = "../../task/hiffy"
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "rng", "update"]
 priority = 4
 requires = {flash = 32768, ram = 32768}
@@ -136,7 +136,7 @@ task-slots = ["hf", "sys", "i2c_driver", "user_leds", "rng_driver", "update_serv
 
 [tasks.hf]
 path = "../../drv/gimlet-hf-server"
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753"]
 priority = 3
 requires = {flash = 16384, ram = 2048}
@@ -148,7 +148,7 @@ task-slots = ["sys"]
 
 [tasks.net]
 path = "../../task/net"
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 4320
 priority = 3
 features = ["h753", "h7-vlan", "gimletlet-nic"]
@@ -161,7 +161,7 @@ task-slots = ["sys", "spi_driver" ]
 
 [tasks.udpecho]
 path = "../../task/udpecho"
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 4
 requires = {flash = 8192, ram = 8192}
 stacksize = 4096
@@ -171,7 +171,7 @@ features = ["vlan"]
 
 [tasks.validate]
 path = "../../task/validate"
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 3
 requires = {flash = 32768, ram = 4096}
 stacksize = 1024 
@@ -180,7 +180,7 @@ task-slots = ["i2c_driver"]
 
 [tasks.idle]
 path = "../../task/idle"
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 requires = {flash = 128, ram = 256}
 stacksize = 256
@@ -189,7 +189,7 @@ start = true
 [tasks.rng_driver]
 features = ["h753"]
 path = "../../drv/stm32h7-rng"
-name = "drv-stm32h7-rng"
+bin-crate = "drv-stm32h7-rng"
 priority = 3
 requires = {flash = 8192, ram = 512}
 uses = ["rng"]
@@ -199,7 +199,7 @@ task-slots = ["sys", "user_leds"]
 
 [tasks.update_server]
 path = "../../drv/stm32h7-update-server"
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 requires = {flash = 8192, ram = 4096}
 stacksize = 2048

--- a/humility-bin/tests/cmd/extract/extract.task.net.stdout
+++ b/humility-bin/tests/cmd/extract/extract.task.net.stdout
@@ -17,7 +17,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -37,7 +37,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -50,7 +50,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 1024}
@@ -59,7 +59,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -71,7 +71,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 features = ["h753", "itm"]
 priority = 3
 max-sizes = {flash = 16384, ram = 2048}
@@ -89,7 +89,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753", "itm"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -103,7 +103,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 3
 max-sizes = {flash = 8192, ram = 2048}
 start = true
@@ -111,7 +111,7 @@ start = true
 task-slots = []
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["itm", "gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -121,7 +121,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["itm", "gimlet"]
 priority = 6
 max-sizes = {flash = 32768, ram = 8192 }
@@ -131,7 +131,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "itm", "i2c", "gpio", "spi", "qspi", "hash", "update", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -140,7 +140,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 65536, ram = 8192 }
@@ -155,7 +155,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -167,7 +167,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -179,7 +179,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -190,7 +190,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 features = ["itm"]
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
@@ -199,7 +199,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan"]
 uses = ["uart7"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -211,7 +211,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -221,7 +221,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -231,7 +231,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096
@@ -241,7 +241,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -270,7 +270,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 32768, ram = 32768}
 stacksize = 16384
@@ -282,7 +282,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000 
@@ -290,7 +290,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -298,7 +298,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -306,7 +306,7 @@ start = true
 task-slots = ["sys"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 5
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -315,7 +315,7 @@ stacksize = 1200
 extern-regions = [ "sram2", "sram3", "sram4" ]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -323,7 +323,7 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256

--- a/humility-bin/tests/cmd/extract/extract.task.power.stdout
+++ b/humility-bin/tests/cmd/extract/extract.task.power.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 6040
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753"]
 priority = 1
 max-sizes = {flash = 2048, ram = 2048}
@@ -60,7 +60,7 @@ start = true
 task-slots = ["jefe"]
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -72,7 +72,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1024
 features = ["h753"]
 priority = 3
@@ -91,7 +91,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -105,7 +105,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 max-sizes = {flash = 8192, ram = 16384}
 start = true
@@ -114,7 +114,7 @@ task-slots = []
 features = ["gimlet","boot-kmdb"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -124,7 +124,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -134,7 +134,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -143,7 +143,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753","stay-in-a2"]
 priority = 4
 max-sizes = {flash = 131072, ram = 8192 }
@@ -158,7 +158,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -168,7 +168,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -180,7 +180,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -192,7 +192,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -203,7 +203,7 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 8192, ram = 8192 }
 stacksize = 1024
@@ -211,7 +211,7 @@ start = true
 notifications = ["timer"]
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -223,7 +223,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -233,7 +233,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -243,7 +243,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -275,7 +275,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -287,7 +287,7 @@ notifications = ["spi-irq"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -295,7 +295,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -303,7 +303,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -312,7 +312,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -323,7 +323,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -331,14 +331,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.u16-ringbuf.stdout
+++ b/humility-bin/tests/cmd/extract/extract.u16-ringbuf.stdout
@@ -18,7 +18,7 @@ size = 256
 default = true
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 16384, ram = 2048}
 start = true
@@ -38,7 +38,7 @@ set_reset_reason = ["sys"]
 request_reset = ["hiffy", "control_plane_agent","udprpc"]
 
 [tasks.net]
-name = "task-net"
+bin-crate = "task-net"
 stacksize = 8000
 priority = 5
 features = ["mgmt", "h753", "gimlet", "vlan", "vpd-mac"]
@@ -51,7 +51,7 @@ task-slots = ["sys", "packrat", { spi_driver = "spi2_driver" }, "jefe"]
 notifications = ["eth-irq", "mdio-timer-irq", "wake-timer", "jefe-state-change"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["h753", "exti", "no-panic"]
 priority = 1
 uses = ["rcc", "gpios", "system_flash", "syscfg", "exti"]
@@ -80,7 +80,7 @@ pin = 3
 owner = {name = "sprot", notification = "rot_irq"}
 
 [tasks.spi2_driver]
-name = "drv-stm32h7-spi-server"
+bin-crate = "drv-stm32h7-spi-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 features = ["spi2", "h753"]
@@ -92,7 +92,7 @@ task-slots = ["sys"]
 notifications = ["spi-irq"]
 
 [tasks.i2c_driver]
-name = "drv-stm32xx-i2c-server"
+bin-crate = "drv-stm32xx-i2c-server"
 stacksize = 1048
 features = ["h753"]
 priority = 3
@@ -110,7 +110,7 @@ notifications = ["i2c2-irq", "i2c3-irq", "i2c4-irq"]
 "i2c4.error" = "i2c4-irq"
 
 [tasks.spd]
-name = "task-spd"
+bin-crate = "task-spd"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram = 16384}
@@ -124,7 +124,7 @@ notifications = ["i2c1-irq", "jefe-state-change"]
 "i2c1.error" = "i2c1-irq"
 
 [tasks.packrat]
-name = "task-packrat"
+bin-crate = "task-packrat"
 priority = 1
 start = true
 # task-slots is explicitly empty: packrat should not send IPCs!
@@ -132,7 +132,7 @@ task-slots = []
 features = ["gimlet"]
 
 [tasks.thermal]
-name = "task-thermal"
+bin-crate = "task-thermal"
 features = ["gimlet"]
 priority = 5
 max-sizes = {flash = 32768, ram = 8192 }
@@ -142,7 +142,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq", "jefe"]
 notifications = ["timer"]
 
 [tasks.power]
-name = "task-power"
+bin-crate = "task-power"
 features = ["gimlet"]
 priority = 6
 max-sizes = {flash = 65536, ram = 16384 }
@@ -152,7 +152,7 @@ task-slots = ["i2c_driver", "sensor", "gimlet_seq"]
 notifications = ["timer", "external_badness"]
 
 [tasks.hiffy]
-name = "task-hiffy"
+bin-crate = "task-hiffy"
 features = ["h753", "stm32h7", "i2c", "gpio", "spi", "qspi", "hash", "sprot"]
 priority = 5
 max-sizes = {flash = 32768, ram = 32768 }
@@ -161,7 +161,7 @@ start = true
 task-slots = ["sys", "hf", "i2c_driver", "hash_driver", "update_server", "sprot"]
 
 [tasks.gimlet_seq]
-name = "drv-gimlet-seq-server"
+bin-crate = "drv-gimlet-seq-server"
 features = ["h753"]
 priority = 4
 max-sizes = {flash = 131072, ram = 16384 }
@@ -176,7 +176,7 @@ fpga_image = "fpga-b.bin"
 register_defs = "gimlet-regs-b.json"
 
 [tasks.gimlet_inspector]
-name = "task-gimlet-inspector"
+bin-crate = "task-gimlet-inspector"
 priority = 6
 features = ["vlan"]
 max-sizes = {flash = 16384, ram = 4096 }
@@ -186,7 +186,7 @@ task-slots = ["net", {seq = "gimlet_seq"}]
 notifications = ["socket"]
 
 [tasks.hash_driver]
-name = "drv-stm32h7-hash-server"
+bin-crate = "drv-stm32h7-hash-server"
 features = ["h753"]
 priority = 2
 max-sizes = {flash = 16384, ram=4096 }
@@ -198,7 +198,7 @@ task-slots = ["sys"]
 notifications = ["hash-irq"]
 
 [tasks.hf]
-name = "drv-gimlet-hf-server"
+bin-crate = "drv-gimlet-hf-server"
 features = ["h753", "hash"]
 priority = 3
 max-sizes = {flash = 16384, ram = 4096 }
@@ -210,7 +210,7 @@ task-slots = ["sys", "hash_driver"]
 notifications = ["qspi-irq"]
 
 [tasks.update_server]
-name = "stm32h7-update-server"
+bin-crate = "stm32h7-update-server"
 priority = 3
 max-sizes = {flash = 16384, ram = 4096}
 stacksize = 2048
@@ -221,14 +221,14 @@ interrupts = {"flash_controller.irq" = "flash-irq"}
 notifications = ["flash-irq"]
 
 [tasks.sensor]
-name = "task-sensor"
+bin-crate = "task-sensor"
 priority = 4
 max-sizes = {flash = 16384, ram = 8192 }
 stacksize = 1024
 start = true
 
 [tasks.host_sp_comms]
-name = "task-host-sp-comms"
+bin-crate = "task-host-sp-comms"
 features = ["stm32h753", "uart7", "baud_rate_3M", "hardware_flow_control", "vlan", "gimlet"]
 uses = ["uart7", "dbgmcu"]
 interrupts = {"uart7.irq" = "usart-irq"}
@@ -240,7 +240,7 @@ task-slots = ["sys", "gimlet_seq", "hf", "control_plane_agent", "net", "packrat"
 notifications = ["jefe-state-change", "usart-irq", "multitimer", "control-plane-agent"]
 
 [tasks.udpecho]
-name = "task-udpecho"
+bin-crate = "task-udpecho"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 4096
@@ -250,7 +250,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.udpbroadcast]
-name = "task-udpbroadcast"
+bin-crate = "task-udpbroadcast"
 priority = 6
 max-sizes = {flash = 16384, ram = 8192}
 stacksize = 2048
@@ -260,7 +260,7 @@ features = ["vlan"]
 notifications = ["socket"]
 
 [tasks.control_plane_agent]
-name = "task-control-plane-agent"
+bin-crate = "task-control-plane-agent"
 priority = 6
 max-sizes = {flash = 131072, ram = 32768}
 stacksize = 4096
@@ -292,7 +292,7 @@ notifications = ["usart-irq", "socket", "timer"]
 interrupts = {"usart1.irq" = "usart-irq"}
 
 [tasks.sprot]
-name = "drv-stm32h7-sprot-server"
+bin-crate = "drv-stm32h7-sprot-server"
 priority = 4
 max-sizes = {flash = 65536, ram = 32768}
 stacksize = 16384
@@ -304,7 +304,7 @@ notifications = ["spi-irq", "rot-irq", "timer"]
 interrupts = {"spi4.irq" = "spi-irq"}
 
 [tasks.validate]
-name = "task-validate"
+bin-crate = "task-validate"
 priority = 5
 max-sizes = {flash = 16384, ram = 4096 }
 stacksize = 1000
@@ -312,7 +312,7 @@ start = true
 task-slots = ["i2c_driver"]
 
 [tasks.vpd]
-name = "task-vpd"
+bin-crate = "task-vpd"
 priority = 4
 max-sizes = {flash = 8192, ram = 1024}
 start = true
@@ -320,7 +320,7 @@ task-slots = ["sys", "i2c_driver"]
 stacksize = 800
 
 [tasks.user_leds]
-name = "drv-user-leds"
+bin-crate = "drv-user-leds"
 features = ["stm32h7"]
 priority = 2
 max-sizes = {flash = 2048, ram = 1024}
@@ -329,7 +329,7 @@ task-slots = ["sys"]
 notifications = ["timer"]
 
 [tasks.dump_agent]
-name = "task-dump-agent"
+bin-crate = "task-dump-agent"
 priority = 6
 max-sizes = {flash = 32768, ram = 16384 }
 start = true
@@ -340,7 +340,7 @@ notifications = ["socket"]
 features = ["net", "vlan"]
 
 [tasks.sbrmi]
-name = "drv-sbrmi"
+bin-crate = "drv-sbrmi"
 priority = 4
 max-sizes = {flash = 8192, ram = 2048 }
 start = true
@@ -348,14 +348,14 @@ task-slots = ["i2c_driver"]
 stacksize = 800
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 8
 max-sizes = {flash = 128, ram = 256}
 stacksize = 256
 start = true
 
 [tasks.udprpc]
-name = "task-udprpc"
+bin-crate = "task-udprpc"
 priority = 6
 max-sizes = {flash = 32768, ram = 8192}
 stacksize = 4096

--- a/humility-bin/tests/cmd/extract/extract.v6.stdout
+++ b/humility-bin/tests/cmd/extract/extract.v6.stdout
@@ -12,7 +12,7 @@ features = ["g070"]
 stacksize = 640
 
 [tasks.jefe]
-name = "task-jefe"
+bin-crate = "task-jefe"
 priority = 0
 max-sizes = {flash = 4096, ram = 512}
 start = true
@@ -21,7 +21,7 @@ stacksize = 352
 notifications = ["timer", "fault"]
 
 [tasks.sys]
-name = "drv-stm32xx-sys"
+bin-crate = "drv-stm32xx-sys"
 features = ["g070"]
 priority = 1
 max-sizes = {flash = 2048, ram = 256}
@@ -31,7 +31,7 @@ stacksize = 256
 task-slots = ["jefe"]
 
 [tasks.usart_driver]
-name = "drv-stm32g0-usart"
+bin-crate = "drv-stm32g0-usart"
 features = ["g070"]
 priority = 2
 max-sizes = {flash = 4096, ram = 256}
@@ -43,7 +43,7 @@ task-slots = ["sys"]
 stacksize = 256
 
 [tasks.idle]
-name = "task-idle"
+bin-crate = "task-idle"
 priority = 5
 max-sizes = {flash = 128, ram = 64}
 stacksize = 64


### PR DESCRIPTION
Per [the corresponding hubris PR], update all the test data to similarly replace `task.$name.name` with `task.$name.bin-crate`.

[the corresponding hubris PR]: https://github.com/oxidecomputer/hubris/pull/2195