### PR TITLE
Use measurement token in auxflash reset as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,6 @@ dependencies = [
  "humility-cortex",
  "humility-probes-core",
  "ihex",
- "measurement-token",
  "num-traits",
  "parse_int",
  "path-slash",
@@ -2359,6 +2358,7 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
+ "measurement-token",
  "multimap",
  "num-derive 0.4.2",
  "num-traits",
@@ -2828,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "measurement-token"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/lpc55_support#936f7d55b76d35165816f6f876f9fa9390fd4f5a"
+source = "git+https://github.com/oxidecomputer/lpc55_support#b507bc6d5dbebabc1d4c9b1ea3c8f24afd68fcae"
 
 [[package]]
 name = "memchr"

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -353,7 +353,7 @@ impl<'a> AuxFlashHandler<'a> {
     }
 
     pub fn reset(&mut self) -> Result<()> {
-        self.core.reset()
+        self.core.reset_with_handoff(self.hubris)
     }
 
     pub fn auxflash_write_from_archive(

--- a/cmd/flash/Cargo.toml
+++ b/cmd/flash/Cargo.toml
@@ -13,7 +13,6 @@ humility-probes-core = { workspace = true }
 cmd-auxflash = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
-measurement-token = { workspace = true }
 parse_int = { workspace = true }
 num-traits = { workspace = true }
 tempfile = { workspace = true }

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -140,10 +140,6 @@ impl<'a> EepromHandler<'a> {
         humility::msg!("done");
         Ok(())
     }
-
-    pub fn reset(&mut self) -> Result<()> {
-        self.core.reset()
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -21,6 +21,7 @@ idol.workspace = true
 indexmap.workspace = true
 indicatif.workspace = true
 log.workspace = true
+measurement-token.workspace = true
 multimap.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true


### PR DESCRIPTION
This moves "reset with measurement token handoff" into a new `Core::reset_with_handoff`, which is implemented by default on all `Core` types.  Then, we use this function in both post-flashing and auxflash reset.

I also deleted `EepromHandler::reset` because it was unused.