### PR TITLE
Increment `halted` in `reset_and_halt`

### DIFF
--- a/humility-probes-core/src/probe_rs.rs
+++ b/humility-probes-core/src/probe_rs.rs
@@ -302,6 +302,7 @@ impl Core for ProbeCore {
     fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()> {
         let mut core = self.session.core(0)?;
         core.reset_and_halt(dur)?;
+        self.halted += 1;
         Ok(())
     }
 


### PR DESCRIPTION
Otherwise, we can underflow when `run` is called.