### PR TITLE
Use more powerful reflection functions when possible

### DIFF
--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -89,7 +89,7 @@ pub fn ereport_dump(
         .lookup_qualified_variable(PACKRAT_BUF_NAME)
         .with_context(|| format!("could not find `{PACKRAT_BUF_NAME}`"))?;
 
-    let buf: Value = humility::reflect::load_variable(hubris, core, buf_ty)?;
+    let buf: Value = humility::reflect::read_variable(hubris, core, buf_ty)?;
     let outer_storage: Value = buf.field("cell.value.ereport_bufs.storage")?;
     let inner_storage: Value = outer_storage.field("storage")?;
     let array: Vec<humility_doppel::MaybeUninit<u8>> =

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -171,7 +171,7 @@ fn read_uqvar(
         return Ok(None);
     };
     let buf: doppel::MaybeUninit<Vec<u8>> =
-        reflect::load_variable(hubris, core, var)?;
+        reflect::read_variable(hubris, core, var)?;
     Ok(Some(buf.value))
 }
 
@@ -185,7 +185,7 @@ fn read_qualified_state_buf(
     };
 
     let as_static_cell: doppel::ClaimOnceCell =
-        reflect::load_variable(hubris, core, var)?;
+        reflect::read_variable(hubris, core, var)?;
     Ok(Some(HostStateBuf::from_value(&as_static_cell.cell.value)?))
 }
 

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -170,14 +170,9 @@ fn read_uqvar(
     let Some(var) = hubris.lookup_variable(name).ok() else {
         return Ok(None);
     };
-
-    let mut buf: Vec<u8> = vec![0u8; var.size];
-
-    core.halt()?;
-    core.read_8(var.addr, buf.as_mut_slice())?;
-    core.run()?;
-
-    Ok(Some(buf))
+    let buf: doppel::MaybeUninit<Vec<u8>> =
+        reflect::load_variable(hubris, core, var)?;
+    Ok(Some(buf.value))
 }
 
 fn read_qualified_state_buf(
@@ -189,16 +184,8 @@ fn read_qualified_state_buf(
         return Ok(None);
     };
 
-    let var_ty = hubris.lookup_type(var.goff)?;
-
-    let mut buf: Vec<u8> = vec![0u8; var.size];
-
-    core.halt()?;
-    core.read_8(var.addr, &mut buf)?;
-    core.run()?;
-
-    let v = reflect::load_value(hubris, &buf, var_ty, 0)?;
-    let as_static_cell = doppel::ClaimOnceCell::from_value(&v)?;
+    let as_static_cell: doppel::ClaimOnceCell =
+        reflect::load_variable(hubris, core, var)?;
     Ok(Some(HostStateBuf::from_value(&as_static_cell.cell.value)?))
 }
 

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -338,15 +338,12 @@ impl SensorReader for HiffySensorReader<'_> {
 struct RamSensorReader {
     /// Position of `LAST_READING` in global RAM
     last_reading: HubrisVariable,
-    last_reading_buf: Vec<u8>,
 
     /// Position of `DATA_VALUE` in global RAM
     data_value: HubrisVariable,
-    data_value_buf: Vec<u8>,
 
     /// Position of `NERRORS` in global RAM
     nerrors: HubrisVariable,
-    nerrors_buf: Vec<u8>,
 
     /// Indexes of sensors that we care about
     ///
@@ -381,24 +378,20 @@ impl RamSensorReader {
 
         Ok(Self {
             last_reading,
-            last_reading_buf: vec![0u8; last_reading.size],
             data_value,
-            data_value_buf: vec![0u8; data_value.size],
             nerrors,
-            nerrors_buf: vec![0u8; nerrors.size],
             sensors: sensors.iter().map(|(i, _)| *i).collect(),
         })
     }
 
-    fn unpack_array<T: Load + Copy>(
+    fn read_array<T: Load + Copy>(
         &self,
         hubris: &HubrisArchive,
-        buf: &[u8],
-        var: HubrisVariable,
+        core: &mut dyn Core,
+        var: &HubrisVariable,
     ) -> Result<Vec<T>> {
-        let v =
-            reflect::load_value(hubris, buf, hubris.lookup_type(var.goff)?, 0)?;
-        let out = doppel::MaybeUninit::<Vec<T>>::from_value(&v)?;
+        let out: doppel::MaybeUninit<Vec<T>> =
+            reflect::load_variable(hubris, core, var)?;
         Ok(self.sensors.iter().map(|i| out.value[*i]).collect())
     }
 }
@@ -409,20 +402,13 @@ impl SensorReader for RamSensorReader {
         hubris: &HubrisArchive,
         core: &mut dyn Core,
     ) -> Result<SensorData> {
-        core.read_8(self.data_value.addr, &mut self.data_value_buf)?;
-        core.read_8(self.last_reading.addr, &mut self.last_reading_buf)?;
-        core.read_8(self.nerrors.addr, &mut self.nerrors_buf)?;
+        let data_values =
+            self.read_array::<f32>(hubris, core, &self.data_value)?;
 
-        let data_values = self.unpack_array::<f32>(
+        let last_reading = self.read_array::<Option<LastReading>>(
             hubris,
-            &self.data_value_buf,
-            self.data_value,
-        )?;
-
-        let last_reading = self.unpack_array::<Option<LastReading>>(
-            hubris,
-            &self.last_reading_buf,
-            self.last_reading,
+            core,
+            &self.last_reading,
         )?;
 
         // Clear data values that aren't valid (according to `last_reading`)
@@ -436,7 +422,7 @@ impl SensorReader for RamSensorReader {
             .collect::<Vec<_>>();
 
         let nerrors = self
-            .unpack_array::<u32>(hubris, &self.nerrors_buf, self.nerrors)?
+            .read_array::<u32>(hubris, core, &self.nerrors)?
             .into_iter()
             .map(Option::Some)
             .collect();

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -391,7 +391,7 @@ impl RamSensorReader {
         var: &HubrisVariable,
     ) -> Result<Vec<T>> {
         let out: doppel::MaybeUninit<Vec<T>> =
-            reflect::load_variable(hubris, core, var)?;
+            reflect::read_variable(hubris, core, var)?;
         Ok(self.sensors.iter().map(|i| out.value[*i]).collect())
     }
 }

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -790,7 +790,7 @@ pub fn load<'a, T: Load>(
 }
 
 /// Loads a variable and interprets it as a particular `Load`-able type
-pub fn load_variable<T: Load>(
+pub fn read_variable<T: Load>(
     hubris: &HubrisArchive,
     core: &mut dyn Core,
     var: &HubrisVariable,

--- a/humility-pmbus/src/lib.rs
+++ b/humility-pmbus/src/lib.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow};
 use humility::{core::Core, hubris::*};
 use std::collections::BTreeMap;
 
@@ -17,40 +17,16 @@ pub fn sensor_id_map(
         .qualified_variables()
         .find(|&(n, _v)| n == "task_power::bsp::CONTROLLER_CONFIG")
         .ok_or_else(|| anyhow!("could not find CONTROLLER_CONFIG"))?;
-    let mut buf: Vec<u8> = vec![0u8; var.size];
-    core.halt()?;
-    core.read_8(var.addr, buf.as_mut_slice())?;
-    core.run()?;
-    let controller_config = humility::reflect::load_value(
-        hubris,
-        &buf,
-        hubris.lookup_type(var.goff)?,
-        0,
-    )?;
+    let array: humility::reflect::Array =
+        humility::reflect::load_variable(hubris, core, var)?;
 
     // Destructure CONTROLLER_CONFIG to build a map of voltage sensor IDs
     // (which we can easily compute) to index in the CONTROLLER_CONFIG
     // array.
-    use humility::reflect::{Base, Value};
-    let Value::Array(array) = controller_config else {
-        bail!("invalid shape for CONTROLLER_CONFIG: {controller_config:?}");
-    };
     let mut sensor_id_to_index = BTreeMap::new();
     for (i, cfg) in array.iter().enumerate() {
-        let Value::Struct(s) = cfg else {
-            bail!("invalid shape for CONTROLLER_CONFIG[{i}]: {cfg:?}");
-        };
-        let v = &s["voltage"];
-        let Value::Tuple(t) = v else {
-            bail!("could not get 'voltage': {v:?}");
-        };
-        let Value::Base(b) = &t[0] else {
-            bail!("could not get sensor ID from 'voltage': {v:?}");
-        };
-        let Base::U32(sensor_id) = b else {
-            bail!("bad sensor id type: {b:?}");
-        };
-        sensor_id_to_index.insert(*sensor_id, i);
+        let sensor_id: u32 = cfg.field("voltage.0")?;
+        sensor_id_to_index.insert(sensor_id, i);
     }
     Ok(sensor_id_to_index)
 }

--- a/humility-pmbus/src/lib.rs
+++ b/humility-pmbus/src/lib.rs
@@ -18,7 +18,7 @@ pub fn sensor_id_map(
         .find(|&(n, _v)| n == "task_power::bsp::CONTROLLER_CONFIG")
         .ok_or_else(|| anyhow!("could not find CONTROLLER_CONFIG"))?;
     let array: humility::reflect::Array =
-        humility::reflect::load_variable(hubris, core, var)?;
+        humility::reflect::read_variable(hubris, core, var)?;
 
     // Destructure CONTROLLER_CONFIG to build a map of voltage sensor IDs
     // (which we can easily compute) to index in the CONTROLLER_CONFIG


### PR DESCRIPTION
This PR uses improved reflection APIs in a few place.

The relevant APIs are the following:

- `read_variable` (renamed in this PR, was previously `load_variable`) reads a value from a `Core` then uses `Load::from_value` to get a type `T`
- `reflect::Struct::field` accesses a field by name, to eliminate manual destructuring chains