### PR TITLE
Remove call functionality from `humility rpc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,6 +1311,7 @@ dependencies = [
  "humility-cmd-dashboard",
  "humility-cmd-debugmailbox",
  "humility-cmd-diagnose",
+ "humility-cmd-discover",
  "humility-cmd-doc",
  "humility-cmd-dump",
  "humility-cmd-exec",
@@ -1347,7 +1348,6 @@ dependencies = [
  "humility-cmd-rendmp",
  "humility-cmd-reset",
  "humility-cmd-ringbuf",
- "humility-cmd-rpc",
  "humility-cmd-sbrmi",
  "humility-cmd-sensors",
  "humility-cmd-spctrl",
@@ -1512,6 +1512,29 @@ dependencies = [
  "humility-doppel",
  "humility-jefe",
  "parse_int",
+]
+
+[[package]]
+name = "humility-cmd-discover"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.23",
+ "colored",
+ "hif",
+ "hubpack",
+ "humility-cli",
+ "humility-cmd",
+ "humility-cmd-hiffy",
+ "humility-core",
+ "humility-doppel",
+ "humility-hiffy",
+ "humility-idol",
+ "idol",
+ "indexmap 1.9.3",
+ "parse_int",
+ "serde",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2107,29 +2130,6 @@ dependencies = [
  "humility-cmd",
  "humility-core",
  "humility-doppel",
-]
-
-[[package]]
-name = "humility-cmd-rpc"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap 3.2.23",
- "colored",
- "hif",
- "hubpack",
- "humility-cli",
- "humility-cmd",
- "humility-cmd-hiffy",
- "humility-core",
- "humility-doppel",
- "humility-hiffy",
- "humility-idol",
- "idol",
- "indexmap 1.9.3",
- "parse_int",
- "serde",
- "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "cmd/doc",
     "cmd/dump",
     "cmd/tofino-eeprom",
+    "cmd/discover",
     "cmd/exec",
     "cmd/extract",
     "cmd/flash",
@@ -41,7 +42,6 @@ members = [
     "cmd/hiffy",
     "cmd/host",
     "cmd/hydrate",
-    "cmd/rpc",
     "cmd/i2c",
     "cmd/ibc",
     "cmd/jefe",
@@ -140,6 +140,7 @@ cmd-counters = { path = "./cmd/counters", package = "humility-cmd-counters" }
 cmd-dashboard = { path = "./cmd/dashboard", package = "humility-cmd-dashboard" }
 cmd-diagnose = { path = "./cmd/diagnose", package = "humility-cmd-diagnose" }
 cmd-debugmailbox = { path = "./cmd/debugmailbox", package = "humility-cmd-debugmailbox" }
+cmd-discover = { path = "./cmd/discover", package = "humility-cmd-discover" }
 cmd-doc = { path = "./cmd/doc", package = "humility-cmd-doc" }
 cmd-dump = { path = "./cmd/dump", package = "humility-cmd-dump" }
 cmd-tofino-eeprom = { path = "./cmd/tofino-eeprom", package = "humility-cmd-tofino-eeprom" }
@@ -177,7 +178,6 @@ cmd-reset = { path = "./cmd/reset", package = "humility-cmd-reset" }
 cmd-rencm = { path = "./cmd/rencm", package = "humility-cmd-rencm" }
 cmd-rendmp = { path = "./cmd/rendmp", package = "humility-cmd-rendmp" }
 cmd-ringbuf = { path = "./cmd/ringbuf", package = "humility-cmd-ringbuf" }
-cmd-rpc = { path = "./cmd/rpc", package = "humility-cmd-rpc" }
 cmd-sbrmi = { path = "./cmd/sbrmi", package = "humility-cmd-sbrmi" }
 cmd-sensors = { path = "./cmd/sensors", package = "humility-cmd-sensors" }
 cmd-spctrl = { path = "./cmd/spctrl", package = "humility-cmd-spctrl" }

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility repl](#humility-repl): read, eval, print, loop
 - [humility reset](#humility-reset): Reset the chip using external pins
 - [humility ringbuf](#humility-ringbuf): read and display a specified ring buffer
-- [humility rpc](#humility-rpc): execute Idol calls over a network
+- [humility rpc](#humility-rpc): listen for compatible SPs on a network
 - [humility sbrmi](#humility-sbrmi): Sideband Remote Management Interface (SB-RMI) commands
 - [humility sensors](#humility-sensors): query sensors and sensor data
 - [humility spctrl](#humility-spctrl): RoT -> SP control
@@ -2763,26 +2763,9 @@ documentation](https://github.com/oxidecomputer/hubris/blob/master/lib/ringbuf/s
 
 ### `humility rpc`
 
-`humility rpc` allows for execution of Idol commands over a network, rather
-than through a debugger.
-
-It requires the Hubris `udprpc` task to be listening on port 8.  This task
-decodes bytes from a UDP packet, and shoves them directly into `sys_send` to
-a target task.
-
-An archive is required so that `humility` knows what functions are available
-and how to call them.  The archive ID is checked against the image ID on the
-target; `udprpc` will refuse to execute commands when the ID does not match.
-
-Function calls are handled identically to the `humility hiffy` subcommand,
-except that an `--ip` address is required:
-
-```console
-$ humility rpc --ip fe80::0c1d:9aff:fe64:b8c2%en0 -c UserLeds.led_on -aindex=0
-UserLeds.led_on() = ()
-```
-
-Alternatively, you can set the `HUMILITY_RPC_IP` environmental variable.
+`humility rpc` lets you discover SPs on a network, instead of using a
+physically attached debugger.  Once SPs are discovered, they may be used as
+a target by setting `HUMILITY_IP` or providing the `--ip` argument.
 
 You may need to configure an IPv6 network for `humility rpc` to work. On
 illumos, it looks like this:
@@ -2811,9 +2794,6 @@ When listening, it is mandatory to specify the interface (e.g. `humility rpc
 not include identity information. If they are marked as `(vpdfail)`, they
 are running a new-enough `udpbroadcast`, but the SP was unable to read its
 identity from its VPD.
