### PR TITLE
Ignore archive with rebootleby

### DIFF
--- a/cmd/rebootleby/src/lib.rs
+++ b/cmd/rebootleby/src/lib.rs
@@ -145,7 +145,7 @@ pub fn init() -> Command {
         name: "rebootleby",
         run: rebootleby,
         kind: CommandKind::Attached {
-            archive: Archive::Optional,
+            archive: Archive::Ignored,
             attach: Attach::LiveOnly,
             validate: Validate::None,
         },


### PR DESCRIPTION
The bootleby archive looks kind of like a hubris archive but it can't actually be fully loaded with `-a`. This isn't a problem because rebootleby takes the archive separately but it can create confusion if you do attempt to pass it in. Just ignore the archive.