### PR TITLE
Panic if env vars are set when running tests

### DIFF
--- a/humility-bin/tests/cli_tests.rs
+++ b/humility-bin/tests/cli_tests.rs
@@ -245,6 +245,15 @@ fn cli_tests() {
         panic!("make_tests() failed: {:?}", err);
     }
 
+    for v in ["HUMILITY_DUMP", "HUMILITY_IP", "HUMILITY_ARCHIVE"] {
+        if std::env::var_os(v).is_some() {
+            panic!(
+                "`{v}` environment variable will interfere with tests; \
+                 please unset it"
+            );
+        }
+    }
+
     match std::env::var_os("TRYCMD_TEST") {
         Some(case) => {
             trycmd::TestCases::new().case(case);


### PR DESCRIPTION
This PR brought to you by thousands of lines of
```
++++ actual:   stderr
        1 + humility: WARNING: dump on command-line overriding archive in environment
   1    2 | humility: attached to dump
Update snapshots with `TRYCMD=overwrite`
Debug output with `TRYCMD=dump`
test cli_tests ... FAILED

failures:

---- cli_tests stdout ----

thread 'cli_tests' panicked at /Users/mjk/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/trycmd-0.13.7/src/runner.rs:93:17:
956 of 986 tests failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```