### PR TITLE
Fix cargo run and install.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.88" # must match Cargo.toml
+          toolchain: "1.89" # must match Cargo.toml
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -101,7 +101,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: "1.89" # must match Cargo.toml
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 #
 
 [workspace]
+default-members = ["humility-bin"]
 members = [
     "humility-arch-arm",
     "humility-arch-cortex",
@@ -82,7 +83,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88" # if this changes, edit ci.yaml as well!
+rust-version = "1.89" # if this changes, edit ci.yaml as well!
 
 [workspace.dependencies]
 # `git`-based deps


### PR DESCRIPTION
Since xtask was added a while back, both cargo run and cargo install have been broken, requiring you to specify a package.

This fixes that.