### PR TITLE
Move spd core implementation into `humility-spd`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,12 +2136,12 @@ dependencies = [
  "hif",
  "humility-cli",
  "humility-cmd",
- "humility-cmd-spd",
  "humility-core",
  "humility-hiffy",
  "humility-i2c",
  "humility-idol",
  "humility-pmbus",
+ "humility-spd",
  "indicatif",
  "num-derive 0.4.2",
  "num-traits",
@@ -2240,10 +2240,10 @@ dependencies = [
  "humility-cli",
  "humility-cmd",
  "humility-core",
- "humility-doppel",
  "humility-hiffy",
  "humility-i2c",
  "humility-log",
+ "humility-spd",
  "jep106",
  "parse_int",
  "spd",
@@ -2567,6 +2567,19 @@ dependencies = [
  "probe-rs",
  "rusb",
  "thiserror",
+]
+
+[[package]]
+name = "humility-spd"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "humility-core",
+ "humility-doppel",
+ "humility-hiffy",
+ "humility-i2c",
+ "humility-log",
+ "spd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ members = [
     "humility-log",
     "humility-net-core",
     "humility-pmbus",
-    "humility-stack",
     "humility-probes-core",
+    "humility-spd",
+    "humility-stack",
     "cmd/auxflash",
     "cmd/console-proxy",
     "cmd/counters",
@@ -132,6 +133,7 @@ humility-log = { path = "./humility-log" }
 humility-net-core = { path = "./humility-net-core" }
 humility-pmbus = { path = "./humility-pmbus" }
 humility-probes-core = { path = "./humility-probes-core" }
+humility-spd = { path = "./humility-spd" }
 humility-stack = { path = "./humility-stack" }
 cmd-auxflash = { path = "./cmd/auxflash", package = "humility-cmd-auxflash" }
 cmd-console-proxy = { path = "./cmd/console-proxy", package = "humility-cmd-console-proxy" }

--- a/cmd/rendmp/Cargo.toml
+++ b/cmd/rendmp/Cargo.toml
@@ -24,6 +24,6 @@ humility-hiffy.workspace = true
 humility-i2c.workspace = true
 humility-idol.workspace = true
 humility-pmbus.workspace = true
+humility-spd.workspace = true
 humility.workspace = true
 
-cmd-spd.workspace = true

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1719,7 +1719,7 @@ fn rendmp_phase_check<'a>(
             "DIMM presence check disabled, if this check hangs, remove the \
             DIMMs and retry."
         );
-    } else if cmd_spd::spd_any(hubris, core)? {
+    } else if humility_spd::spd_any(hubris, core)? {
         bail!(
             "cannot check phases with DIMMs present: if a checked \
             phase powers a DIMM, an I2C hang can result; this can be \

--- a/cmd/spd/Cargo.toml
+++ b/cmd/spd/Cargo.toml
@@ -14,8 +14,8 @@ parse_int.workspace = true
 
 humility-cli.workspace = true
 humility-cmd.workspace = true
-humility-doppel.workspace = true
 humility-hiffy.workspace = true
 humility-i2c.workspace = true
 humility-log.workspace = true
+humility-spd.workspace = true
 humility.workspace = true

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -107,16 +107,12 @@
 //!
 
 use humility::hubris::*;
-use humility::{
-    reflect,
-    reflect::{Base, Load, Value},
-};
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
-use humility_doppel as doppel;
 use humility_hiffy::*;
 use humility_i2c::I2cArgs;
 use humility_log::msg;
+use humility_spd::{GIMLET_SPD_SIZE, SpdData, spd_lookup};
 use std::fs::File;
 use std::io::Write;
 use std::str;
@@ -176,9 +172,6 @@ struct SpdArgs {
     output: Option<String>,
 }
 
-/// SPD array size for Gimlet
-const GIMLET_SPD_SIZE: usize = spd::ee1004::MAX_SIZE;
-
 fn from_bcd(val: u8) -> u8 {
     (val >> 4) * 10 + (val & 0xf)
 }
@@ -200,7 +193,7 @@ fn dump_spd(
 ) -> Result<()> {
     // We're reading the same data out of both DDR4 and DDR5 SPD buffers, but
     // they have different positions.
-    let buf = &data.0;
+    let buf = data.get();
     let addrs = match buf.len() {
         spd::ee1004::MAX_SIZE => {
             use spd::ee1004::Offset;
@@ -337,137 +330,6 @@ fn set_page(
     ops.push(Op::DropN(4));
 }
 
-//
-// Our SPD data is sitting in packrat, so we'll specify just enough of the
-// embedded structures to get at it.
-//
-static PACKRAT_BUF_NAME: &str = "task_packrat::main::BUFS";
-
-/// Raw data read from a single SPD
-struct SpdData(Vec<u8>);
-
-/// Reads in-memory SPD data from a system (either live or post-mortem)
-///
-/// Looks for either a `SPD_DATA` global buffer or a field in the `packrat`
-/// buffers.  If neither is available, returns `Ok(None)`; otherwise, returns a
-/// `Vec<SpdData>` (one [`SpdData`] per DIMM in the system).
-fn spd_lookup(
-    hubris: &HubrisArchive,
-    core: &mut dyn humility::core::Core,
-) -> Result<Option<Vec<SpdData>>> {
-    if let Ok(variables) = hubris.lookup_variables("SPD_DATA") {
-        if variables.len() > 1 {
-            bail!("more than one SPD_DATA?");
-        }
-
-        let var = variables[0];
-        let mut buf: Vec<u8> = vec![0u8; var.size];
-
-        core.halt()?;
-        core.read_8(var.addr, &mut buf)?;
-        core.run()?;
-
-        if !buf.len().is_multiple_of(GIMLET_SPD_SIZE) {
-            bail!(
-                "SPD_DATA is {} bytes; expected even multiple \
-                 of {GIMLET_SPD_SIZE}",
-                buf.len(),
-            );
-        }
-        Ok(Some(
-            buf.chunks_exact(GIMLET_SPD_SIZE)
-                .map(|chunk| SpdData(chunk.to_vec()))
-                .collect(),
-        ))
-    } else if let Ok(var) = hubris.lookup_qualified_variable(PACKRAT_BUF_NAME) {
-        let var_ty = hubris.lookup_type(var.goff)?;
-        let mut buf: Vec<u8> = vec![0u8; var.size];
-
-        core.halt()?;
-        core.read_8(var.addr, &mut buf)?;
-        core.run()?;
-
-        let v = reflect::load_value(hubris, &buf, var_ty, 0)?;
-        let as_static_cell = doppel::ClaimOnceCell::from_value(&v)?;
-        let Value::Struct(packrat_bufs) = &as_static_cell.cell.value else {
-            bail!("expected {PACKRAT_BUF_NAME} to be a struct");
-        };
-        let Some(Value::Struct(compute_sled_bufs)) = packrat_bufs
-            .get("gimlet_bufs")
-            .or_else(|| packrat_bufs.get("cosmo_bufs"))
-        else {
-            bail!("could not find `gimlet_bufs` or `cosmo_bufs`");
-        };
-        let Some(spd_data) = compute_sled_bufs.get("spd_data") else {
-            bail!("could not find `spd_data` in sled-specific packrat bufs");
-        };
-
-        // We have multiple versions of SPD data.  In older firmwares (Gimlet
-        // only), it's a single `[u8; 8192]` buffer; in newer firmwares, it's a
-        // nested struct that contains a `[[u8; DATA_SIZE]; DIMM_COUNT]`.
-        let spd_bufs = match spd_data {
-            Value::Array(a) => {
-                if a.len() % GIMLET_SPD_SIZE != 0 {
-                    bail!(
-                        "SPD data in {PACKRAT_BUF_NAME} is {} bytes;
-                         expected even multiple of {GIMLET_SPD_SIZE}",
-                        a.len(),
-                    );
-                }
-                let mut out = Vec::with_capacity(a.len() / GIMLET_SPD_SIZE);
-                for vs in a.chunks_exact(GIMLET_SPD_SIZE) {
-                    let mut chunk = Vec::with_capacity(GIMLET_SPD_SIZE);
-                    for v in vs {
-                        let Value::Base(Base::U8(b)) = v else {
-                            bail!("expected `u8` array");
-                        };
-                        chunk.push(*b);
-                    }
-                    out.push(SpdData(chunk))
-                }
-                out
-            }
-            Value::Struct(s) => {
-                let Some(Value::Array(a)) = s.get("spd_data") else {
-                    bail!("expected `spd_data` to be an array");
-                };
-                let mut out = Vec::with_capacity(a.len());
-                for a in a.iter() {
-                    let Value::Array(a) = a else {
-                        bail!("expected array-of-arrays");
-                    };
-                    let mut chunk = Vec::with_capacity(a.len());
-                    for v in a.iter() {
-                        let Value::Base(Base::U8(b)) = v else {
-                            bail!("expected `u8` array");
-                        };
-                        chunk.push(*b);
-                    }
-                    out.push(SpdData(chunk))
-                }
-                out
-            }
-            _ => bail!("expected `spd_data` to be an array or struct"),
-        };
-        Ok(Some(spd_bufs))
-    } else {
-        Ok(None)
-    }
-}
-
-pub fn spd_any(
-    hubris: &HubrisArchive,
-    core: &mut dyn humility::core::Core,
-) -> Result<bool> {
-    match spd_lookup(hubris, core)? {
-        Some(spd_data) => Ok(spd_data
-            .iter()
-            .flat_map(|d| d.0.iter())
-            .any(|&datum| datum != 0)),
-        None => Ok(false),
-    }
-}
-
 fn spd(context: &mut ExecutionContext) -> Result<()> {
     let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
@@ -483,7 +345,7 @@ fn spd(context: &mut ExecutionContext) -> Result<()> {
 
         let mut header = true;
         for (addr, data) in spd_data.iter().enumerate() {
-            if !data.0.iter().any(|&datum| datum != 0) {
+            if !data.get().iter().any(|&datum| datum != 0) {
                 continue;
             }
 
@@ -650,7 +512,7 @@ fn dump_ddr4_over_i2c(
                 bail!("bad SPD length ({} bytes): {results:?}", buf.len());
             }
 
-            dump_spd(subargs, addr, &SpdData(buf), header)?;
+            dump_spd(subargs, addr, &SpdData::new(buf), header)?;
             header = false;
         }
     }

--- a/humility-spd/Cargo.toml
+++ b/humility-spd/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "humility-spd"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+spd.workspace = true
+
+humility-doppel.workspace = true
+humility-hiffy.workspace = true
+humility-i2c.workspace = true
+humility-log.workspace = true
+humility.workspace = true

--- a/humility-spd/src/lib.rs
+++ b/humility-spd/src/lib.rs
@@ -1,0 +1,156 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use humility::hubris::*;
+use humility::{
+    reflect,
+    reflect::{Base, Load, Value},
+};
+use humility_doppel as doppel;
+
+use anyhow::{Result, bail};
+
+/// Name of the packrat buffer which contains SPD data
+static PACKRAT_BUF_NAME: &str = "task_packrat::main::BUFS";
+
+/// Raw data read from a single SPD
+pub struct SpdData(Vec<u8>);
+
+impl SpdData {
+    /// Builds a new [`SpdData`] object
+    pub fn new(data: Vec<u8>) -> Self {
+        Self(data)
+    }
+
+    /// Returns the inner data buffer
+    pub fn get(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// SPD array size for Gimlet
+pub const GIMLET_SPD_SIZE: usize = spd::ee1004::MAX_SIZE;
+
+/// Reads in-memory SPD data from a system (either live or post-mortem)
+///
+/// Looks for either a `SPD_DATA` global buffer or a field in the `packrat`
+/// buffers.  If neither is available, returns `Ok(None)`; otherwise, returns a
+/// `Vec<SpdData>` (one [`SpdData`] per DIMM in the system).
+pub fn spd_lookup(
+    hubris: &HubrisArchive,
+    core: &mut dyn humility::core::Core,
+) -> Result<Option<Vec<SpdData>>> {
+    if let Ok(variables) = hubris.lookup_variables("SPD_DATA") {
+        if variables.len() > 1 {
+            bail!("more than one SPD_DATA?");
+        }
+
+        let var = variables[0];
+        let mut buf: Vec<u8> = vec![0u8; var.size];
+
+        core.halt()?;
+        core.read_8(var.addr, &mut buf)?;
+        core.run()?;
+
+        if !buf.len().is_multiple_of(GIMLET_SPD_SIZE) {
+            bail!(
+                "SPD_DATA is {} bytes; expected even multiple \
+                 of {GIMLET_SPD_SIZE}",
+                buf.len(),
+            );
+        }
+        Ok(Some(
+            buf.chunks_exact(GIMLET_SPD_SIZE)
+                .map(|chunk| SpdData(chunk.to_vec()))
+                .collect(),
+        ))
+    } else if let Ok(var) = hubris.lookup_qualified_variable(PACKRAT_BUF_NAME) {
+        let var_ty = hubris.lookup_type(var.goff)?;
+        let mut buf: Vec<u8> = vec![0u8; var.size];
+
+        core.halt()?;
+        core.read_8(var.addr, &mut buf)?;
+        core.run()?;
+
+        let v = reflect::load_value(hubris, &buf, var_ty, 0)?;
+        let as_static_cell = doppel::ClaimOnceCell::from_value(&v)?;
+        let Value::Struct(packrat_bufs) = &as_static_cell.cell.value else {
+            bail!("expected {PACKRAT_BUF_NAME} to be a struct");
+        };
+        let Some(Value::Struct(compute_sled_bufs)) = packrat_bufs
+            .get("gimlet_bufs")
+            .or_else(|| packrat_bufs.get("cosmo_bufs"))
+        else {
+            bail!("could not find `gimlet_bufs` or `cosmo_bufs`");
+        };
+        let Some(spd_data) = compute_sled_bufs.get("spd_data") else {
+            bail!("could not find `spd_data` in sled-specific packrat bufs");
+        };
+
+        // We have multiple versions of SPD data.  In older firmwares (Gimlet
+        // only), it's a single `[u8; 8192]` buffer; in newer firmwares, it's a
+        // nested struct that contains a `[[u8; DATA_SIZE]; DIMM_COUNT]`.
+        let spd_bufs = match spd_data {
+            Value::Array(a) => {
+                if a.len() % GIMLET_SPD_SIZE != 0 {
+                    bail!(
+                        "SPD data in {PACKRAT_BUF_NAME} is {} bytes;
+                         expected even multiple of {GIMLET_SPD_SIZE}",
+                        a.len(),
+                    );
+                }
+                let mut out = Vec::with_capacity(a.len() / GIMLET_SPD_SIZE);
+                for vs in a.chunks_exact(GIMLET_SPD_SIZE) {
+                    let mut chunk = Vec::with_capacity(GIMLET_SPD_SIZE);
+                    for v in vs {
+                        let Value::Base(Base::U8(b)) = v else {
+                            bail!("expected `u8` array");
+                        };
+                        chunk.push(*b);
+                    }
+                    out.push(SpdData(chunk))
+                }
+                out
+            }
+            Value::Struct(s) => {
+                let Some(Value::Array(a)) = s.get("spd_data") else {
+                    bail!("expected `spd_data` to be an array");
+                };
+                let mut out = Vec::with_capacity(a.len());
+                for a in a.iter() {
+                    let Value::Array(a) = a else {
+                        bail!("expected array-of-arrays");
+                    };
+                    let mut chunk = Vec::with_capacity(a.len());
+                    for v in a.iter() {
+                        let Value::Base(Base::U8(b)) = v else {
+                            bail!("expected `u8` array");
+                        };
+                        chunk.push(*b);
+                    }
+                    out.push(SpdData(chunk))
+                }
+                out
+            }
+            _ => bail!("expected `spd_data` to be an array or struct"),
+        };
+        Ok(Some(spd_bufs))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Returns true if any non-empty SPD devices are present
+pub fn spd_any(
+    hubris: &HubrisArchive,
+    core: &mut dyn humility::core::Core,
+) -> Result<bool> {
+    match spd_lookup(hubris, core)? {
+        Some(spd_data) => Ok(spd_data
+            .iter()
+            .flat_map(|d| d.0.iter())
+            .any(|&datum| datum != 0)),
+        None => Ok(false),
+    }
+}


### PR DESCRIPTION
This breaks the `cmd-rendmp` → `cmd-spd` chain