### PR TITLE
Get sockets from manifest

### DIFF
--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -244,6 +244,30 @@ fn manifestcmd(context: &mut ExecutionContext) -> Result<()> {
         }
     }
 
+    if !manifest.sockets.is_empty() {
+        println!(
+            "{:>12} => {} socket{}",
+            "sockets",
+            manifest.sockets.len(),
+            if manifest.sockets.len() != 1 { "s" } else { "" }
+        );
+        println!(
+            "               {:20} {:5} {:>6} {:>7} {}",
+            "NAME", "KIND", "PORT", "RXSIZE", "OWNER"
+        );
+
+        for socket in &manifest.sockets {
+            println!(
+                "               {:20} {:5} {:>6} {:>7} {}",
+                socket.name,
+                socket.kind,
+                socket.port,
+                socket.rx.bytes,
+                socket.owner.name,
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -364,7 +364,7 @@ pub struct RpcClient<'a> {
     hubris: &'a HubrisArchive,
     socket: UdpSocket,
     rpc_reply_type: &'a HubrisEnum,
-    buf: [u8; 1024], // matches buffer size in `task-udprpc`
+    buf: Vec<u8>, // sized to match socket buffer size
 }
 
 impl<'a> RpcClient<'a> {
@@ -373,8 +373,8 @@ impl<'a> RpcClient<'a> {
         ip: ScopedV6Addr,
         timeout: Duration,
     ) -> Result<Self> {
-        // Hard-coded socket address, based on Hubris configuration
-        let target = format!("[{ip}]:998");
+        let udprpc = hubris.manifest.get_socket_by_task("udprpc")?;
+        let target = format!("[{ip}]:{}", udprpc.port);
 
         let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
         let socket = UdpSocket::bind("[::]:0")?;
@@ -393,7 +393,8 @@ impl<'a> RpcClient<'a> {
             .lookup_enum_byname(hubris, "RpcReply")?
             .ok_or_else(|| anyhow!("can't find RpcReply"))?;
 
-        Ok(Self { hubris, socket, rpc_reply_type, buf: [0; 1024] })
+        let buf = vec![0u8; udprpc.tx.bytes];
+        Ok(Self { hubris, socket, rpc_reply_type, buf })
     }
 
     pub fn call(

--- a/humility-bin/tests/cmd/manifest/manifest.chilly.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.chilly.0.stdout
@@ -156,3 +156,6 @@
                  74 DIMM_G1                 i2c id=39   temp
                  75 DIMM_H0                 i2c id=40   temp
                  76 DIMM_H1                 i2c id=41   temp
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.control_plane_agent.overflow.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.control_plane_agent.overflow.0.stdout
@@ -258,3 +258,10 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 5 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector

--- a/humility-bin/tests/cmd/manifest/manifest.counters.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.counters.0.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.duplicate_HostFlash_hash_REPLY.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.duplicate_HostFlash_hash_REPLY.stdout
@@ -184,3 +184,9 @@
                  74 DIMM_G1                 i2c id=61   temp
                  75 DIMM_H0                 i2c id=62   temp
                  76 DIMM_H1                 i2c id=63   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               mgmt_gateway         udp    11111    2048 mgmt_gateway

--- a/humility-bin/tests/cmd/manifest/manifest.extern-regions.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.extern-regions.stdout
@@ -258,3 +258,10 @@
                 130 DIMM_G1                 i2c id=74   temp
                 131 DIMM_H0                 i2c id=75   temp
                 132 DIMM_H1                 i2c id=76   temp
+     sockets => 5 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent

--- a/humility-bin/tests/cmd/manifest/manifest.flash-ram-mismatch.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.flash-ram-mismatch.0.stdout
@@ -158,3 +158,7 @@
                  74 DIMM_G1                 i2c id=39   temp
                  75 DIMM_H0                 i2c id=40   temp
                  76 DIMM_H1                 i2c id=41   temp
+     sockets => 2 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast

--- a/humility-bin/tests/cmd/manifest/manifest.gimlet-c-dev-image-default-v1.0.2.zip.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.gimlet-c-dev-image-default-v1.0.2.zip.stdout
@@ -258,3 +258,10 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 5 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.host-panic.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.host-panic.0.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.host-panic.1.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.host-panic.1.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.host-panic.2.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.host-panic.2.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.host-panic.3.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.host-panic.3.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.host-panic.4.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.host-panic.4.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.idol-returns-an-enum.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.idol-returns-an-enum.stdout
@@ -258,3 +258,10 @@
                 130 DIMM_G1                 i2c id=74   temp
                 131 DIMM_H0                 i2c id=75   temp
                 132 DIMM_H1                 i2c id=76   temp
+     sockets => 5 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent

--- a/humility-bin/tests/cmd/manifest/manifest.igor.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.igor.0.stdout
@@ -253,3 +253,9 @@
                 130 DIMM_G1                 i2c id=73   temp
                 131 DIMM_H0                 i2c id=74   temp
                 132 DIMM_H1                 i2c id=75   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.in_bootloader.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.in_bootloader.0.stdout
@@ -158,3 +158,7 @@
                  74 DIMM_G1                 i2c id=39   temp
                  75 DIMM_H0                 i2c id=40   temp
                  76 DIMM_H1                 i2c id=41   temp
+     sockets => 2 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast

--- a/humility-bin/tests/cmd/manifest/manifest.ipc-counts.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.ipc-counts.0.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.kernel-panic.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.kernel-panic.0.stdout
@@ -27,3 +27,6 @@
    i2c buses => 1 controller, 1 bus
                 C PORT MODE NAME          DESCRIPTION
                 2 F    init -             -
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.kernel-panic.1.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.kernel-panic.1.stdout
@@ -254,3 +254,9 @@
                 130 DIMM_G1                 i2c id=73   temp
                 131 DIMM_H0                 i2c id=74   temp
                 132 DIMM_H1                 i2c id=75   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.kiowa.26.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.kiowa.26.stdout
@@ -25,3 +25,6 @@
    i2c buses => 1 controller, 1 bus
                 C PORT MODE NAME          DESCRIPTION
                 2 F    init -             -
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.new-ringbuf.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.new-ringbuf.stdout
@@ -153,3 +153,10 @@
                  60 V1P8_SYS                i2c id=25   current
                  61 V1P8_SYS                i2c id=25   voltage
                  62 vsc7448                 i2c id=26   temp
+     sockets => 5 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               transceivers         udp    11112    2048 transceivers

--- a/humility-bin/tests/cmd/manifest/manifest.nightly-2022-11-01.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.nightly-2022-11-01.stdout
@@ -254,3 +254,9 @@
                 130 DIMM_G1                 i2c id=73   temp
                 131 DIMM_H0                 i2c id=74   temp
                 132 DIMM_H1                 i2c id=75   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.panic-on-boot.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.panic-on-boot.stdout
@@ -254,3 +254,9 @@
                 130 DIMM_G1                 i2c id=73   temp
                 131 DIMM_H0                 i2c id=74   temp
                 132 DIMM_H1                 i2c id=75   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.sidecar-b-image-default.zip.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.sidecar-b-image-default.zip.stdout
@@ -186,3 +186,11 @@
                  94 xcvr29                  qsfp        temp
                  95 xcvr30                  qsfp        temp
                  96 xcvr31                  qsfp        temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               transceivers         udp    11112    2048 transceivers

--- a/humility-bin/tests/cmd/manifest/manifest.spoopy.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.spoopy.0.stdout
@@ -123,3 +123,6 @@
                  58 V12_SYS_A2              i2c id=25   power
                  59 V12_SYS_A2              i2c id=25   current
                  60 V12_SYS_A2              i2c id=25   voltage
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.sprot_status.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.sprot_status.stdout
@@ -254,3 +254,9 @@
                 130 DIMM_G1                 i2c id=73   temp
                 131 DIMM_H0                 i2c id=74   temp
                 132 DIMM_H1                 i2c id=75   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.static-tasks.0.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.static-tasks.0.stdout
@@ -30,3 +30,6 @@
                 2 F    init -             -
                 3 C    init -             -
                 4 F    init -             -
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.static-tasks.1.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.static-tasks.1.stdout
@@ -30,3 +30,6 @@
                 2 F    init -             -
                 3 C    init -             -
                 4 F    init -             -
+     sockets => 1 socket
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho

--- a/humility-bin/tests/cmd/manifest/manifest.task.net.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.task.net.stdout
@@ -258,3 +258,9 @@
                 130 DIMM_G1                 i2c id=74   temp
                 131 DIMM_H0                 i2c id=75   temp
                 132 DIMM_H1                 i2c id=76   temp
+     sockets => 4 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               rpc                  udp      998    1024 udprpc
+               control_plane_agent  udp    11111    2048 control_plane_agent

--- a/humility-bin/tests/cmd/manifest/manifest.task.power.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.task.power.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-bin/tests/cmd/manifest/manifest.u16-ringbuf.stdout
+++ b/humility-bin/tests/cmd/manifest/manifest.u16-ringbuf.stdout
@@ -259,3 +259,11 @@
                 130 DIMM_H1                 i2c id=74   temp
                 131 M2_A                    i2c id=75   temp
                 132 M2_B                    i2c id=76   temp
+     sockets => 6 sockets
+               NAME                 KIND    PORT  RXSIZE OWNER
+               echo                 udp        7    1024 udpecho
+               broadcast            udp      997    1024 udpbroadcast
+               control_plane_agent  udp    11111    2048 control_plane_agent
+               dump_agent           udp    11113    1024 dump_agent
+               inspector            udp    23547     512 gimlet_inspector
+               rpc                  udp      998    1024 udprpc

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -59,7 +59,16 @@ pub struct HubrisManifest {
     pub i2c_devices: Vec<HubrisI2cDevice>,
     pub i2c_buses: Vec<HubrisI2cBus>,
     pub sensors: Vec<HubrisSensor>,
+    pub sockets: Vec<HubrisSocket>,
     pub auxflash: Option<HubrisConfigAuxflash>,
+}
+
+impl HubrisManifest {
+    pub fn get_socket_by_task(&self, task: &str) -> Result<&HubrisSocket> {
+        self.sockets.iter().find(|s| s.owner.name == task).ok_or_else(|| {
+            anyhow!("couldn't find socket with owner {:?}", task)
+        })
+    }
 }
 
 //
@@ -241,8 +250,24 @@ impl HubrisConfigAuxflash {
 #[derive(Clone, Debug, Deserialize)]
 struct HubrisConfigConfig {
     i2c: Option<HubrisConfigI2c>,
+    net: Option<HubrisConfigNet>,
     sensor: Option<HubrisConfigSensor>,
     auxflash: Option<HubrisConfigAuxflash>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct HubrisConfigNet {
+    #[serde(default)]
+    sockets: IndexMap<String, HubrisConfigSocket>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct HubrisConfigSocket {
+    kind: String,
+    owner: HubrisSocketOwner,
+    port: u16,
+    tx: HubrisSocketBuffer,
+    rx: HubrisSocketBuffer,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -367,6 +392,92 @@ pub struct HubrisSensor {
     pub name: String,
     pub kind: HubrisSensorKind,
     pub device: HubrisSensorDevice,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct HubrisSocket {
+    pub name: String,
+    pub kind: String,
+    pub owner: HubrisSocketOwner,
+    pub port: u16,
+    pub tx: HubrisSocketBuffer,
+    pub rx: HubrisSocketBuffer,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HubrisSocketOwner {
+    pub name: String,
+    #[serde(deserialize_with = "deserialize_notification")]
+    pub notification: HubrisSocketNotification,
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+pub struct HubrisSocketBuffer {
+    pub packets: usize,
+    pub bytes: usize,
+}
+
+use serde::de::{self, Deserializer, Visitor};
+
+#[derive(Debug, Clone)]
+pub enum HubrisSocketNotification {
+    Bit(u64),
+    Named(String),
+}
+
+/// Deserialize a `HubrisSocketNotification` from either a string or integer
+fn deserialize_notification<'de, D>(
+    deserializer: D,
+) -> Result<HubrisSocketNotification, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct NotificationVisitor;
+    impl<'de> Visitor<'de> for NotificationVisitor {
+        type Value = HubrisSocketNotification;
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string or an integer")
+        }
+
+        fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(HubrisSocketNotification::Bit(v))
+        }
+
+        // Handle the case where the value is an integer
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            match u64::try_from(v) {
+                Ok(v) => self.visit_u64(v),
+                Err(_) => Err(E::custom("i64 must be positive")),
+            }
+        }
+
+        // Handle the case where the value is a string, and parse it
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(HubrisSocketNotification::Named(v.to_owned()))
+        }
+    }
+    deserializer.deserialize_any(NotificationVisitor)
+}
+
+impl Serialize for HubrisSocketNotification {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            HubrisSocketNotification::Bit(i) => serializer.serialize_u64(*i),
+            HubrisSocketNotification::Named(n) => serializer.serialize_str(n),
+        }
+    }
 }
 
 impl fmt::Display for HubrisSensorKind {
@@ -1161,6 +1272,20 @@ impl HubrisArchive {
             }
             if let Some(sensor) = config.sensor.as_ref() {
                 self.load_sensor_config(sensor)?;
+            }
+            if let Some(net) = config.net.as_ref() {
+                self.manifest.sockets = net
+                    .sockets
+                    .iter()
+                    .map(|(name, cfg)| HubrisSocket {
+                        name: name.clone(),
+                        kind: cfg.kind.clone(),
+                        owner: cfg.owner.clone(),
+                        port: cfg.port,
+                        tx: cfg.tx,
+                        rx: cfg.rx,
+                    })
+                    .collect();
             }
         }
 
@@ -1970,6 +2095,13 @@ impl HubrisArchive {
         (0..self.ntasks())
             .map(|t| self.lookup_module(HubrisTask::Task(t as u32)).unwrap())
             .find(|t| t.iface.as_ref().map(|i| i.name == name).unwrap_or(false))
+    }
+
+    pub fn get_socket_by_iface(&self, iface: &str) -> Result<&HubrisSocket> {
+        let module = self.lookup_module_by_iface(iface).ok_or_else(|| {
+            anyhow!("couldn't find task implementing {:?}", iface)
+        })?;
+        self.manifest.get_socket_by_task(&module.name)
     }
 
     pub fn modules(&self) -> impl Iterator<Item = &HubrisModule> {

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -442,6 +442,9 @@ impl<'a> HiffyContext<'a> {
             bail!("can't make non-Idol calls over RPC");
         }
 
+        // Find the socket that we'll be using to communicate
+        let udprpc = self.hubris.manifest.get_socket_by_task("udprpc")?;
+
         // Pick values that are much larger than we'd ever see on a machine
         const HIFFY_TEXT_SIZE: usize = 65536;
         const HIFFY_RSTACK_SIZE: usize = 65536;
@@ -477,6 +480,9 @@ impl<'a> HiffyContext<'a> {
             hubris: Option<std::ptr::NonNull<HubrisArchive>>,
             core: Option<std::ptr::NonNull<dyn Core>>,
 
+            /// Socket used for communication
+            socket: Option<HubrisSocket>,
+
             /// If we receive an RPC result, then record the buffer here
             results: Vec<Vec<u8>>,
 
@@ -489,6 +495,7 @@ impl<'a> HiffyContext<'a> {
                     HiffySendWorkspace {
                         hubris: None,
                         core: None,
+                        socket: None,
                         results: vec![],
                         errors: vec![],
                     });
@@ -538,8 +545,7 @@ impl<'a> HiffyContext<'a> {
                     .map_err(|_| Failure::Fault(Fault::BadParameter(2)))?;
             }
 
-            let mut buf = [0u8; 1024]; // matches buffer size in `task-udprpc`
-            HIFFY_SEND_WORKSPACE.with(|workspace| {
+            let buf = HIFFY_SEND_WORKSPACE.with(|workspace| {
                 let mut workspace = workspace.borrow_mut();
                 let (hubris, core) = {
                     // SAFETY: we only ever call this function when the pointers
@@ -553,6 +559,9 @@ impl<'a> HiffyContext<'a> {
                         )
                     }
                 };
+                let socket = workspace.socket.as_ref().unwrap();
+
+                let mut buf = vec![0u8; socket.tx.bytes];
                 let image_id = hubris.image_id().unwrap();
 
                 let header = RpcHeader {
@@ -565,6 +574,15 @@ impl<'a> HiffyContext<'a> {
 
                 let mut packet = header.as_bytes().to_vec();
                 packet.extend(&payload[0..nbytes as usize]);
+                if packet.len() > socket.rx.bytes {
+                    let e = anyhow!(
+                        "packet length {} exceeds rx buf size {}",
+                        packet.len(),
+                        socket.rx.bytes,
+                    );
+                    workspace.errors.push(e);
+                    return Err(Failure::FunctionError(0));
+                }
 
                 // Send the packet out
                 if let Err(e) = core.send(&packet, NetAgent::UdpRpc) {
@@ -575,8 +593,9 @@ impl<'a> HiffyContext<'a> {
                 // Try to receive a reply
                 match core.recv(buf.as_mut_slice(), NetAgent::UdpRpc) {
                     Ok(n) => {
-                        workspace.results.push(buf[0..n].to_vec());
-                        Ok(())
+                        buf.truncate(n);
+                        workspace.results.push(buf.clone());
+                        Ok(buf)
                     }
                     Err(e) => {
                         workspace.errors.push(e);
@@ -663,6 +682,7 @@ impl<'a> HiffyContext<'a> {
                     .unwrap(),
                 ),
 
+                socket: Some(udprpc.clone()),
                 results: vec![],
                 errors: vec![],
             };

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -15,7 +15,9 @@
 use anyhow::{Context, Result, anyhow, bail};
 use humility::{
     core::{Core, NetAgent},
-    hubris::{HubrisArchive, HubrisFlashMap, HubrisRegion, HubrisTask},
+    hubris::{
+        HubrisArchive, HubrisFlashMap, HubrisRegion, HubrisSocket, HubrisTask,
+    },
     msg,
     net::ScopedV6Addr,
 };
@@ -50,45 +52,30 @@ impl NetCore {
         hubris: &HubrisArchive,
         timeout: Duration,
     ) -> Result<Self> {
-        let udprpc_socket = if hubris.lookup_task("udprpc").is_some() {
-            // See oxidecomputer/oana for standard Hubris UDP ports
-            let target = format!("[{addr}]:998");
-
+        let open_socket = |socket: &HubrisSocket| -> Result<_> {
+            let target = format!("[{addr}]:{}", socket.port);
             let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
-            let udprpc_socket = UdpSocket::bind("[::]:0")?;
-            udprpc_socket.set_read_timeout(Some(timeout))?;
-            udprpc_socket.connect(&dest[..])?;
-            Some(udprpc_socket)
-        } else {
-            None
+            let socket = UdpSocket::bind("[::]:0")?;
+            socket.set_read_timeout(Some(timeout))?;
+            socket.connect(&dest[..])?;
+            Ok(socket)
         };
+        let udprpc_socket = hubris
+            .manifest
+            .get_socket_by_task("udprpc")
+            .ok()
+            .map(open_socket)
+            .transpose()?;
 
         // We'll check to see if there's a dump agent available over UDP, which
         // means
         // 1) There's a task implementing the `DumpAgent` interface
-        // 2) That task has the `net` feature enabled
-
-        // Find the dump agent task name.  This is usually `dump_agent`, but
-        // that's not guaranteed; what *is* guaranteed is that it implements the
-        // DumpAgent interface.
-        let dump_agent_task =
-            hubris.lookup_module_by_iface("DumpAgent").map(|t| t.task);
-        let has_dump_agent = dump_agent_task
-            .map(|t| hubris.does_task_have_feature(t, "net").unwrap())
-            .unwrap_or(false);
-
-        //
-        // See oxidecomputer/oana for standard Hubris UDP ports
-        let dump_agent_socket = if has_dump_agent {
-            let target = format!("[{addr}]:11113");
-            let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
-            let dump_agent_socket = UdpSocket::bind("[::]:0")?;
-            dump_agent_socket.set_read_timeout(Some(timeout))?;
-            dump_agent_socket.connect(&dest[..])?;
-            Some(dump_agent_socket)
-        } else {
-            None
-        };
+        // 2) That task has an associated socket
+        let dump_agent_socket = hubris
+            .get_socket_by_iface("DumpAgent")
+            .ok()
+            .map(open_socket)
+            .transpose()?;
 
         let mut out = Self {
             udprpc_socket,


### PR DESCRIPTION
We previously hard-coded socket ports (fine) and sizes (ehhhhh) based on expected services.

This isn't particularly robust – we expect ports to be stable (because they're assigned in OANA), but buffer sizes may vary from image to image.

This PR parses socket data into our `HubrisManifest`, then uses it when talking to the SP.  It also removes repeated code in socket construction, and does other miscellaneous cleanups.

As always, most of the LOC changes are in snapshot tests, because I've added socket printing to `humility manifest`.