### PR TITLE
Move auxflash core implementation into `humility-auxflash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,6 +1340,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "humility-auxflash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "humility-core",
+ "humility-hiffy",
+ "humility-idol",
+ "indicatif",
+ "tlvc",
+]
+
+[[package]]
 name = "humility-bin"
 version = "0.12.17"
 dependencies = [
@@ -1463,13 +1475,11 @@ dependencies = [
  "clap 3.2.23",
  "colored",
  "hif",
+ "humility-auxflash",
  "humility-cli",
  "humility-cmd",
  "humility-core",
- "humility-hiffy",
- "humility-idol",
  "idol",
- "indicatif",
  "log",
  "parse_int",
  "tlvc",
@@ -1654,9 +1664,9 @@ dependencies = [
  "anyhow",
  "clap 3.2.23",
  "goblin",
+ "humility-auxflash",
  "humility-cli",
  "humility-cmd",
- "humility-cmd-auxflash",
  "humility-core",
  "humility-cortex",
  "humility-probes-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ default-members = ["humility-bin"]
 members = [
     "humility-arch-arm",
     "humility-arch-cortex",
+    "humility-auxflash",
     "humility-bin",
     "humility-cmd",
     "humility-cli",
@@ -119,6 +120,7 @@ capstone = {git = "https://github.com/oxidecomputer/capstone-rs.git"}
 # Local `path`-based deps
 humility = { path = "./humility-core", package = "humility-core" }
 humility-arch-arm = { path = "./humility-arch-arm" }
+humility-auxflash = { path = "./humility-auxflash" }
 humility-cortex = { path = "./humility-arch-cortex" }
 humility-cmd = { path = "./humility-cmd", default-features = false }
 humility-cli = { path = "./humility-cli" }

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -12,12 +12,10 @@ tlvc.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 colored.workspace = true
-indicatif.workspace = true
 log.workspace = true
 parse_int.workspace = true
 
 humility.workspace = true
+humility-auxflash.workspace = true
 humility-cmd.workspace = true
 humility-cli.workspace = true
-humility-hiffy.workspace = true
-humility-idol.workspace = true

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -9,21 +9,14 @@
 //! This subcommand should be rarely used; `humility flash` will automatically
 //! program auxiliary flash when needed.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::CommandKind;
-use indicatif::{ProgressBar, ProgressStyle};
 
-use humility::core::Core;
-use humility::hubris::*;
+use humility_auxflash::AuxFlashHandler;
 use humility_cmd::{Archive, Attach, Command, Validate};
-use humility_hiffy::HiffyContext;
-use humility_idol::{HubrisIdol, IdolArgument};
-
-const DEFAULT_SLOT_SIZE_BYTES: usize = 2 * 1024 * 1024;
-const READ_CHUNK_SIZE: usize = 256; // limited by HIFFY_SCRATCH_SIZE
 
 #[derive(Parser, Debug)]
 #[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -68,311 +61,42 @@ enum AuxFlashCommand {
     },
 }
 
-pub struct AuxFlashHandler<'a> {
-    hubris: &'a HubrisArchive,
-    core: &'a mut dyn Core,
-    context: HiffyContext<'a>,
-}
-
-impl<'a> AuxFlashHandler<'a> {
-    pub fn new(
-        hubris: &'a HubrisArchive,
-        core: &'a mut dyn Core,
-        hiffy_timeout: u32,
-    ) -> Result<Self> {
-        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self { hubris, core, context })
-    }
-
-    pub fn slot_size_bytes(&self) -> Result<usize> {
-        self.hubris
-            .manifest
-            .auxflash
-            .as_ref()
-            .map(|i| i.slot_size_bytes())
-            .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
-    }
-
-    pub fn slot_count(&mut self) -> Result<u32> {
-        let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
-        let value = humility_hiffy::hiffy_call(
-            self.hubris,
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            None,
-            None,
-        )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        };
-        let v = v.as_base()?;
-        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))
-    }
-
-    /// Returns the active slot, or `None` if there is no active slot
-    pub fn active_slot(&mut self) -> Result<Option<u32>> {
-        let op = self
-            .hubris
-            .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-        let value = humility_hiffy::hiffy_call(
-            self.hubris,
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            None,
-            None,
-        )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) if e == "NoActiveSlot" => {
-                return Ok(None);
-            }
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        };
-        let v = v.as_base()?;
-        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32")).map(Some)
-    }
-
-    fn slot_erase(&mut self, slot: u32) -> Result<()> {
-        let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
-        let value = humility_hiffy::hiffy_call(
-            self.hubris,
-            self.core,
-            &mut self.context,
-            &op,
-            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-            None,
-            None,
-        )?;
-        match value {
-            Ok(..) => Ok(()),
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        }
-    }
-
-    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
-        let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-        let value = humility_hiffy::hiffy_call(
-            self.hubris,
-            self.core,
-            &mut self.context,
-            &op,
-            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-            None,
-            None,
-        )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) if e == "MissingChck" => return Ok(None),
-            Err(e) => bail!("{}", e),
-        };
-        let array = v.as_1tuple().unwrap().as_array().unwrap();
-        assert_eq!(array.len(), 32);
-        let mut out = [0u8; 32];
-        for (o, v) in out
-            .iter_mut()
-            .zip(array.iter().map(|i| i.as_base().unwrap().as_u8().unwrap()))
-        {
-            *o = v;
-        }
-
-        Ok(Some(out))
-    }
-
-    fn auxflash_status(&mut self, verbose: bool) -> Result<()> {
-        let slot_count = self.slot_count()?;
-        let active_slot = self.active_slot()?;
-        println!(" {} | {}", "slot".bold(), "status".bold());
-        println!("------|----------------------------");
-        for i in 0..slot_count {
-            print!("  {:>3} | ", i);
-            match self.slot_status(i) {
-                Err(e) => {
-                    println!("Error: {}", e.to_string().red());
-                }
-                Ok(None) => println!("{}", "Missing checksum".yellow()),
-                Ok(Some(v)) => {
-                    if active_slot == Some(i) {
-                        print!("{} (", "Active".green());
-                    } else {
-                        print!("{} (", "Valid ".blue());
-                    }
-                    if verbose {
-                        for byte in v {
-                            print!("{:0>2x}", byte);
-                        }
-                    } else {
-                        for byte in &v[0..4] {
-                            print!("{:0>2x}", byte);
-                        }
-                        print!("...");
-                    }
-                    println!(")");
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn auxflash_read(
-        &mut self,
-        slot: u32,
-        count: Option<usize>,
-    ) -> Result<Vec<u8>> {
-        let op =
-            self.hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
-        let slot_size = self.slot_size_bytes()?;
-
-        let mut out = vec![0u8; count.unwrap_or(slot_size)];
-        let bar = ProgressBar::new(0);
-        bar.set_style(
-            ProgressStyle::default_bar()
-                .template("humility: reading [{bar:30}] {bytes}/{total_bytes}"),
-        );
-        bar.set_length(out.len() as u64);
-        for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
-            let offset = i * READ_CHUNK_SIZE;
-            let value = humility_hiffy::hiffy_call(
-                self.hubris,
-                self.core,
-                &mut self.context,
-                &op,
-                &[
-                    ("slot", IdolArgument::Scalar(slot as u64)),
-                    ("offset", IdolArgument::Scalar(offset as u64)),
-                ],
-                None,
-                Some(chunk),
-            )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
-            bar.set_position(offset as u64);
-        }
-        bar.set_position(out.len() as u64);
-        bar.finish_and_clear();
-
-        Ok(out)
-    }
-
-    pub fn auxflash_write(
-        &mut self,
-        slot: u32,
-        data: &[u8],
-        force: bool,
-    ) -> Result<()> {
-        // If the input data can be parsed as TLV-C, then check against
-        // the slot checksum currently loaded in auxiliary flash, skipping
-        // flashing if they match.
-        let mut reader = tlvc::TlvcReader::begin(data)
-            .map_err(|e| anyhow!("TlvcReader::begin failed: {:?}", e))?;
-        let mut chck_data = None;
-        loop {
-            match reader.next() {
-                Ok(Some(chunk)) => {
-                    if &chunk.header().tag == b"CHCK" {
-                        assert_eq!(chunk.len(), 32);
-                        let mut out = [0; 32];
-                        chunk.read_exact(0, &mut out).map_err(|e| {
-                            anyhow!("Failed to read chunk: {:?}", e)
-                        })?;
-                        chck_data = Some(out);
-                        break;
-                    }
-                }
-                Ok(None) => break,
-                Err(e) => {
-                    humility::msg!(
-                        "Failed to load data as TLV-C ({e:?}); \
-                         skipping reflash check",
-                    );
-                    break;
-                }
-            }
-        }
-        if let Some(chck_data) = chck_data
-            && let Ok(Some(chck_slot)) = self.slot_status(slot)
-            && chck_data == chck_slot
-        {
-            humility::msg!("Slot {slot} is already programmed with our data",);
-            if force {
-                humility::msg!("Reprogramming it anyways!");
-            } else {
-                humility::msg!("Skipping reprogramming.");
-                return Ok(());
-            }
-        }
-
-        humility::msg!("erasing slot {slot}");
-        self.slot_erase(slot)?;
-
-        let slot_size = self.slot_size_bytes()?;
-        if data.len() > slot_size {
-            bail!(
-                "Data is too large ({} bytes, slot size is {} bytes)",
-                data.len(),
-                slot_size
-            );
-        }
-        let op =
-            self.hubris.get_idol_command("AuxFlash.write_slot_with_offset")?;
-
-        let bar = ProgressBar::new(0);
-        bar.set_style(
-            ProgressStyle::default_bar()
-                .template("humility: writing [{bar:30}] {bytes}/{total_bytes}"),
-        );
-        bar.set_length(data.len() as u64);
-        for (i, chunk) in data.chunks(self.context.data_size()).enumerate() {
-            let offset = i * self.context.data_size();
-            let value = humility_hiffy::hiffy_call(
-                self.hubris,
-                self.core,
-                &mut self.context,
-                &op,
-                &[
-                    ("slot", IdolArgument::Scalar(slot as u64)),
-                    ("offset", IdolArgument::Scalar(offset as u64)),
-                ],
-                Some(chunk),
-                None,
-            )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
-            bar.set_position(offset as u64);
-        }
-        bar.set_position(data.len() as u64);
-        bar.finish_and_clear();
-        humility::msg!("done");
-        Ok(())
-    }
-
-    pub fn reset(&mut self) -> Result<()> {
-        self.core.reset_with_handoff(self.hubris)
-    }
-
-    pub fn auxflash_write_from_archive(
-        &mut self,
-        slot: u32,
-        force: bool,
-    ) -> Result<()> {
-        let data = self.hubris.read_auxflash_data()?.ok_or_else(|| {
-            anyhow!(
-                "Could not find auxiliary data in the archive. \
-                     Does this Hubris app include auxiliary blobs?"
-            )
-        })?;
-        humility::msg!("Flashing auxiliary data from the Hubris archive");
-        self.auxflash_write(slot, &data, force)
-    }
-}
-
 ////////////////////////////////////////////////////////////////////////////////
+
+fn auxflash_status(mut worker: AuxFlashHandler, verbose: bool) -> Result<()> {
+    let slot_count = worker.slot_count()?;
+    let active_slot = worker.active_slot()?;
+    println!(" {} | {}", "slot".bold(), "status".bold());
+    println!("------|----------------------------");
+    for i in 0..slot_count {
+        print!("  {:>3} | ", i);
+        match worker.slot_status(i) {
+            Err(e) => {
+                println!("Error: {}", e.to_string().red());
+            }
+            Ok(None) => println!("{}", "Missing checksum".yellow()),
+            Ok(Some(v)) => {
+                if active_slot == Some(i) {
+                    print!("{} (", "Active".green());
+                } else {
+                    print!("{} (", "Valid ".blue());
+                }
+                if verbose {
+                    for byte in v {
+                        print!("{:0>2x}", byte);
+                    }
+                } else {
+                    for byte in &v[0..4] {
+                        print!("{:0>2x}", byte);
+                    }
+                    print!("...");
+                }
+                println!(")");
+            }
+        }
+    }
+    Ok(())
+}
 
 fn auxflash(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
@@ -383,7 +107,7 @@ fn auxflash(context: &mut ExecutionContext) -> Result<()> {
 
     match subargs.cmd {
         AuxFlashCommand::Status { verbose } => {
-            worker.auxflash_status(verbose)?;
+            auxflash_status(worker, verbose)?;
         }
         AuxFlashCommand::Erase { slot } => {
             worker.slot_erase(slot)?;

--- a/cmd/flash/Cargo.toml
+++ b/cmd/flash/Cargo.toml
@@ -10,7 +10,7 @@ humility-cortex = { workspace = true }
 humility-cmd = { workspace = true }
 humility-cli = { workspace = true }
 humility-probes-core = { workspace = true }
-cmd-auxflash = { workspace = true }
+humility-auxflash = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 parse_int = { workspace = true }

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -35,6 +35,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{CommandFactory, Parser};
 use humility::{core::Core, hubris::*};
+use humility_auxflash::AuxFlashHandler;
 use humility_cli::{
     Cli, {ExecutionContext, Subcommand},
 };
@@ -315,15 +316,14 @@ fn get_image_state(
 
         // Note that we only run this check if we pass the image ID check;
         // otherwise, the Idol / hiffy memory maps are unknown.
-        let mut worker =
-            match cmd_auxflash::AuxFlashHandler::new(hubris, core, 15_000) {
-                Ok(w) => w,
-                Err(e) => {
-                    // Halt the core before returning!
-                    core.halt()?;
-                    return Err(e);
-                }
-            };
+        let mut worker = match AuxFlashHandler::new(hubris, core, 15_000) {
+            Ok(w) => w,
+            Err(e) => {
+                // Halt the core before returning!
+                core.halt()?;
+                return Err(e);
+            }
+        };
         let r = match worker.active_slot() {
             Ok(Some(s)) => {
                 humility::msg!("verified auxflash in slot {s}");
@@ -462,7 +462,7 @@ fn program_auxflash(
     core: &mut dyn Core,
     data: &[u8],
 ) -> Result<()> {
-    let mut worker = cmd_auxflash::AuxFlashHandler::new(hubris, core, 15_000)?;
+    let mut worker = AuxFlashHandler::new(hubris, core, 15_000)?;
 
     // At this point, we've already rebooted into the new image.
     //

--- a/humility-auxflash/Cargo.toml
+++ b/humility-auxflash/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "humility-auxflash"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+indicatif.workspace = true
+tlvc.workspace = true
+
+humility.workspace = true
+humility-hiffy.workspace = true
+humility-idol.workspace = true

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -1,0 +1,298 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use anyhow::{Result, anyhow, bail};
+use indicatif::{ProgressBar, ProgressStyle};
+
+use humility::core::Core;
+use humility::hubris::*;
+use humility_hiffy::HiffyContext;
+use humility_idol::{HubrisIdol, IdolArgument};
+
+const DEFAULT_SLOT_SIZE_BYTES: usize = 2 * 1024 * 1024;
+const READ_CHUNK_SIZE: usize = 256; // limited by HIFFY_SCRATCH_SIZE
+
+/// Handle to interact with auxiliary flash
+pub struct AuxFlashHandler<'a> {
+    hubris: &'a HubrisArchive,
+    core: &'a mut dyn Core,
+    context: HiffyContext<'a>,
+}
+
+impl<'a> AuxFlashHandler<'a> {
+    /// Builds a new [`AuxFlashHandler`]
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        core: &'a mut dyn Core,
+        hiffy_timeout: u32,
+    ) -> Result<Self> {
+        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
+        Ok(Self { hubris, core, context })
+    }
+
+    /// Returns the auxflash slot size
+    pub fn slot_size_bytes(&self) -> Result<usize> {
+        self.hubris
+            .manifest
+            .auxflash
+            .as_ref()
+            .map(|i| i.slot_size_bytes())
+            .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
+    }
+
+    /// Returns the number of auxflash slots
+    pub fn slot_count(&mut self) -> Result<u32> {
+        let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
+        let value = humility_hiffy::hiffy_call(
+            self.hubris,
+            self.core,
+            &mut self.context,
+            &op,
+            &[],
+            None,
+            None,
+        )?;
+        let v = match value {
+            Ok(v) => v,
+            Err(e) => bail!("Got Hiffy error: {}", e),
+        };
+        let v = v.as_base()?;
+        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))
+    }
+
+    /// Returns the active slot, or `None` if there is no active slot
+    pub fn active_slot(&mut self) -> Result<Option<u32>> {
+        let op = self
+            .hubris
+            .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
+        let value = humility_hiffy::hiffy_call(
+            self.hubris,
+            self.core,
+            &mut self.context,
+            &op,
+            &[],
+            None,
+            None,
+        )?;
+        let v = match value {
+            Ok(v) => v,
+            Err(e) if e == "NoActiveSlot" => {
+                return Ok(None);
+            }
+            Err(e) => bail!("Got Hiffy error: {}", e),
+        };
+        let v = v.as_base()?;
+        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32")).map(Some)
+    }
+
+    /// Erases a single auxflash slot
+    pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
+        let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
+        let value = humility_hiffy::hiffy_call(
+            self.hubris,
+            self.core,
+            &mut self.context,
+            &op,
+            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+            None,
+            None,
+        )?;
+        match value {
+            Ok(..) => Ok(()),
+            Err(e) => bail!("Got Hiffy error: {}", e),
+        }
+    }
+
+    /// Returns the checksum of an auxflash slot
+    ///
+    /// This is `None` if the checksum is not present (because the slot has been
+    /// erased).
+    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
+        let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
+        let value = humility_hiffy::hiffy_call(
+            self.hubris,
+            self.core,
+            &mut self.context,
+            &op,
+            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+            None,
+            None,
+        )?;
+        let v = match value {
+            Ok(v) => v,
+            Err(e) if e == "MissingChck" => return Ok(None),
+            Err(e) => bail!("{}", e),
+        };
+        let array = v.as_1tuple().unwrap().as_array().unwrap();
+        assert_eq!(array.len(), 32);
+        let mut out = [0u8; 32];
+        for (o, v) in out
+            .iter_mut()
+            .zip(array.iter().map(|i| i.as_base().unwrap().as_u8().unwrap()))
+        {
+            *o = v;
+        }
+
+        Ok(Some(out))
+    }
+
+    /// Reads some number of bytes from a particular slot
+    ///
+    /// If `count` is empty, reads the entire slot
+    pub fn auxflash_read(
+        &mut self,
+        slot: u32,
+        count: Option<usize>,
+    ) -> Result<Vec<u8>> {
+        let op =
+            self.hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
+        let slot_size = self.slot_size_bytes()?;
+
+        let mut out = vec![0u8; count.unwrap_or(slot_size)];
+        let bar = ProgressBar::new(0);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("humility: reading [{bar:30}] {bytes}/{total_bytes}"),
+        );
+        bar.set_length(out.len() as u64);
+        for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
+            let offset = i * READ_CHUNK_SIZE;
+            let value = humility_hiffy::hiffy_call(
+                self.hubris,
+                self.core,
+                &mut self.context,
+                &op,
+                &[
+                    ("slot", IdolArgument::Scalar(slot as u64)),
+                    ("offset", IdolArgument::Scalar(offset as u64)),
+                ],
+                None,
+                Some(chunk),
+            )?;
+            if let Err(e) = value {
+                bail!("Got Hubris error: {:?}", e);
+            }
+            bar.set_position(offset as u64);
+        }
+        bar.set_position(out.len() as u64);
+        bar.finish_and_clear();
+
+        Ok(out)
+    }
+
+    /// Writes some number of bytes to a particular slot
+    ///
+    /// If the slot is already programmed with a matching `CHCK` field, then
+    /// writing is skipped (unless `force` is set).
+    pub fn auxflash_write(
+        &mut self,
+        slot: u32,
+        data: &[u8],
+        force: bool,
+    ) -> Result<()> {
+        // If the input data can be parsed as TLV-C, then check against
+        // the slot checksum currently loaded in auxiliary flash, skipping
+        // flashing if they match.
+        let mut reader = tlvc::TlvcReader::begin(data)
+            .map_err(|e| anyhow!("TlvcReader::begin failed: {:?}", e))?;
+        let mut chck_data = None;
+        loop {
+            match reader.next() {
+                Ok(Some(chunk)) => {
+                    if &chunk.header().tag == b"CHCK" {
+                        assert_eq!(chunk.len(), 32);
+                        let mut out = [0; 32];
+                        chunk.read_exact(0, &mut out).map_err(|e| {
+                            anyhow!("Failed to read chunk: {:?}", e)
+                        })?;
+                        chck_data = Some(out);
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    humility::msg!(
+                        "Failed to load data as TLV-C ({e:?}); \
+                         skipping reflash check",
+                    );
+                    break;
+                }
+            }
+        }
+        if let Some(chck_data) = chck_data
+            && let Ok(Some(chck_slot)) = self.slot_status(slot)
+            && chck_data == chck_slot
+        {
+            humility::msg!("Slot {slot} is already programmed with our data",);
+            if force {
+                humility::msg!("Reprogramming it anyways!");
+            } else {
+                humility::msg!("Skipping reprogramming.");
+                return Ok(());
+            }
+        }
+
+        humility::msg!("erasing slot {slot}");
+        self.slot_erase(slot)?;
+
+        let slot_size = self.slot_size_bytes()?;
+        if data.len() > slot_size {
+            bail!(
+                "Data is too large ({} bytes, slot size is {} bytes)",
+                data.len(),
+                slot_size
+            );
+        }
+        let op =
+            self.hubris.get_idol_command("AuxFlash.write_slot_with_offset")?;
+
+        let bar = ProgressBar::new(0);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template("humility: writing [{bar:30}] {bytes}/{total_bytes}"),
+        );
+        bar.set_length(data.len() as u64);
+        for (i, chunk) in data.chunks(self.context.data_size()).enumerate() {
+            let offset = i * self.context.data_size();
+            let value = humility_hiffy::hiffy_call(
+                self.hubris,
+                self.core,
+                &mut self.context,
+                &op,
+                &[
+                    ("slot", IdolArgument::Scalar(slot as u64)),
+                    ("offset", IdolArgument::Scalar(offset as u64)),
+                ],
+                Some(chunk),
+                None,
+            )?;
+            if let Err(e) = value {
+                bail!("Got Hubris error: {:?}", e);
+            }
+            bar.set_position(offset as u64);
+        }
+        bar.set_position(data.len() as u64);
+        bar.finish_and_clear();
+        humility::msg!("done");
+        Ok(())
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        self.core.reset_with_handoff(self.hubris)
+    }
+
+    pub fn auxflash_write_from_archive(
+        &mut self,
+        slot: u32,
+        force: bool,
+    ) -> Result<()> {
+        let data = self.hubris.read_auxflash_data()?.ok_or_else(|| {
+            anyhow!(
+                "Could not find auxiliary data in the archive. \
+                 Does this Hubris app include auxiliary blobs?"
+            )
+        })?;
+        humility::msg!("Flashing auxiliary data from the Hubris archive");
+        self.auxflash_write(slot, &data, force)
+    }
+}


### PR DESCRIPTION
This removes one `cmd`-to-`cmd` dependency by decoupling `humility-cmd-flash` from `humility-cmd-auxflash`.

`humility-auxflash` is still unfortunately CLI-flavored (doing its own logging and progress bars), but this is a step in the right direction.