### PR TITLE
More laps when waiting for hiffy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "humility-bin"
-version = "0.12.15"
+version = "0.12.16"
 dependencies = [
  "anyhow",
  "bitfield",

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "humility-bin"
 edition.workspace = true
-version = "0.12.15"
+version = "0.12.16"
 license = "MPL-2.0"
 
 [build-dependencies]

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information try --help
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.12.15 
+humility 0.12.16 
 
 ```
 
@@ -28,7 +28,7 @@ For more information try --help
 
 ```
 $ humility -c apx432 -V
-humility 0.12.15 
+humility 0.12.16 
 
 ```
 

--- a/humility-bin/tests/cmd/version.trycmd
+++ b/humility-bin/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.12.15 
+humility 0.12.16 
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.12.15 
+humility 0.12.16 
 
 ```

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1025,28 +1025,29 @@ impl<'a> HiffyContext<'a> {
         }
 
         let mut lap = 0;
-        const MAX_LAPS: u64 = 10;
 
-        let ready = loop {
+        let start = std::time::Instant::now();
+        let mut ready = false;
+        while start.elapsed().as_millis() < u128::from(self.timeout) {
             if !syscall_observed {
                 if has_task_started(self.hubris, core, hiffy_task.unwrap())? {
                     syscall_observed = true;
                 }
             } else if core.read_word_32(self.ready.addr)? == 1 {
-                break true;
+                ready = true;
+                break;
             }
 
             core.op_done()?;
 
             lap += 1;
 
-            if lap >= MAX_LAPS {
-                break false;
-            }
+            // sleep time is based on vibes
+            let sleep_time = Duration::from_millis(lap.min(20));
+            thread::sleep(sleep_time);
 
-            thread::sleep(Duration::from_millis(lap));
             core.op_start()?;
-        };
+        }
 
         if !ready {
             bail!("HIF execution facility unavailable");

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1028,7 +1028,8 @@ impl<'a> HiffyContext<'a> {
 
         let start = std::time::Instant::now();
         let mut ready = false;
-        while start.elapsed().as_millis() < u128::from(self.timeout) {
+        let timeout = Duration::from_millis(self.timeout.into());
+        while start.elapsed() < timeout {
             if !syscall_observed {
                 if has_task_started(self.hubris, core, hiffy_task.unwrap())? {
                     syscall_observed = true;


### PR DESCRIPTION
This is a (stochastic) fix for https://github.com/oxidecomputer/humility/issues/614

It gives us ~250 chances to catch `hiffy` in a syscall over 5 seconds (using our typical timeout), rather than 10 chances over ~50 ms (using a hard-coded loop count).  Testing on my desk, I can longer trigger the `HIF execution facility unavailable` failure by making `hiffy` calls while hashing the host flash (to load the SP CPU); previously, it happened about 50% of the time.

In the worst case, this could cause `humility hiffy` calls to take twice as long (if we almost hit the timeout waiting for the `hiffy` task, then almost hit it waiting for the operation to complete) – but I don't think that's a big issue here.