### PR TITLE
Add `humility ereport` subcommnad

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,8 @@ dependencies = [
  "humility-cmd",
  "humility-core",
  "humility-doppel",
+ "serde",
+ "serde_json",
  "zerocopy 0.6.6",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy 0.8.48",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1212,6 +1256,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
@@ -1313,6 +1363,7 @@ dependencies = [
  "humility-cmd-discover",
  "humility-cmd-doc",
  "humility-cmd-dump",
+ "humility-cmd-ereport",
  "humility-cmd-exec",
  "humility-cmd-extract",
  "humility-cmd-flash",
@@ -1522,7 +1573,7 @@ dependencies = [
  "indexmap 1.9.3",
  "parse_int",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1558,8 +1609,23 @@ dependencies = [
  "lzss",
  "num-traits",
  "parse_int",
- "zerocopy",
+ "zerocopy 0.6.6",
  "zip",
+]
+
+[[package]]
+name = "humility-cmd-ereport"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ciborium",
+ "clap 3.2.23",
+ "hex",
+ "humility-cli",
+ "humility-cmd",
+ "humility-core",
+ "humility-doppel",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1638,7 +1704,7 @@ dependencies = [
  "indexmap 1.9.3",
  "parse_int",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1725,7 +1791,7 @@ dependencies = [
  "parse_int",
  "serde",
  "serde_json",
- "zerocopy",
+ "zerocopy 0.6.6",
  "zip",
 ]
 
@@ -1761,7 +1827,7 @@ dependencies = [
  "idol",
  "parse_int",
  "pmbus",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -1866,7 +1932,7 @@ dependencies = [
  "num-traits",
  "parse_int",
  "pmbus",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2089,7 +2155,7 @@ dependencies = [
  "pmbus",
  "strum 0.25.0",
  "strum_macros 0.25.3",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2136,7 +2202,7 @@ dependencies = [
  "parse_int",
  "raw-cpuid",
  "termimad 0.21.1",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2314,7 +2380,7 @@ dependencies = [
  "serde",
  "tlvc",
  "tlvc-text",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2368,7 +2434,7 @@ dependencies = [
  "thiserror",
  "toml 0.5.11",
  "winapi",
- "zerocopy",
+ "zerocopy 0.6.6",
  "zip",
 ]
 
@@ -2395,7 +2461,7 @@ dependencies = [
  "humility-core",
  "indexmap 1.9.3",
  "serde",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2415,7 +2481,7 @@ dependencies = [
  "lzss",
  "num-traits",
  "rand",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2431,7 +2497,7 @@ dependencies = [
  "log",
  "parse_int",
  "postcard",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -2537,7 +2603,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "static_assertions",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4128,7 +4194,7 @@ source = "git+https://github.com/oxidecomputer/tlvc#533f0bf26b0a8f32d287af4f2ea0
 dependencies = [
  "byteorder",
  "crc",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4139,7 +4205,7 @@ dependencies = [
  "ron 0.8.0",
  "serde",
  "tlvc",
- "zerocopy",
+ "zerocopy 0.6.6",
 ]
 
 [[package]]
@@ -4737,7 +4803,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive 0.8.48",
 ]
 
 [[package]]
@@ -4745,6 +4820,17 @@ name = "zerocopy-derive"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "cmd/dump",
     "cmd/tofino-eeprom",
     "cmd/discover",
+    "cmd/ereport",
     "cmd/exec",
     "cmd/extract",
     "cmd/flash",
@@ -142,6 +143,7 @@ cmd-discover = { path = "./cmd/discover", package = "humility-cmd-discover" }
 cmd-doc = { path = "./cmd/doc", package = "humility-cmd-doc" }
 cmd-dump = { path = "./cmd/dump", package = "humility-cmd-dump" }
 cmd-tofino-eeprom = { path = "./cmd/tofino-eeprom", package = "humility-cmd-tofino-eeprom" }
+cmd-ereport = { path = "./cmd/ereport", package = "humility-cmd-ereport" }
 cmd-exec = { path = "./cmd/exec", package = "humility-cmd-exec" }
 cmd-extract = { path = "./cmd/extract", package = "humility-cmd-extract" }
 cmd-flash = { path = "./cmd/flash", package = "humility-cmd-flash" }
@@ -195,9 +197,10 @@ anyhow = { version = "1.0.44", features = ["backtrace"] }
 atty = "0.2"
 bitfield = "0.13.2"
 byteorder = "1.3.4"
-cargo_metadata = "0.12.0"
 cargo-readme = "3.3.1"
+cargo_metadata = "0.12.0"
 chrono = "0.4.38"
+ciborium = "0.2.2"
 clap = { version = "3.0.12", features = ["derive", "env"] }
 colored = "2.0.0"
 crc-any = "2.3.5"
@@ -209,6 +212,7 @@ env_logger = "0.9.0"
 fallible-iterator = "0.3.0"
 gimli = "0.32.0"
 goblin = "0.10"
+hex = "0.4.3"
 hubpack = "0.1.1"
 ihex = "3.0"
 indexmap = { version = "1.7", features = ["serde-1"] }

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ a specified target.  (In the above example, one could execute `humility
 - [humility discover](#humility-discover): listen for compatible SPs on a network
 - [humility doc](#humility-doc): print command documentation
 - [humility dump](#humility-dump): generate Hubris dump
+- [humility ereport](#humility-ereport): ereport examination
 - [humility exec](#humility-exec): execute command within context of an environment
 - [humility extract](#humility-extract): extract all or part of a Hubris archive
 - [humility flash](#humility-flash): flash archive onto attached device
@@ -649,6 +650,10 @@ ID TASK                       GEN PRI STATE
 25 idle                         0   8 RUNNING
 ```
 
+
+
+### `humility ereport`
+`humility ereport` lets you examine the ereport buffer in an image.
 
 
 ### `humility exec`

--- a/cmd/ereport/Cargo.toml
+++ b/cmd/ereport/Cargo.toml
@@ -9,6 +9,8 @@ anyhow.workspace = true
 ciborium.workspace = true
 clap.workspace = true
 hex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 zerocopy.workspace = true
 
 humility.workspace = true

--- a/cmd/ereport/Cargo.toml
+++ b/cmd/ereport/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "humility-cmd-ereport"
+version = "0.1.0"
+edition.workspace = true
+description = "ereport examination"
+
+[dependencies]
+anyhow.workspace = true
+ciborium.workspace = true
+clap.workspace = true
+hex.workspace = true
+zerocopy.workspace = true
+
+humility.workspace = true
+humility-cmd.workspace = true
+humility-cli.workspace = true
+humility-doppel.workspace = true

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -40,12 +40,20 @@ struct Flags {
     /// Print ereports in JSON format
     #[clap(short, long)]
     json: bool,
+
     /// Recover previously-sent ereports from the buffer
+    ///
+    /// The circular buffer may contain previously-sent ereports outside of its
+    /// valid range, i.e. before the `front` index.  When this flag is set, we
+    /// examine those bytes to find valid-looking ereports and print them (with
+    /// `recovered: true`).
     #[clap(short, long)]
     recover: bool,
 }
 
-/// Ereport header (required to agree with SP implementation)
+/// Raw ereport header
+///
+/// This must agree with the SP's implementation in `snitch_core::Store`
 #[derive(Debug, FromBytes)]
 #[repr(C)]
 struct EreportHeader {
@@ -62,6 +70,7 @@ pub struct Ereport {
     task_index: u16,
     timestamp: u64,
     recovered: bool,
+    ena: u64,
     contents: ciborium::Value,
 }
 
@@ -81,12 +90,20 @@ pub fn ereport_dump(
         .with_context(|| format!("could not find `{PACKRAT_BUF_NAME}`"))?;
 
     let buf: Value = humility::reflect::load_variable(hubris, core, buf_ty)?;
-    let storage: Value =
-        buf.field("cell.value.ereport_bufs.storage.storage")?;
+    let outer_storage: Value = buf.field("cell.value.ereport_bufs.storage")?;
+    let inner_storage: Value = outer_storage.field("storage")?;
     let array: Vec<humility_doppel::MaybeUninit<u8>> =
-        storage.field("buffer")?;
-    let front = storage.field::<u32>("front")? as usize;
-    let back = storage.field::<u32>("back")? as usize;
+        inner_storage.field("buffer")?;
+    let front = inner_storage.field::<u32>("front")? as usize;
+    let back = inner_storage.field::<u32>("back")? as usize;
+    let earliest_ena = outer_storage.field::<u64>("earliest_ena")?;
+    let insert_state =
+        outer_storage.field::<humility::reflect::Enum>("insert_state")?;
+    if insert_state.disc() != "Collecting" {
+        humility::warn!(
+            "ereports are being lost; `insert_state` is {insert_state:#?}"
+        );
+    }
 
     // Read data from the circular buffer
     let mut buf_data = Vec::with_capacity(array.len());
@@ -97,6 +114,7 @@ pub fn ereport_dump(
     }
     let mut ereports = vec![];
     let mut buf_data = buf_data.as_slice();
+    let mut current_ena = earliest_ena;
     while !buf_data.is_empty() {
         let header =
             EreportHeader::read_from_prefix(buf_data).ok_or_else(|| {
@@ -112,19 +130,28 @@ pub fn ereport_dump(
             task_index: header.task.into(),
             timestamp: header.timestamp.into(),
             recovered: false,
+            ena: current_ena,
             contents,
         });
         buf_data = next;
+        let Some(next_ena) = current_ena.checked_add(1) else {
+            humility::warn!("ena overflow; breaking out of loop");
+            break;
+        };
+        current_ena = next_ena;
     }
 
     if recover {
         let mut recovered = vec![];
         let mut buf = VecDeque::new();
+        let mut current_ena = earliest_ena;
         let mut i = front;
         while i != back {
             i = i.checked_sub(1).unwrap_or_else(|| array.len() - 1);
             buf.push_front(array[i].value);
-            if let Some(e) = try_recover_ereport(hubris, &mut buf) {
+            if let Some(e) =
+                try_recover_ereport(hubris, &mut buf, &mut current_ena)
+            {
                 assert!(e.recovered);
                 recovered.push(e);
                 buf.clear();
@@ -136,6 +163,22 @@ pub fn ereport_dump(
         recovered.reverse();
         std::mem::swap(&mut ereports, &mut recovered);
         ereports.extend(recovered);
+    }
+
+    // Go through and substitute "k" -> "class" and "v" -> "version"
+    for e in &mut ereports {
+        let Some(m) = e.contents.as_map_mut() else {
+            continue;
+        };
+        for (k, _v) in m.iter_mut() {
+            if let Some(s) = k.as_text_mut() {
+                if s == "k" {
+                    *s = "class".to_owned()
+                } else if s == "v" {
+                    *s = "version".to_owned()
+                }
+            }
+        }
     }
 
     Ok(ereports)
@@ -155,11 +198,12 @@ fn ereport_print(
                 println!();
             }
             println!(
-                "task: {} ({})",
+                "task:      {} ({})",
                 e.task_name.as_deref().unwrap_or("<unknown>"),
                 e.task_index,
             );
             println!("timestamp: {}", e.timestamp);
+            println!("ena:       {}", e.ena);
             if e.recovered || flags.recover {
                 println!("recovered: {}", e.recovered);
             }
@@ -174,6 +218,7 @@ fn ereport_print(
 fn try_recover_ereport(
     hubris: &HubrisArchive,
     buf: &mut VecDeque<u8>,
+    ena: &mut u64,
 ) -> Option<Ereport> {
     // Cheapest possible check: we must have enough room for the header and at
     // least one byte of payload.
@@ -193,11 +238,19 @@ fn try_recover_ereport(
     let task =
         hubris.lookup_module(HubrisTask::Task(header.task.into())).ok()?;
     let contents = ciborium::from_reader(&buf[HEADER_SIZE..]).ok()?;
+
+    // Step the ENA backwards; the ereport is invalid if it wraps or hits 0
+    *ena = ena.checked_sub(1)?;
+    if *ena == 0 {
+        return None;
+    }
+
     Some(Ereport {
         task_name: Some(task.name.clone()),
         task_index: header.task.into(),
         timestamp: header.timestamp.into(),
         recovered: true,
+        ena: *ena,
         contents,
     })
 }
@@ -256,10 +309,10 @@ fn pretty_print_value(value: &ciborium::Value, indent: usize, is_key: bool) {
                 print!("{pad}  ");
                 pretty_print_value(k, indent + 1, true);
                 print!(": ");
-                // Special-case handling for the `k`, which is an ereport name
+                // Special-case handling for the class, which is an ereport name
                 // and is printed without quotes
                 let is_ereport_key = match k {
-                    ciborium::Value::Text(t) => t == "k",
+                    ciborium::Value::Text(t) => t == "class",
                     _ => false,
                 };
                 pretty_print_value(v, indent + 1, is_ereport_key);

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! ## `humility ereport`
+//! `humility ereport` lets you examine the ereport buffer in an image.
+
+use humility::reflect::Value;
+use humility::{
+    core::Core,
+    hubris::{HubrisArchive, HubrisTask},
+};
+use humility_cli::{ExecutionContext, Subcommand};
+use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
+
+use anyhow::{Context, Result, anyhow};
+use std::fmt::Write;
+use zerocopy::FromBytes;
+
+use clap::{CommandFactory, Parser};
+
+#[derive(Parser, Debug)]
+#[clap(name = "ereport", about = env!("CARGO_PKG_DESCRIPTION"))]
+struct EreportArgs {
+    #[clap(subcommand)]
+    cmd: EreportCmd,
+}
+
+#[derive(Parser, Debug)]
+enum EreportCmd {
+    /// Print the contents of the ereport buffer
+    Dump {
+        #[clap(short, long)]
+        verbose: bool,
+    },
+}
+
+/// Reasons a server might cite when using the `REPLY_FAULT` syscall.
+#[derive(Debug, FromBytes)]
+#[repr(C)]
+pub struct EreportHeader {
+    data_len: zerocopy::byteorder::little_endian::U16,
+    task: zerocopy::byteorder::little_endian::U16,
+    timestamp: zerocopy::byteorder::little_endian::U64,
+}
+
+fn ereport_dump(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    verbose: bool,
+) -> Result<()> {
+    static PACKRAT_BUF_NAME: &str = "task_packrat::main::BUFS";
+    let buf_ty = hubris
+        .lookup_qualified_variable(PACKRAT_BUF_NAME)
+        .with_context(|| format!("could not find `{PACKRAT_BUF_NAME}`"))?;
+
+    let buf: Value = humility::reflect::load_variable(hubris, core, buf_ty)?;
+    let storage: Value =
+        buf.field("cell.value.ereport_bufs.storage.storage")?;
+    let array: Vec<humility_doppel::MaybeUninit<u8>> =
+        storage.field("buffer")?;
+    let front = storage.field::<u32>("front")? as usize;
+    let back = storage.field::<u32>("back")? as usize;
+
+    if verbose {
+        println!(
+            "buffer has {} bytes; front: {front}, back: {back}",
+            array.len()
+        );
+    }
+
+    // Read data from the circular buffer
+    let mut buf_data = Vec::with_capacity(array.len());
+    let mut i = front;
+    while i != back {
+        buf_data.push(array[i].value);
+        i = (i + 1) % array.len();
+    }
+    let mut buf_data = buf_data.as_slice();
+    while !buf_data.is_empty() {
+        let header =
+            EreportHeader::read_from_prefix(buf_data).ok_or_else(|| {
+                anyhow!("could not get ereport header from buffer")
+            })?;
+        buf_data = &buf_data[std::mem::size_of::<EreportHeader>()..];
+        let (ereport_data, next) =
+            buf_data.split_at(usize::from(header.data_len));
+        let task = hubris.lookup_module(HubrisTask::Task(header.task.into()));
+        println!(
+            "task: {} ({})",
+            task.map(|t| t.name.as_str()).unwrap_or("<unknown>"),
+            header.task
+        );
+        println!("timestamp: {}", header.timestamp);
+        if verbose {
+            println!("  {header:?}, {ereport_data:x?}");
+        }
+        println!("{}", pretty_print_cbor(ereport_data)?);
+        buf_data = next;
+    }
+
+    Ok(())
+}
+
+fn pretty_print_cbor(
+    data: &[u8],
+) -> Result<String, ciborium::de::Error<std::io::Error>> {
+    let value: ciborium::Value = ciborium::from_reader(data)?;
+    let mut output = String::new();
+    pretty_print_value(&value, &mut output, 0, false);
+    Ok(output)
+}
+
+fn pretty_print_value(
+    value: &ciborium::Value,
+    out: &mut String,
+    indent: usize,
+    is_key: bool,
+) {
+    let pad = "  ".repeat(indent);
+
+    match value {
+        ciborium::Value::Null => write!(out, "null").unwrap(),
+        ciborium::Value::Bool(b) => write!(out, "{b}").unwrap(),
+        ciborium::Value::Integer(n) => {
+            // ciborium::value::Integer can be converted to i128
+            let n: i128 = (*n).into();
+            write!(out, "{n}").unwrap();
+        }
+        ciborium::Value::Float(f) => write!(out, "{f}").unwrap(),
+        ciborium::Value::Text(s) => {
+            if is_key {
+                write!(out, "{s}").unwrap()
+            } else {
+                write!(out, "\"{s}\"").unwrap()
+            }
+        }
+        ciborium::Value::Bytes(b) => {
+            write!(out, "h'{}'", hex::encode(b)).unwrap()
+        }
+
+        ciborium::Value::Array(items) => {
+            if items.is_empty() {
+                write!(out, "[]").unwrap();
+                return;
+            }
+            writeln!(out, "[").unwrap();
+            for (i, item) in items.iter().enumerate() {
+                write!(out, "{pad}  ").unwrap();
+                pretty_print_value(item, out, indent + 1, false);
+                if i + 1 < items.len() {
+                    writeln!(out, ",").unwrap();
+                } else {
+                    writeln!(out).unwrap();
+                }
+            }
+            write!(out, "{pad}]").unwrap();
+        }
+
+        ciborium::Value::Map(entries) => {
+            if entries.is_empty() {
+                write!(out, "{pad}{{}}").unwrap();
+                return;
+            }
+            if indent > 0 {
+                writeln!(out, "{pad}{{").unwrap();
+            }
+            for (i, (k, v)) in entries.iter().enumerate() {
+                write!(out, "{pad}  ").unwrap();
+                pretty_print_value(k, out, indent + 1, true);
+                write!(out, ": ").unwrap();
+                // Special-case handling for the `k`, which is an ereport name
+                // and is printed without quotes
+                let is_ereport_key = match k {
+                    ciborium::Value::Text(t) => t == "k",
+                    _ => false,
+                };
+                pretty_print_value(v, out, indent + 1, is_ereport_key);
+                if i + 1 < entries.len() {
+                    writeln!(out, ",").unwrap();
+                } else {
+                    writeln!(out).unwrap();
+                }
+            }
+            if indent > 0 {
+                write!(out, "{pad}}}").unwrap();
+            }
+        }
+
+        ciborium::Value::Tag(tag, inner) => {
+            write!(out, "tag({tag}) ").unwrap();
+            pretty_print_value(inner, out, indent, false);
+        }
+
+        _ => write!(out, "<unknown>").unwrap(),
+    }
+}
+
+fn ereport(context: &mut ExecutionContext) -> Result<()> {
+    let core = &mut **context.core.as_mut().unwrap();
+    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
+    let hubris = context.archive.as_ref().unwrap();
+
+    let subargs = EreportArgs::try_parse_from(subargs)?;
+
+    match subargs.cmd {
+        EreportCmd::Dump { verbose } => ereport_dump(hubris, core, verbose),
+    }
+}
+
+pub fn init() -> Command {
+    Command {
+        app: EreportArgs::command(),
+        name: "ereport",
+        run: ereport,
+        kind: CommandKind::Attached {
+            archive: Archive::Required,
+            attach: Attach::Any,
+            validate: Validate::Booted,
+        },
+    }
+}

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -14,7 +14,7 @@ use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 use anyhow::{Context, Result, anyhow};
-use std::fmt::Write;
+use std::collections::VecDeque;
 use zerocopy::FromBytes;
 
 use clap::{CommandFactory, Parser};
@@ -30,24 +30,48 @@ struct EreportArgs {
 enum EreportCmd {
     /// Print the contents of the ereport buffer
     Dump {
-        #[clap(short, long)]
-        verbose: bool,
+        #[clap(flatten)]
+        flags: Flags,
     },
+}
+
+#[derive(Parser, Debug)]
+struct Flags {
+    /// Print verbose info while processing ereports
+    #[clap(short, long, conflicts_with = "json")]
+    verbose: bool,
+    /// Print ereports in JSON format
+    #[clap(short, long)]
+    json: bool,
+    /// Recover previously-sent ereports from the buffer
+    #[clap(short, long)]
+    recover: bool,
 }
 
 /// Reasons a server might cite when using the `REPLY_FAULT` syscall.
 #[derive(Debug, FromBytes)]
 #[repr(C)]
-pub struct EreportHeader {
+struct EreportHeader {
     data_len: zerocopy::byteorder::little_endian::U16,
     task: zerocopy::byteorder::little_endian::U16,
     timestamp: zerocopy::byteorder::little_endian::U64,
 }
 
+const HEADER_SIZE: usize = std::mem::size_of::<EreportHeader>();
+
+#[derive(serde::Serialize)]
+struct Ereport {
+    task_name: Option<String>,
+    task_index: u16,
+    timestamp: u64,
+    recovered: bool,
+    contents: ciborium::Value,
+}
+
 fn ereport_dump(
     hubris: &HubrisArchive,
     core: &mut dyn Core,
-    verbose: bool,
+    flags: Flags,
 ) -> Result<()> {
     static PACKRAT_BUF_NAME: &str = "task_packrat::main::BUFS";
     let buf_ty = hubris
@@ -62,7 +86,7 @@ fn ereport_dump(
     let front = storage.field::<u32>("front")? as usize;
     let back = storage.field::<u32>("back")? as usize;
 
-    if verbose {
+    if flags.verbose {
         println!(
             "buffer has {} bytes; front: {front}, back: {back}",
             array.len()
@@ -76,123 +100,182 @@ fn ereport_dump(
         buf_data.push(array[i].value);
         i = (i + 1) % array.len();
     }
+    let mut ereports = vec![];
     let mut buf_data = buf_data.as_slice();
     while !buf_data.is_empty() {
         let header =
             EreportHeader::read_from_prefix(buf_data).ok_or_else(|| {
                 anyhow!("could not get ereport header from buffer")
             })?;
-        buf_data = &buf_data[std::mem::size_of::<EreportHeader>()..];
+        buf_data = &buf_data[HEADER_SIZE..];
         let (ereport_data, next) =
             buf_data.split_at(usize::from(header.data_len));
         let task = hubris.lookup_module(HubrisTask::Task(header.task.into()));
-        println!(
-            "task: {} ({})",
-            task.map(|t| t.name.as_str()).unwrap_or("<unknown>"),
-            header.task
-        );
-        println!("timestamp: {}", header.timestamp);
-        if verbose {
-            println!("  {header:?}, {ereport_data:x?}");
-        }
-        println!("{}", pretty_print_cbor(ereport_data)?);
+        let contents = ciborium::from_reader(ereport_data)?;
+        ereports.push(Ereport {
+            task_name: task.map(|t| t.name.clone()).ok(),
+            task_index: header.task.into(),
+            timestamp: header.timestamp.into(),
+            recovered: false,
+            contents,
+        });
         buf_data = next;
+    }
+
+    if flags.recover {
+        let mut recovered = vec![];
+        let mut buf = VecDeque::new();
+        let mut i = front;
+        while i != back {
+            i = i.checked_sub(1).unwrap_or_else(|| array.len() - 1);
+            buf.push_front(array[i].value);
+            if let Some(e) = try_recover_ereport(hubris, &mut buf) {
+                assert!(e.recovered);
+                recovered.push(e);
+                buf.clear();
+            }
+        }
+        // ereports are recovered in reverse order (since we iterate backwards
+        // through the buffer), so we'll reverse their order then prepend them
+        // to the list of normal ereports.
+        recovered.reverse();
+        std::mem::swap(&mut ereports, &mut recovered);
+        ereports.extend(recovered);
+    }
+
+    if flags.json {
+        println!("{}", serde_json::ser::to_string_pretty(&ereports)?);
+    } else {
+        for (i, e) in ereports.iter().enumerate() {
+            if i > 0 {
+                println!();
+            }
+            println!(
+                "task: {} ({})",
+                e.task_name.as_deref().unwrap_or("<unknown>"),
+                e.task_index,
+            );
+            println!("timestamp: {}", e.timestamp);
+            if e.recovered || flags.recover {
+                println!("recovered: {}", e.recovered);
+            }
+            pretty_print_value(&e.contents, 0, false);
+        }
     }
 
     Ok(())
 }
 
-fn pretty_print_cbor(
-    data: &[u8],
-) -> Result<String, ciborium::de::Error<std::io::Error>> {
-    let value: ciborium::Value = ciborium::from_reader(data)?;
-    let mut output = String::new();
-    pretty_print_value(&value, &mut output, 0, false);
-    Ok(output)
+/// Tries to recover an ereport from the given buffer
+fn try_recover_ereport(
+    hubris: &HubrisArchive,
+    buf: &mut VecDeque<u8>,
+) -> Option<Ereport> {
+    // Cheapest possible check: we must have enough room for the header and at
+    // least one byte of payload.
+    if buf.len() <= HEADER_SIZE {
+        return None;
+    }
+    // Second-cheapest check: the header must imply the correct size.  We do
+    // this manually to avoid needing a contiguous buffer, which is a more
+    // expensive operation (shuffling data around).
+    let data_len = u16::from_le_bytes([buf[0], buf[1]]);
+    if data_len == 0 || usize::from(data_len) + HEADER_SIZE != buf.len() {
+        return None;
+    }
+    let buf = &*buf.make_contiguous();
+
+    let header = EreportHeader::read_from_prefix(buf).unwrap(); // size checked
+    let task =
+        hubris.lookup_module(HubrisTask::Task(header.task.into())).ok()?;
+    let contents = ciborium::from_reader(&buf[HEADER_SIZE..]).ok()?;
+    Some(Ereport {
+        task_name: Some(task.name.clone()),
+        task_index: header.task.into(),
+        timestamp: header.timestamp.into(),
+        recovered: true,
+        contents,
+    })
 }
 
-fn pretty_print_value(
-    value: &ciborium::Value,
-    out: &mut String,
-    indent: usize,
-    is_key: bool,
-) {
+/// Recursively pretty-print a CBOR value
+fn pretty_print_value(value: &ciborium::Value, indent: usize, is_key: bool) {
     let pad = "  ".repeat(indent);
 
     match value {
-        ciborium::Value::Null => write!(out, "null").unwrap(),
-        ciborium::Value::Bool(b) => write!(out, "{b}").unwrap(),
+        ciborium::Value::Null => print!("null"),
+        ciborium::Value::Bool(b) => print!("{b}"),
         ciborium::Value::Integer(n) => {
             // ciborium::value::Integer can be converted to i128
             let n: i128 = (*n).into();
-            write!(out, "{n}").unwrap();
+            print!("{n}");
         }
-        ciborium::Value::Float(f) => write!(out, "{f}").unwrap(),
+        ciborium::Value::Float(f) => print!("{f}"),
         ciborium::Value::Text(s) => {
             if is_key {
-                write!(out, "{s}").unwrap()
+                print!("{s}")
             } else {
-                write!(out, "\"{s}\"").unwrap()
+                print!("\"{s}\"")
             }
         }
         ciborium::Value::Bytes(b) => {
-            write!(out, "h'{}'", hex::encode(b)).unwrap()
+            print!("h'{}'", hex::encode(b))
         }
 
         ciborium::Value::Array(items) => {
             if items.is_empty() {
-                write!(out, "[]").unwrap();
+                print!("[]");
                 return;
             }
-            writeln!(out, "[").unwrap();
+            println!("[");
             for (i, item) in items.iter().enumerate() {
-                write!(out, "{pad}  ").unwrap();
-                pretty_print_value(item, out, indent + 1, false);
+                print!("{pad}  ");
+                pretty_print_value(item, indent + 1, false);
                 if i + 1 < items.len() {
-                    writeln!(out, ",").unwrap();
+                    println!(",");
                 } else {
-                    writeln!(out).unwrap();
+                    println!();
                 }
             }
-            write!(out, "{pad}]").unwrap();
+            print!("{pad}]");
         }
 
         ciborium::Value::Map(entries) => {
             if entries.is_empty() {
-                write!(out, "{pad}{{}}").unwrap();
+                print!("{pad}{{}}");
                 return;
             }
             if indent > 0 {
-                writeln!(out, "{pad}{{").unwrap();
+                println!("{pad}{{");
             }
             for (i, (k, v)) in entries.iter().enumerate() {
-                write!(out, "{pad}  ").unwrap();
-                pretty_print_value(k, out, indent + 1, true);
-                write!(out, ": ").unwrap();
+                print!("{pad}  ");
+                pretty_print_value(k, indent + 1, true);
+                print!(": ");
                 // Special-case handling for the `k`, which is an ereport name
                 // and is printed without quotes
                 let is_ereport_key = match k {
                     ciborium::Value::Text(t) => t == "k",
                     _ => false,
                 };
-                pretty_print_value(v, out, indent + 1, is_ereport_key);
+                pretty_print_value(v, indent + 1, is_ereport_key);
                 if i + 1 < entries.len() {
-                    writeln!(out, ",").unwrap();
+                    println!(",");
                 } else {
-                    writeln!(out).unwrap();
+                    println!();
                 }
             }
             if indent > 0 {
-                write!(out, "{pad}}}").unwrap();
+                print!("{pad}}}");
             }
         }
 
         ciborium::Value::Tag(tag, inner) => {
-            write!(out, "tag({tag}) ").unwrap();
-            pretty_print_value(inner, out, indent, false);
+            print!("tag({tag}) ");
+            pretty_print_value(inner, indent, false);
         }
 
-        _ => write!(out, "<unknown>").unwrap(),
+        _ => print!("<unknown>"),
     }
 }
 
@@ -204,7 +287,7 @@ fn ereport(context: &mut ExecutionContext) -> Result<()> {
     let subargs = EreportArgs::try_parse_from(subargs)?;
 
     match subargs.cmd {
-        EreportCmd::Dump { verbose } => ereport_dump(hubris, core, verbose),
+        EreportCmd::Dump { flags } => ereport_dump(hubris, core, flags),
     }
 }
 

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -37,9 +37,6 @@ enum EreportCmd {
 
 #[derive(Parser, Debug)]
 struct Flags {
-    /// Print verbose info while processing ereports
-    #[clap(short, long, conflicts_with = "json")]
-    verbose: bool,
     /// Print ereports in JSON format
     #[clap(short, long)]
     json: bool,
@@ -48,7 +45,7 @@ struct Flags {
     recover: bool,
 }
 
-/// Reasons a server might cite when using the `REPLY_FAULT` syscall.
+/// Ereport header (required to agree with SP implementation)
 #[derive(Debug, FromBytes)]
 #[repr(C)]
 struct EreportHeader {
@@ -60,7 +57,7 @@ struct EreportHeader {
 const HEADER_SIZE: usize = std::mem::size_of::<EreportHeader>();
 
 #[derive(serde::Serialize)]
-struct Ereport {
+pub struct Ereport {
     task_name: Option<String>,
     task_index: u16,
     timestamp: u64,
@@ -68,11 +65,16 @@ struct Ereport {
     contents: ciborium::Value,
 }
 
-fn ereport_dump(
+/// Read ereports from the given system
+///
+/// If `recover` is `true`, then we attempt to recover ereports from outside the
+/// valid range of the circular buffer; ereports which are recovered have
+/// [`Ereport::recovered`] set to `true`.
+pub fn ereport_dump(
     hubris: &HubrisArchive,
     core: &mut dyn Core,
-    flags: Flags,
-) -> Result<()> {
+    recover: bool,
+) -> Result<Vec<Ereport>> {
     static PACKRAT_BUF_NAME: &str = "task_packrat::main::BUFS";
     let buf_ty = hubris
         .lookup_qualified_variable(PACKRAT_BUF_NAME)
@@ -85,13 +87,6 @@ fn ereport_dump(
         storage.field("buffer")?;
     let front = storage.field::<u32>("front")? as usize;
     let back = storage.field::<u32>("back")? as usize;
-
-    if flags.verbose {
-        println!(
-            "buffer has {} bytes; front: {front}, back: {back}",
-            array.len()
-        );
-    }
 
     // Read data from the circular buffer
     let mut buf_data = Vec::with_capacity(array.len());
@@ -122,7 +117,7 @@ fn ereport_dump(
         buf_data = next;
     }
 
-    if flags.recover {
+    if recover {
         let mut recovered = vec![];
         let mut buf = VecDeque::new();
         let mut i = front;
@@ -143,6 +138,15 @@ fn ereport_dump(
         ereports.extend(recovered);
     }
 
+    Ok(ereports)
+}
+
+fn ereport_print(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    flags: Flags,
+) -> Result<()> {
+    let ereports = ereport_dump(hubris, core, flags.recover)?;
     if flags.json {
         println!("{}", serde_json::ser::to_string_pretty(&ereports)?);
     } else {
@@ -287,7 +291,7 @@ fn ereport(context: &mut ExecutionContext) -> Result<()> {
     let subargs = EreportArgs::try_parse_from(subargs)?;
 
     match subargs.cmd {
-        EreportCmd::Dump { flags } => ereport_dump(hubris, core, flags),
+        EreportCmd::Dump { flags } => ereport_print(hubris, core, flags),
     }
 }
 

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -44,6 +44,7 @@ cmd-discover = { workspace = true }
 cmd-doc = { workspace = true }
 cmd-dump = { workspace = true }
 cmd-tofino-eeprom = { workspace = true }
+cmd-ereport = { workspace = true }
 cmd-exec = { workspace = true }
 cmd-extract = { workspace = true }
 cmd-flash = { workspace = true, optional = true }

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -1025,6 +1025,16 @@ impl Load for Value {
     }
 }
 
+impl Load for Enum {
+    fn from_value(v: &Value) -> Result<Self> {
+        if let Value::Enum(e) = v {
+            Ok(e.clone())
+        } else {
+            bail!("expected an enum, got {v:?}");
+        }
+    }
+}
+
 impl Load for bool {
     fn from_value(v: &Value) -> Result<Self> {
         v.as_base()?.as_bool().ok_or_else(|| anyhow!("not a bool: {:?}", v))

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -135,19 +135,37 @@ impl Value {
     pub fn field<T: Load>(&self, f: &str) -> Result<T> {
         let mut v = self;
         for f in f.split(".") {
-            let Value::Struct(s) = v else {
-                bail!("expected a struct when getting field `{f}`");
-            };
-            v = s.get(f).ok_or_else(|| {
-                anyhow!(
-                    "could not field field `{f}`; available fields are {:?}",
-                    s.members
-                        .keys()
-                        .map(|s| s.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )
-            })?;
+            match v {
+                Value::Struct(s) => {
+                    v = s.get(f).ok_or_else(|| {
+                        anyhow!(
+                            "could not field field `{f}`; \
+                             available fields are {:?}",
+                            s.members
+                                .keys()
+                                .map(|s| s.as_str())
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    })?;
+                }
+                Value::Tuple(t) => {
+                    let index: usize = f.parse().with_context(|| {
+                        format!("could not parse tuple index from `{f}`")
+                    })?;
+                    v = t.1.get(index).ok_or_else(|| {
+                        anyhow!(
+                            "could not get field {index} from tuple \
+                             with {} elements",
+                            t.1.len()
+                        )
+                    })?;
+                }
+                _ => bail!(
+                    "expected a struct or tuple when getting field `{f}`, \
+                     got {v:?}"
+                ),
+            }
         }
         T::from_value(v)
     }
@@ -1040,6 +1058,16 @@ impl Load for u64 {
 impl Load for f32 {
     fn from_value(v: &Value) -> Result<Self> {
         v.as_base()?.as_f32().ok_or_else(|| anyhow!("not a f32: {:?}", v))
+    }
+}
+
+impl Load for Array {
+    fn from_value(v: &Value) -> Result<Self> {
+        if let Value::Array(v) = v {
+            Ok(v.clone())
+        } else {
+            bail!("expected array, got {v:?}");
+        }
     }
 }
 

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -131,6 +131,27 @@ impl Value {
         }
     }
 
+    /// Looks up a `struct` field with dot-separated members
+    pub fn field<T: Load>(&self, f: &str) -> Result<T> {
+        let mut v = self;
+        for f in f.split(".") {
+            let Value::Struct(s) = v else {
+                bail!("expected a struct when getting field `{f}`");
+            };
+            v = s.get(f).ok_or_else(|| {
+                anyhow!(
+                    "could not field field `{f}`; available fields are {:?}",
+                    s.members
+                        .keys()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?;
+        }
+        T::from_value(v)
+    }
+
     /// Interprets this as a 1-tuple (e.g. `(x,)`) and extracts its sole value,
     /// returning an error if it isn't a 1-tuple.
     pub fn as_1tuple(&self) -> Result<&Value> {

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -84,7 +84,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use crate::core::Core;
 use crate::hubris::{
     HubrisArchive, HubrisArray, HubrisBasetype, HubrisEnum, HubrisGoff,
-    HubrisPrintFormat, HubrisStruct, HubrisType, HubrisUnion,
+    HubrisPrintFormat, HubrisStruct, HubrisType, HubrisUnion, HubrisVariable,
 };
 
 // Re-export so that others can use #[derive(Load)]
@@ -748,6 +748,21 @@ pub fn load<'a, T: Load>(
             std::any::type_name::<T>()
         )
     })
+}
+
+/// Loads a variable and interprets it as a particular `Load`-able type
+pub fn load_variable<T: Load>(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    var: &HubrisVariable,
+) -> Result<T> {
+    let var_ty = hubris.lookup_type(var.goff)?;
+    let mut buf: Vec<u8> = vec![0u8; var.size];
+
+    core.read_8(var.addr, &mut buf)?;
+    let v = load(hubris, &buf, var_ty, 0)?;
+
+    Ok(v)
 }
 
 /// Loads data from memory image `buf` at offset `addr` and represents it as a

--- a/humility-doppel/src/lib.rs
+++ b/humility-doppel/src/lib.rs
@@ -399,6 +399,7 @@ pub struct UnsafeCell {
     pub value: Value,
 }
 
+#[derive(Clone, Debug)]
 pub struct MaybeUninit<T> {
     pub value: T,
 }


### PR DESCRIPTION
This PR adds a `humility ereport` subcommand to dump ereports from packrat.

```console
$ humility -d ~/Desktop/hubris.core.ereports ereport dump
humility: attached to dump
task: ereportulator (27)
timestamp: 9441
  k: hw.apollo.undervolt,
  v: 13,
  volts: 0,
  n: 5678,
  bus: "MainBusB"
```

It includes both normal and JSON formatting, e.g.
```json
[
  {
    "task_name": "ereportulator",
    "task_index": 27,
    "timestamp": 9441,
    "recovered": false,
    "contents": {
      "k": "hw.apollo.undervolt",
      "v": 13,
      "volts": 0.0,
      "n": 5678,
      "bus": "MainBusB"
    }
  }
]
```

By default, it prints just ereports which are in the valid portion of the circular buffer; the `--recover` flag also searches for ereports which have been sent but are still available in RAM.

This is written to be library-friendly: `pub fn ereport_dump(..)` does no printing of its own, just returns a `Result<Vec<Ereport>>`.

There are also some incidental improvements to reflection, which I'd like to use more widely in a subsequent PR.