### PR TITLE
Move `get_probe_serial` to method on `Cli`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "humility-core",
  "indexmap 1.9.3",
  "parse_int",
+ "regex",
  "serde",
  "serde_json",
 ]
@@ -1688,7 +1689,6 @@ dependencies = [
  "ctrlc",
  "humility-cli",
  "humility-cmd",
- "humility-cmd-openocd",
  "humility-core",
  "tempfile",
 ]
@@ -1964,7 +1964,6 @@ dependencies = [
  "ctrlc",
  "humility-cli",
  "humility-cmd",
- "regex",
  "tempfile",
 ]
 

--- a/cmd/gdb/Cargo.toml
+++ b/cmd/gdb/Cargo.toml
@@ -10,7 +10,6 @@ description = "Attach to a running system using GDB"
 humility = { workspace = true }
 humility-cmd = { workspace = true }
 humility-cli = { workspace = true }
-cmd-openocd = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 ctrlc = { workspace = true }

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -19,8 +19,6 @@
 
 use std::process::{Command, Stdio};
 
-use cmd_openocd::get_probe_serial;
-
 use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Command as HumilityCmd, CommandKind};
 
@@ -62,7 +60,7 @@ fn gdb(context: &mut ExecutionContext) -> Result<()> {
     }
 
     let subargs = GdbArgs::try_parse_from(subargs)?;
-    let serial = get_probe_serial(&context.cli, subargs.serial.clone())?;
+    let serial = context.cli.get_probe_serial(subargs.serial.as_deref())?;
 
     let work_dir = tempfile::tempdir()?;
     let name = match &hubris.manifest.name {

--- a/cmd/openocd/Cargo.toml
+++ b/cmd/openocd/Cargo.toml
@@ -10,5 +10,4 @@ humility-cli = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
 ctrlc = { workspace = true }
-regex = { workspace = true }
 tempfile = { workspace = true }

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::process;
 
-use humility_cli::{Cli, ExecutionContext, Subcommand};
+use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::{Archive, Command, CommandKind};
 
 use anyhow::{Context, Result, bail};
@@ -36,54 +36,6 @@ struct OcdArgs {
     extra_options: Vec<String>,
 }
 
-/// Extracts and returns the probe serial name for use in OpenOCD
-///
-/// We can get the serial name from two different places:
-/// - If the global `--probe` argument is of the form `vid:pid:serial`, then we
-///   can extract the serial name.  This is also the case if we're using an
-///   environment file, which populates `args.probe` automatically.
-/// - If the `--serial` argument is given in this command's subarguments,
-///   then we use it directly.
-///
-/// This function checks both sources, returns an error if they conflict, and
-/// returns the (optional) serial name otherwise.
-pub fn get_probe_serial(
-    args: &Cli,
-    subargs_serial: Option<String>,
-) -> Result<Option<String>> {
-    match &args.probe {
-        Some(probe) => {
-            let re = regex::Regex::new(
-                r"^([[:xdigit:]]+):([[:xdigit:]]+):([[:xdigit:]]+)$",
-            )
-            .unwrap();
-            if let Some(cap) = re.captures(probe) {
-                if subargs_serial.is_some() {
-                    if args.target.is_some() {
-                        bail!(
-                            "Cannot specify probe serial number with both \
-                             environment and `--serial`"
-                        );
-                    } else {
-                        bail!(
-                            "Cannot specify probe serial number with both \
-                             `--probe` and `--serial`"
-                        );
-                    }
-                }
-                Ok(Some(cap.get(3).unwrap().as_str().to_string()))
-            } else {
-                bail!(
-                    "Cannot specify `--probe {}` with `openocd` subcommand \
-                     (must be of the form vid:pid:serial)",
-                    probe
-                );
-            }
-        }
-        None => Ok(subargs_serial),
-    }
-}
-
 fn openocd(context: &mut ExecutionContext) -> Result<()> {
     if context.cli.probe.is_some() {
         bail!("Cannot specify --probe with `openocd` subcommand");
@@ -92,7 +44,7 @@ fn openocd(context: &mut ExecutionContext) -> Result<()> {
     let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
 
     let subargs = OcdArgs::try_parse_from(subargs)?;
-    let serial = get_probe_serial(&context.cli, subargs.serial.clone())?;
+    let serial = context.cli.get_probe_serial(subargs.serial.as_deref())?;
 
     let hubris = context.archive.as_ref().unwrap();
 

--- a/humility-cli/Cargo.toml
+++ b/humility-cli/Cargo.toml
@@ -8,9 +8,10 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-serde_json.workspace = true
-serde.workspace = true
-parse_int.workspace = true
 indexmap.workspace = true
+parse_int.workspace = true
+regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 humility.workspace = true

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub mod env;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{AppSettings, ArgGroup, ArgMatches, Parser};
 use env::Environment;
 use humility::{core::Core, hubris::HubrisArchive, msg, net, warn};
@@ -112,6 +112,55 @@ pub struct Cli {
 
     #[clap(subcommand)]
     pub cmd: Option<Subcommand>,
+}
+
+impl Cli {
+    /// Extracts and returns the probe serial name
+    ///
+    /// We can get the serial name from two different places:
+    /// - If the global `--probe` argument is of the form `vid:pid:serial`, then we
+    ///   can extract the serial name.  This is also the case if we're using an
+    ///   environment file, which populates `args.probe` automatically.
+    /// - If the `--serial` argument is given in this command's subarguments,
+    ///   then we use it directly.
+    ///
+    /// This function checks both sources, returns an error if they conflict, and
+    /// returns the (optional) serial name otherwise.
+    pub fn get_probe_serial(
+        &self,
+        subargs_serial: Option<&str>,
+    ) -> Result<Option<String>> {
+        match &self.probe {
+            Some(probe) => {
+                let re = regex::Regex::new(
+                    r"^([[:xdigit:]]+):([[:xdigit:]]+):([[:xdigit:]]+)$",
+                )
+                .unwrap();
+                if let Some(cap) = re.captures(probe) {
+                    if subargs_serial.is_some() {
+                        if self.target.is_some() {
+                            bail!(
+                                "Cannot specify probe serial number with both \
+                                 environment and `--serial`"
+                            );
+                        } else {
+                            bail!(
+                                "Cannot specify probe serial number with both \
+                                 `--probe` and `--serial`"
+                            );
+                        }
+                    }
+                    Ok(Some(cap.get(3).unwrap().as_str().to_string()))
+                } else {
+                    bail!(
+                        "`--probe` argument must be of the form
+                         `vid:pid:serial`, not {probe}",
+                    );
+                }
+            }
+            None => Ok(subargs_serial.map(|s| s.to_owned())),
+        }
+    }
 }
 
 #[derive(Parser, Debug, Clone)]


### PR DESCRIPTION
This removes a `cmd-gdb` → `cmd-openocd` dependency