### PR TITLE
Add option to configure debug probe speed

### DIFF
--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -104,7 +104,7 @@ fn force_openocd(
     };
 
     let serial = {
-        let mut c = humility_probes_core::attach(probe, hubris)?;
+        let mut c = humility_probes_core::attach(probe, hubris, args.speed)?;
         let core = c.as_mut();
 
         validate(hubris, core, subargs)?;
@@ -367,7 +367,11 @@ fn flashcmd(context: &mut ExecutionContext) -> Result<()> {
     };
 
     humility::msg!("attaching with chip set to {chip:x?}");
-    let mut c = humility_probes_core::attach_for_flashing(probe, &chip)?;
+    let mut c = humility_probes_core::attach_for_flashing(
+        probe,
+        &chip,
+        context.cli.speed,
+    )?;
     let core = c.as_mut();
 
     validate(hubris, core, &subargs)?;

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -40,9 +40,13 @@ fn reset(context: &mut ExecutionContext) -> Result<()> {
                 "Need a chip to do a soft reset or halt after reset"
             )
         })?;
-        humility_probes_core::attach_to_chip(probe, Some(&chip))?
+        humility_probes_core::attach_to_chip(
+            probe,
+            Some(&chip),
+            context.cli.speed,
+        )?
     } else {
-        humility_probes_core::attach_to_probe(probe)?
+        humility_probes_core::attach_to_probe(probe, context.cli.speed)?
     };
 
     let r = if subargs.halt {

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -45,6 +45,11 @@ pub struct Cli {
     #[clap(long, short, group = "hubris")]
     pub probe: Option<String>,
 
+    /// When using a hardware debug probe, set the max speed of the SWD/JTAG
+    /// interface on the debug probe in kilohertz.
+    #[clap(long, short, value_name = "speed_khz")]
+    pub speed: Option<u32>,
+
     /// File that contains the Hubris archive. This may also be set via
     /// the HUMILITY_ARCHIVE environment variable. Run "humility doc" for
     /// more information on Hubris archives.

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -73,7 +73,7 @@ pub fn attach_probe(
         None => "auto",
     };
 
-    humility_probes_core::attach(probe, hubris)
+    humility_probes_core::attach(probe, hubris, None)
 }
 
 #[cfg(not(feature = "probes"))]

--- a/humility-probes-core/src/lib.rs
+++ b/humility-probes-core/src/lib.rs
@@ -97,7 +97,7 @@ fn open_probe<T: Into<DebugProbeSelector> + Clone>(
         && let Some(rcode) = err.downcast_ref::<rusb::Error>()
         && *rcode == rusb::Error::Busy
     {
-        bail!("USB link in use; is OpenOCD or  another debugger running?");
+        bail!("USB link in use; is OpenOCD or another debugger running?");
     }
 
     let mut probe = res?;

--- a/humility-probes-core/src/lib.rs
+++ b/humility-probes-core/src/lib.rs
@@ -97,10 +97,7 @@ fn open_probe<T: Into<DebugProbeSelector> + Clone>(
         && let Some(rcode) = err.downcast_ref::<rusb::Error>()
         && *rcode == rusb::Error::Busy
     {
-        bail!(
-            "USB link in use; is OpenOCD or \
-                        another debugger running?"
-        );
+        bail!("USB link in use; is OpenOCD or  another debugger running?");
     }
 
     let mut probe = res?;


### PR DESCRIPTION
By default `probe-rs` uses a hardcoded debug adapter speed. For adapters that cannot meet that exact speed they may fall back to a slower one rather than use an internal sane default. This can slow down operation on some adapters (like mculink).

This change adds and optional command line flag to provide a speed setting.

An example of the impact this setting has:

```
~/w/h/t/release (feature/set-probe-speed)> time ./humility flash -F
humility: attached to archive
humility: attaching with chip set to "STM32H753ZITx"
humility: attached via CMSIS-DAP
humility: archive appears to be already flashed; forcing re-flash
humility: flashing done

________________________________________________________
Executed in   48.68 secs

~/w/h/t/release (feature/set-probe-speed)> time ./humility --speed 8000 flash -F
humility: attached to archive
humility: attaching with chip set to "STM32H753ZITx"
humility: attached via CMSIS-DAP
humility: archive appears to be already flashed; forcing re-flash
humility: flashing done

________________________________________________________
Executed in   34.44 secs
```

Tested with stlinkv3, mculink, and another generic daplink device.