-
-To call all targets that match an archive, `--listen` can be combined with
-`--call`
 
 
 ### `humility sbrmi`

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility dashboard](#humility-dashboard): dashboard for Hubris sensor data
 - [humility debugmailbox](#humility-debugmailbox): interact with the debug mailbox on the LPC55
 - [humility diagnose](#humility-diagnose): analyze a system to detect common problems
+- [humility discover](#humility-discover): listen for compatible SPs on a network
 - [humility doc](#humility-doc): print command documentation
 - [humility dump](#humility-dump): generate Hubris dump
 - [humility exec](#humility-exec): execute command within context of an environment
@@ -276,7 +277,6 @@ a specified target.  (In the above example, one could execute `humility
 - [humility repl](#humility-repl): read, eval, print, loop
 - [humility reset](#humility-reset): Reset the chip using external pins
 - [humility ringbuf](#humility-ringbuf): read and display a specified ring buffer
-- [humility rpc](#humility-rpc): listen for compatible SPs on a network
 - [humility sbrmi](#humility-sbrmi): Sideband Remote Management Interface (SB-RMI) commands
 - [humility sensors](#humility-sensors): query sensors and sensor data
 - [humility spctrl](#humility-spctrl): RoT -> SP control
@@ -551,6 +551,40 @@ reporting issues in a running system. It's mostly concerned with
 This is application-independent logic, so it doesn't have any visibility
 into things the _application_ may think are fishy -- only general behaviors
 at the OS level, like faults.
+
+
+### `humility discover`
+
+`humility discover` lets you discover SPs on a network, instead of using a
+physically attached debugger.  Once SPs are discovered, they may be used as
+a target by setting `HUMILITY_IP` or providing the `--ip` argument.
+
+You may need to configure an IPv6 network for `humility discover` to work. On
+illumos, it looks like this:
+
+```console
+$ pfexec ipadm create-addr -t -T addrconf e1000g0/addrconf
+```
+
+To listen for compatible devices on your network, run `humility discover`
+
+```console
+$ humility discover
+humility: listening... (ctrl-C to stop, or timeout in 5s)
+MAC               IPv6                      COMPAT PART        REV SERIAL
+a8:40:25:04:02:81 fe80::aa40:25ff:fe04:281  Yes    913-0000019   6 BRM42220066
+a8:40:25:05:05:00 fe80::aa40:25ff:fe05:500  No     (legacy)      0 (legacy)
+a8:40:25:05:05:00 fe80::aa40:25ff:fe05:501  No     (legacy)      0 (legacy)
+```
+
+Under the hood, this listens for packets from the Hubris `udpbroadcast`
+task, which includes MAC address and image ID (checked for compatibility).
+When listening, it is mandatory to specify the interface (e.g. `humility
+discover  -i en0` on MacOS). If the `Part` / `Serial` columns are
+marked as `(legacy)`, the SP is running an older version of `udpbroadcast`
+that did not include identity information. If they are marked as
+`(vpdfail)`, they are running a new-enough `udpbroadcast`, but the SP was
+unable to read its identity from its VPD.
 
 
 ### `humility doc`
@@ -2759,41 +2793,6 @@ entire series); this can be effected with the `--expand` option.
 
 See the [`ringbuf`
 documentation](https://github.com/oxidecomputer/hubris/blob/master/lib/ringbuf/src/lib.rs) for more details.
-
-
-### `humility rpc`
-
-`humility rpc` lets you discover SPs on a network, instead of using a
-physically attached debugger.  Once SPs are discovered, they may be used as
-a target by setting `HUMILITY_IP` or providing the `--ip` argument.
-
-You may need to configure an IPv6 network for `humility rpc` to work. On
-illumos, it looks like this:
-
-```console
-$ pfexec ipadm create-addr -t -T addrconf e1000g0/addrconf
-```
-
-To listen for compatible devices on your network, run `humility rpc
---listen`
-
-```console
-$ humility rpc --listen
-humility: listening... (ctrl-C to stop, or timeout in 5s)
-MAC               IPv6                      COMPAT PART        REV SERIAL
-a8:40:25:04:02:81 fe80::aa40:25ff:fe04:281  Yes    913-0000019   6 BRM42220066
-a8:40:25:05:05:00 fe80::aa40:25ff:fe05:500  No     (legacy)      0 (legacy)
-a8:40:25:05:05:00 fe80::aa40:25ff:fe05:501  No     (legacy)      0 (legacy)
-```
-
-Under the hood, this listens for packets from the Hubris `udpbroadcast`
-task, which includes MAC address and image ID (checked for compatibility).
-When listening, it is mandatory to specify the interface (e.g. `humility rpc
---listen -i en0` on MacOS). If the `Part` / `Serial` columns are marked as
-`(legacy)`, the SP is running an older version of `udpbroadcast` that did
-not include identity information. If they are marked as `(vpdfail)`, they
-are running a new-enough `udpbroadcast`, but the SP was unable to read its
-identity from its VPD.
 
 
 ### `humility sbrmi`

--- a/cmd/discover/Cargo.toml
+++ b/cmd/discover/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "humility-cmd-rpc"
+name = "humility-cmd-discover"
 version = "0.1.0"
 edition.workspace = true
 description = "listen for compatible SPs on a network"

--- a/cmd/discover/src/lib.rs
+++ b/cmd/discover/src/lib.rs
@@ -2,24 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! ## `humility rpc`
+//! ## `humility discover`
 //!
-//! `humility rpc` lets you discover SPs on a network, instead of using a
+//! `humility discover` lets you discover SPs on a network, instead of using a
 //! physically attached debugger.  Once SPs are discovered, they may be used as
 //! a target by setting `HUMILITY_IP` or providing the `--ip` argument.
 //!
-//! You may need to configure an IPv6 network for `humility rpc` to work. On
+//! You may need to configure an IPv6 network for `humility discover` to work. On
 //! illumos, it looks like this:
 //!
 //! ```console
 //! $ pfexec ipadm create-addr -t -T addrconf e1000g0/addrconf
 //! ```
 //!
-//! To listen for compatible devices on your network, run `humility rpc
-//! --listen`
+//! To listen for compatible devices on your network, run `humility discover`
 //!
 //! ```console
-//! $ humility rpc --listen
+//! $ humility discover
 //! humility: listening... (ctrl-C to stop, or timeout in 5s)
 //! MAC               IPv6                      COMPAT PART        REV SERIAL
 //! a8:40:25:04:02:81 fe80::aa40:25ff:fe04:281  Yes    913-0000019   6 BRM42220066
@@ -29,12 +28,12 @@
 //!
 //! Under the hood, this listens for packets from the Hubris `udpbroadcast`
 //! task, which includes MAC address and image ID (checked for compatibility).
-//! When listening, it is mandatory to specify the interface (e.g. `humility rpc
-//! --listen -i en0` on MacOS). If the `Part` / `Serial` columns are marked as
-//! `(legacy)`, the SP is running an older version of `udpbroadcast` that did
-//! not include identity information. If they are marked as `(vpdfail)`, they
-//! are running a new-enough `udpbroadcast`, but the SP was unable to read its
-//! identity from its VPD.
+//! When listening, it is mandatory to specify the interface (e.g. `humility
+//! discover  -i en0` on MacOS). If the `Part` / `Serial` columns are
+//! marked as `(legacy)`, the SP is running an older version of `udpbroadcast`
+//! that did not include identity information. If they are marked as
+//! `(vpdfail)`, they are running a new-enough `udpbroadcast`, but the SP was
+//! unable to read its identity from its VPD.
 
 use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv6Addr, UdpSocket};
@@ -51,10 +50,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Parser, Debug)]
 #[clap(
-    name = "rpc", about = env!("CARGO_PKG_DESCRIPTION"),
+    name = "discover", about = env!("CARGO_PKG_DESCRIPTION"),
     group = ArgGroup::new("target").multiple(false)
 )]
-struct RpcArgs {
+struct DiscoverArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 2000, value_name = "timeout_ms",
@@ -62,21 +61,8 @@ struct RpcArgs {
     )]
     timeout: u32,
 
-    /// list interfaces
-    #[clap(long, short)]
-    list: bool,
-
-    /// listen for compatible SPs on the network
-    #[clap(
-        long,
-        conflicts_with = "list",
-        group = "target",
-        requires = "interface"
-    )]
-    listen: bool,
-
     /// interface on which to listen, e.g. 'en0'
-    #[clap(short, requires = "listen", value_parser = decode_iface)]
+    #[clap(short, value_parser = decode_iface)]
     interface: Option<u32>,
 }
 
