### PR TITLE
Build against stable Rust on buildomat, not nightly

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -3,7 +3,7 @@
 #: name = "build-and-test"
 #: variety = "basic"
 #: target = "helios"
-#: rust_toolchain = "nightly"
+#: rust_toolchain = "stable"
 #: output_rules = []
 #:
 


### PR DESCRIPTION
There's no reason to inflict nightly shenanigans on ourselves, e.g. https://github.com/rust-lang/rust/issues/145779 caused CI failures on buildomat: https://github.com/oxidecomputer/humility/pull/564/checks?check_run_id=48839525526