### PR TITLE
Fix fan speed rendering

### DIFF
--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -916,7 +916,7 @@ fn draw_graph<B: Backend>(f: &mut Frame<B>, parent: Rect, graph: &mut Graph) {
     // and a right justified 8 + margins), but we don't want it to consume
     // more than 80%; calculate accordingly.
     //
-    let r = std::cmp::min((30 * 100) / parent.width, 80);
+    let r = std::cmp::min((30u16 * 100).div_ceil(parent.width), 80);
 
     let chunks = Layout::default()
         .direction(Direction::Horizontal)


### PR DESCRIPTION
Due to bad rounding, the final character of fan speed could be clipped at specific sizes:
<img width="1044" height="1042" alt="Screenshot 2025-09-04 at 9 58 20 AM" src="https://github.com/user-attachments/assets/f7d54b37-28e2-40ee-8fdb-9cce20c81355" />

This PR changes the calculation to round up, fixing the clipping.

(It also removes some unnecessary allocation while I'm at it)

Closes https://github.com/oxidecomputer/humility/issues/242