@@ -107,7 +93,7 @@ struct Target {
     serial: String,
 }
 
-fn rpc_listen_one(
+fn discover_listen_one(
     timeout: Duration,
     interface: u32,
     port: u32,
@@ -235,11 +221,11 @@ fn rpc_listen_one(
     Ok(seen)
 }
 
-fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
+fn discover_listen(discover_args: &DiscoverArgs) -> Result<BTreeSet<Target>> {
     // For some reason, macOS requires the interface to be non-zero:
     // https://users.rust-lang.org/t/ipv6-upnp-multicast-for-rust-dlna-server-macos/24425
     // https://bluejekyll.github.io/blog/posts/multicasting-in-rust/
-    let interface = match &rpc_args.interface {
+    let interface = match &discover_args.interface {
         None => {
             if cfg!(target_os = "macos") {
                 bail!("Must specify interface with `-i` on macOS");
@@ -250,7 +236,7 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
         Some(iface) => *iface,
     };
 
-    let timeout = Duration::from_millis(rpc_args.timeout as u64);
+    let timeout = Duration::from_millis(discover_args.timeout as u64);
     let ports = [8, 8888];
     humility::msg!(
         "listening for {} seconds on ports {ports:?}...",
@@ -261,7 +247,7 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
         .iter()
         .map(|&port| {
             std::thread::spawn(move || -> Result<BTreeSet<Target>> {
-                rpc_listen_one(timeout, interface, port)
+                discover_listen_one(timeout, interface, port)
             })
         })
         .collect::<Vec<_>>();
@@ -285,13 +271,17 @@ fn rpc_listen(rpc_args: &RpcArgs) -> Result<BTreeSet<Target>> {
     Ok(seen)
 }
 
-fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
+fn discover_dump(seen: BTreeSet<Target>, image_id: Option<&[u8]>) {
     if !seen.is_empty() {
         println!(
-            "{:17} {:25} {:6} {:11} {:3} {:11}",
+            "{:17} {:25}{} {:11} {:3} {:11}",
             "MAC".bold(),
             "IPv6".bold(),
-            "COMPAT".bold(),
+            if image_id.is_some() {
+                format!(" {:6}", "COMPAT".bold())
+            } else {
+                format!(" {:16}", "IMAGE ID".bold())
+            },
             "PART".bold(),
             "REV".bold(),
             "SERIAL".bold(),
@@ -304,10 +294,16 @@ fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
             print!("{:02x}", byte)
         }
         print!(" {:25} ", target.ip);
-        if target.image_id == image_id {
-            print!("{:6}", "Yes".green());
+        if let Some(image_id) = image_id {
+            if target.image_id == image_id {
+                print!("{:6}", "Yes".green());
+            } else {
+                print!("{:6}", "No".red());
+            }
         } else {
-            print!("{:6}", "No".red());
+            for i in target.image_id {
+                print!("{i:02x}");
+            }
         }
         print!(" {:11}", target.part_number);
         print!(" {:3}", target.revision);
@@ -315,25 +311,26 @@ fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
     }
 }
 
-fn rpc_run(context: &mut ExecutionContext) -> Result<()> {
+fn discover_run(context: &mut ExecutionContext) -> Result<()> {
     let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = RpcArgs::try_parse_from(subargs)?;
+    let subargs = DiscoverArgs::try_parse_from(subargs)?;
     let hubris = context.archive.as_ref().unwrap();
 
-    // We previously had more subcommands here, but are down to just `--listen`
-    if subargs.listen {
-        rpc_dump(rpc_listen(&subargs)?, hubris.image_id().unwrap());
-        Ok(())
-    } else {
-        bail!("expected --listen")
+    let image_id = hubris.image_id();
+    if image_id.is_none() {
+        humility::warn!("no archive provided; not checking for compatibility");
     }
+
+    // We previously had more subcommands here, but are down to just `--listen`
+    discover_dump(discover_listen(&subargs)?, image_id);
+    Ok(())
 }
 
 pub fn init() -> Command {
     Command {
-        app: RpcArgs::command(),
-        name: "rpc",
-        run: rpc_run,
-        kind: CommandKind::Detached { archive: Archive::Required },
+        app: DiscoverArgs::command(),
+        name: "discover",
+        run: discover_run,
+        kind: CommandKind::Detached { archive: Archive::Optional },
     }
 }

--- a/cmd/rpc/Cargo.toml
+++ b/cmd/rpc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "humility-cmd-rpc"
 version = "0.1.0"
 edition.workspace = true
-description = "execute Idol calls over a network"
+description = "listen for compatible SPs on a network"
 
 [dependencies]
 humility.workspace = true

--- a/cmd/rpc/src/lib.rs
+++ b/cmd/rpc/src/lib.rs
@@ -4,26 +4,9 @@
 
 //! ## `humility rpc`
 //!
-//! `humility rpc` allows for execution of Idol commands over a network, rather
-//! than through a debugger.
-//!
-//! It requires the Hubris `udprpc` task to be listening on port 8.  This task
-//! decodes bytes from a UDP packet, and shoves them directly into `sys_send` to
-//! a target task.
-//!
-//! An archive is required so that `humility` knows what functions are available
-//! and how to call them.  The archive ID is checked against the image ID on the
-//! target; `udprpc` will refuse to execute commands when the ID does not match.
-//!
-//! Function calls are handled identically to the `humility hiffy` subcommand,
-//! except that an `--ip` address is required:
-//!
-//! ```console
-//! $ humility rpc --ip fe80::0c1d:9aff:fe64:b8c2%en0 -c UserLeds.led_on -aindex=0
-//! UserLeds.led_on() = ()
-//! ```
-//!
-//! Alternatively, you can set the `HUMILITY_RPC_IP` environmental variable.
+//! `humility rpc` lets you discover SPs on a network, instead of using a
+//! physically attached debugger.  Once SPs are discovered, they may be used as
+//! a target by setting `HUMILITY_IP` or providing the `--ip` argument.
 //!
 //! You may need to configure an IPv6 network for `humility rpc` to work. On
 //! illumos, it looks like this:
@@ -52,26 +35,19 @@
 //! not include identity information. If they are marked as `(vpdfail)`, they
 //! are running a new-enough `udpbroadcast`, but the SP was unable to read its
 //! identity from its VPD.
-//!
-//! To call all targets that match an archive, `--listen` can be combined with
-//! `--call`
 
 use std::collections::BTreeSet;
-use std::net::{IpAddr, Ipv6Addr, ToSocketAddrs, UdpSocket};
+use std::net::{IpAddr, Ipv6Addr, UdpSocket};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, bail};
 use clap::{ArgGroup, IntoApp, Parser};
 use colored::Colorize;
 use hubpack::SerializedSize;
-use humility::net::{ScopedV6Addr, decode_iface};
-use humility::{hubris::*, reflect};
+use humility::net::decode_iface;
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Command, CommandKind};
-use humility_doppel::RpcHeader;
-use humility_idol as idol;
 use serde::{Deserialize, Serialize};
-use zerocopy::{AsBytes, U16, U64};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -90,10 +66,6 @@ struct RpcArgs {
     #[clap(long, short)]
     list: bool,
 
-    /// call a particular function
-    #[clap(long, short, conflicts_with = "list", requires = "target")]
-    call: Option<String>,
-
     /// listen for compatible SPs on the network
     #[clap(
         long,
@@ -103,26 +75,9 @@ struct RpcArgs {
     )]
     listen: bool,
 
-    /// arguments
-    #[clap(long, short, requires = "call")]
-    task: Option<String>,
-
     /// interface on which to listen, e.g. 'en0'
     #[clap(short, requires = "listen", value_parser = decode_iface)]
     interface: Option<u32>,
-
-    /// arguments
-    #[clap(long, short, requires = "call", use_delimiter = true)]
-    arguments: Vec<String>,
-
-    /// IPv6 addresses, e.g. `fe80::0c1d:9aff:fe64:b8c2%en0`
-    #[clap(
-        long,
-        env = "HUMILITY_RPC_IP",
-        group = "target",
-        use_value_delimiter = true
-    )]
-    ip: Option<Vec<ScopedV6Addr>>,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, SerializedSize)]
@@ -360,209 +315,18 @@ fn rpc_dump(seen: BTreeSet<Target>, image_id: &[u8]) {
     }
 }
 
-pub struct RpcClient<'a> {
-    hubris: &'a HubrisArchive,
-    socket: UdpSocket,
-    rpc_reply_type: &'a HubrisEnum,
-    buf: Vec<u8>, // sized to match socket buffer size
-}
-
-impl<'a> RpcClient<'a> {
-    pub fn new(
-        hubris: &'a HubrisArchive,
-        ip: ScopedV6Addr,
-        timeout: Duration,
-    ) -> Result<Self> {
-        let udprpc = hubris.manifest.get_socket_by_task("udprpc")?;
-        let target = format!("[{ip}]:{}", udprpc.port);
-
-        let dest = target.to_socket_addrs()?.collect::<Vec<_>>();
-        let socket = UdpSocket::bind("[::]:0")?;
-        socket.set_read_timeout(Some(timeout))?;
-        socket.connect(&dest[..])?;
-
-        let rpc_task = hubris.lookup_task("udprpc").ok_or_else(|| {
-            anyhow!(
-                "Could not find `udprpc` task in this image. \
-                 Only -dev and -lab images include `udprpc`; \
-                 are you running a production image?"
-            )
-        })?;
-        let rpc_reply_type = hubris
-            .lookup_module(rpc_task)?
-            .lookup_enum_byname(hubris, "RpcReply")?
-            .ok_or_else(|| anyhow!("can't find RpcReply"))?;
-
-        let buf = vec![0u8; udprpc.tx.bytes];
-        Ok(Self { hubris, socket, rpc_reply_type, buf })
-    }
-
-    pub fn call(
-        &mut self,
-        op: &idol::IdolOperation,
-        args: &[(&str, idol::IdolArgument)],
-    ) -> Result<Result<reflect::Value, String>> {
-        let payload = op.payload(args)?;
-
-        let our_image_id = self.hubris.image_id().unwrap();
-
-        let nreply = op.reply_size()?;
-
-        let header = RpcHeader {
-            image_id: U64::from_bytes(our_image_id.try_into().unwrap()),
-            task: U16::new(op.task.task().try_into().unwrap()),
-            op: U16::new(op.code),
-            nreply: U16::new(nreply as u16),
-            nbytes: U16::new(payload.len().try_into().unwrap()),
-        };
-        let mut packet = header.as_bytes().to_vec();
-        packet.extend(payload.iter());
-
-        self.socket.send(&packet).context("unable to send packet")?;
-        let n = self
-            .socket
-            .recv(&mut self.buf)
-            .context("unable to receive packet")?;
-        let buf = &self.buf[..n];
-
-        if buf[0] != 0 {
-            // TODO: assumes the discriminator is a u8. It's not clear from
-            // context whether this assumption carries through into the udprpc
-            // task.
-            match self.rpc_reply_type.lookup_variant_by_tag(Tag::from(buf[0])) {
-                Some(e) => {
-                    let msg = format!("Got error from `udprpc`: {}", e.name);
-                    if e.name == "BadImageId" {
-                        bail!(
-                            "{msg}: {:02x?} (Humility) {:02x?} (Hubris)",
-                            our_image_id,
-                            &buf[1..9]
-                        );
-                    } else {
-                        bail!("{msg}");
-                    }
-                }
-                None => bail!("Got unknown error from `udprpc`: {}", buf[0]),
-            }
-        } else {
-            // Check the return code from the Idol call
-            let rc = u32::from_be_bytes(buf[1..5].try_into().unwrap());
-            let val = if rc == 0 { Ok(buf[5..].to_vec()) } else { Err(rc) };
-            let result = humility_hiffy::hiffy_decode(self.hubris, op, val)?;
-            Ok(result)
-        }
-    }
-}
-
-fn rpc_call(
-    hubris: &HubrisArchive,
-    op: &idol::IdolOperation,
-    args: &[(&str, idol::IdolArgument)],
-    ips: Vec<ScopedV6Addr>,
-    timeout: u32,
-) -> Result<()> {
-    let timeout = Duration::from_millis(u64::from(timeout));
-
-    for &ip in &ips {
-        let mut client = RpcClient::new(hubris, ip, timeout)
-            .context("unable to create RpcClient")?;
-        let result = client.call(op, args).context("unable to make call")?;
-        print!("{:25} ", ip);
-        humility_hiffy::hiffy_print_result(hubris, op, result)
-            .context("unable to print result")?;
-    }
-
-    Ok(())
-}
-
 fn rpc_run(context: &mut ExecutionContext) -> Result<()> {
     let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let subargs = RpcArgs::try_parse_from(subargs)?;
     let hubris = context.archive.as_ref().unwrap();
 
-    if subargs.list {
-        cmd_hiffy::hiffy_list(hubris, vec![])?;
-        return Ok(());
-    }
-
-    if subargs.listen && subargs.call.is_none() {
+    // We previously had more subcommands here, but are down to just `--listen`
+    if subargs.listen {
         rpc_dump(rpc_listen(&subargs)?, hubris.image_id().unwrap());
-        return Ok(());
-    }
-
-    // For some reason, macOS requires the interface to be non-zero:
-    // https://users.rust-lang.org/t/ipv6-upnp-multicast-for-rust-dlna-server-macos/24425
-    // https://bluejekyll.github.io/blog/posts/multicasting-in-rust/
-    let interface = match subargs.interface {
-        None => {
-            if cfg!(target_os = "macos") {
-                bail!("Must specify interface with `-i` on macOS");
-            } else {
-                0
-            }
-        }
-        Some(iface) => iface,
-    };
-
-    let ips = if subargs.listen {
-        let image_id = hubris.image_id().unwrap();
-
-        rpc_listen(&subargs)?
-            .iter()
-            .filter(|t| t.image_id == image_id)
-            .map(|target| match target.ip {
-                IpAddr::V4(ip) => bail!(
-                    "target {target:?} had an unanticipated \
-                    IPv4 address ({ip})"
-                ),
-                IpAddr::V6(ip) => Ok(ScopedV6Addr { ip, scopeid: interface }),
-            })
-            .collect::<Result<Vec<_>>>()?
+        Ok(())
     } else {
-        subargs.ip.ok_or_else(|| {
-            anyhow!(
-                "the `--ip <IPS>` argument is required by `humility rpc` \
-                unless `--listen` is also set"
-            )
-        })?
-    };
-
-    if let Some(call) = &subargs.call {
-        if hubris.lookup_task("udprpc").is_none() {
-            bail!("no `udprpc` task in the target image");
-        }
-
-        let func: Vec<&str> = call.split('.').collect();
-
-        if func.len() != 2 {
-            bail!("calls must be interface.operation (-l to list)");
-        }
-
-        let mut args = vec![];
-
-        for arg in &subargs.arguments {
-            let arg: Vec<&str> = arg.split('=').collect();
-
-            if arg.len() != 2 {
-                bail!("arguments must be argument=value (-l to list)");
-            }
-
-            args.push((arg[0], idol::IdolArgument::String(arg[1])));
-        }
-
-        let task = match &subargs.task {
-            Some(task) => Some(hubris.try_lookup_task(task)?),
-            None => None,
-        };
-
-        let op = idol::IdolOperation::new(hubris, func[0], func[1], task)?;
-        rpc_call(hubris, &op, &args, ips, subargs.timeout)
-            .context("failed to make RPC call")?;
-
-        return Ok(());
+        bail!("expected --listen")
     }
-
-    bail!("expected --listen, --list, or --call")
 }
 
 pub fn init() -> Command {

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -41,6 +41,7 @@ cmd-counters = { workspace = true }
 cmd-dashboard = { workspace = true }
 cmd-diagnose = { workspace = true }
 cmd-debugmailbox = { workspace = true, optional = true }
+cmd-discover = { workspace = true }
 cmd-doc = { workspace = true }
 cmd-dump = { workspace = true }
 cmd-tofino-eeprom = { workspace = true }
@@ -78,7 +79,6 @@ cmd-reset = { workspace = true, optional = true }
 cmd-rencm = { workspace = true }
 cmd-rendmp = { workspace = true }
 cmd-ringbuf = { workspace = true }
-cmd-rpc = { workspace = true }
 cmd-sbrmi = { workspace = true }
 cmd-sensors = { workspace = true }
 cmd-spctrl = { workspace = true }

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod env;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{AppSettings, ArgGroup, ArgMatches, Parser};
 use env::Environment;
 use humility::{core::Core, hubris::HubrisArchive, msg, net, warn};
@@ -163,7 +163,8 @@ impl ExecutionContext {
             if let Ok(e) = env::var("HUMILITY_PROBE") {
                 cli.probe = Some(e);
             } else if let Ok(e) = env::var("HUMILITY_IP") {
-                cli.ip = Some(e.parse()?);
+                cli.ip =
+                    Some(e.parse().context("could not parse HUMILITY_IP")?);
             } else if let Ok(e) = env::var("HUMILITY_TARGET") {
                 cli.target = Some(e);
             } else if let Ok(e) = env::var("HUMILITY_DUMP") {


### PR DESCRIPTION
(staged on top of #608)

`humility rpc --ip=... --call ...` is _almost_ identical to `humility --ip=... hiffy --call ...`, and duplicates the calling implementation.  The **one** exception is being able to execute a `udprpc` call across every compatible SP.  I don't think we use that functionality anywhere (searching the whole `oxidecomputer` org finds no users of `humility rpc`), so I'd vote to delete it.

This leaves `humility rpc --listen` as the only subcommand, which is still useful (and not duplicated elsewhere).