### PR TITLE
Use `with_context` for non-trivial contexts

### DIFF
--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -308,7 +308,7 @@ fn hiffy(context: &mut ExecutionContext) -> Result<()> {
         if let Some(data) = output {
             if let Some(out) = &subargs.output {
                 std::fs::write(out, &data)
-                    .context(format!("Could not write to {}", out))?;
+                    .with_context(|| format!("Could not write to {}", out))?;
                 println!("Wrote {} bytes to '{}'", data.len(), out);
             } else if subargs.hex {
                 println!("Data: {:x?}", data);

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -2310,10 +2310,12 @@ impl HubrisArchive {
             assert!(nbytes > 0);
 
             let mut id = vec![0; nbytes];
-            core.read_8(addr, &mut id[0..nbytes]).context(format!(
-                "failed to read image ID at 0x{:x}; board mismatch?",
-                addr
-            ))?;
+            core.read_8(addr, &mut id[0..nbytes]).with_context(|| {
+                format!(
+                    "failed to read image ID at 0x{:x}; board mismatch?",
+                    addr
+                )
+            })?;
 
             let deltas = id
                 .iter()
@@ -2673,7 +2675,7 @@ impl HubrisArchive {
                         bail!("task {} has bad regions addr 0x{:x}", i, taddr);
                     }
 
-                    core.read_8(taddr, &mut indices).context(format!(
+                    core.read_8(taddr, &mut indices).with_context(|| format!(
                         "failed to read region descriptors for task {} at 0x{:x}",
                         i, taddr)
                     )?;
@@ -4268,10 +4270,11 @@ impl HubrisObjectLoader {
         }
 
         self.load_object_dwarf(task, buffer, &elf)
-            .context(format!("{}: failed to load DWARF", object))?;
+            .with_context(|| format!("{}: failed to load DWARF", object))?;
 
-        self.load_object_frames(task, buffer, &elf)
-            .context(format!("{}: failed to load debug frames", object))?;
+        self.load_object_frames(task, buffer, &elf).with_context(|| {
+            format!("{}: failed to load debug frames", object)
+        })?;
 
         let iface = self.load_object_idolatry(object, buffer, &elf)?;
 

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -120,7 +120,7 @@ impl HiffyFunction {
     ) -> Result<Vec<(String, u16)>> {
         let arg = hubris
             .lookup_enum(self.args[ndx])
-            .context(format!("expected enum for arg #{}", ndx))?;
+            .with_context(|| format!("expected enum for arg #{}", ndx))?;
 
         let mut variants = vec![];
 
@@ -144,7 +144,7 @@ impl HiffyFunction {
     ) -> Result<u16> {
         let arg = hubris
             .lookup_enum(self.args[ndx])
-            .context(format!("expected enum for {}", what))?;
+            .with_context(|| format!("expected enum for {}", what))?;
 
         for v in &arg.variants {
             let tag = v.tag.ok_or_else(|| {
@@ -228,7 +228,7 @@ impl<'a> HiffyContext<'a> {
 
         let result = core
             .read_word_32(v.addr)
-            .context(format!("couldn't read {}", name))?;
+            .with_context(|| format!("couldn't read {}", name))?;
 
         Ok(result)
     }

--- a/humility-idol/src/lib.rs
+++ b/humility-idol/src/lib.rs
@@ -385,10 +385,9 @@ fn bytes_from_str(value: &str) -> Result<Vec<u8>> {
         let mut bytes: Vec<u8> = Vec::new();
         for element in value.split(' ') {
             let element = element.trim();
-            let byte: u8 = element.parse().context(format!(
-                "cannot parse \"{}\" as u8 (is it base 10?)",
-                element
-            ))?;
+            let byte: u8 = element.parse().with_context(|| {
+                format!("cannot parse \"{}\" as u8 (is it base 10?)", element)
+            })?;
             bytes.push(byte);
         }
 
@@ -735,9 +734,9 @@ fn call_arg_enum(
     value: &IdolArgument,
     buf: &mut [u8],
 ) -> Result<()> {
-    let t = hubris
-        .lookup_type(member.goff)
-        .context(format!("expected type for arg {} ({})", arg, member.goff))?;
+    let t = hubris.lookup_type(member.goff).with_context(|| {
+        format!("expected type for arg {} ({})", arg, member.goff)
+    })?;
 
     let value = match value {
         IdolArgument::String(value) => *value,

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -176,7 +176,7 @@ impl NetCore {
         if self.flash.read(addr, data).is_some() {
             Ok(())
         } else {
-            self.read_ram(addr, data).context(format!(
+            self.read_ram(addr, data).with_context(|| format!(
                 "0x{addr:0x} can't be read via the archive or over the network"
             ))
         }


### PR DESCRIPTION
If the context is anything other than a static string, we should use `with_context` to avoid doing the work (typically a `format!(..)` call).  This _probably_ doesn't make a noticeably difference, but is a pet peeve of mine.