### PR TITLE
Bump `idol`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +424,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
@@ -470,7 +477,7 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "textwrap",
 ]
@@ -494,7 +501,7 @@ dependencies = [
  "anstream 0.6.11",
  "anstyle",
  "clap_lex 0.6.0",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -918,8 +925,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -932,8 +949,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -942,9 +973,20 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2433,7 +2475,7 @@ dependencies = [
  "scroll 0.13.0",
  "serde",
  "serde_json",
- "strsim",
+ "strsim 0.10.0",
  "thiserror",
  "toml 0.5.11",
  "winapi",
@@ -2655,14 +2697,18 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idol"
-version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/idolatry.git#f2396893e786d4bfa75212312908198b8d6a5310"
+version = "0.6.0"
+source = "git+https://github.com/oxidecomputer/idolatry.git#2c43ec5122030a4de12861bd7071e657f8d25b7f"
 dependencies = [
  "indexmap 1.9.3",
+ "once_cell",
+ "prettyplease",
+ "proc-macro2",
  "quote",
  "ron 0.8.0",
  "serde",
- "toml 0.7.3",
+ "serde_with 3.8.1",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2700,6 +2746,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -3332,7 +3379,7 @@ dependencies = [
  "num-traits",
  "ron 0.8.0",
  "serde",
- "serde_with",
+ "serde_with 1.14.0",
 ]
 
 [[package]]
@@ -3359,12 +3406,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "probe-rs"
 version = "0.12.0"
 source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#078eafb444c4e03fa7d41c7273264d00564210ce"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "bitfield",
  "bitvec",
@@ -3394,7 +3451,7 @@ name = "probe-rs-target"
 version = "0.12.0"
 source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide-v0.12.0#078eafb444c4e03fa7d41c7273264d00564210ce"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "jep106",
  "serde",
 ]
@@ -3607,7 +3664,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -3618,7 +3675,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -3629,7 +3686,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300a51053b1cb55c80b7a9fde4120726ddf25ca241a1cbb926626f62fb136bff"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -3834,7 +3891,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
  "serde",
- "serde_with_macros",
+ "serde_with_macros 1.5.2",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros 3.8.1",
+ "time",
 ]
 
 [[package]]
@@ -3843,10 +3918,22 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4015,6 +4102,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -4194,8 +4287,10 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
+ "itoa",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4203,6 +4298,15 @@ name = "time-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tlvc"
@@ -4232,17 +4336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ rust-version = "1.89" # if this changes, edit ci.yaml as well!
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
 humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.3" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git"}
+idol = {git = "https://github.com/oxidecomputer/idolatry.git" }
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
 ipcc-data = { git = "https://github.com/oxidecomputer/ipcc-rs" }
 measurement-token = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -45,7 +45,7 @@
 //! within Humility, use `-L` (`--list-functions`).
 //!
 
-use ::idol::syntax::{Operation, Reply};
+use ::idol::syntax::send::{Operation, Reply};
 use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
@@ -114,10 +114,10 @@ pub fn hiffy_list(hubris: &HubrisArchive, filter: Vec<String>) -> Result<()> {
         match args.next() {
             None => {}
             Some(arg) => {
-                println!("{}{:<27} {}", margin, arg.0, arg.1.ty.0);
+                println!("{}{:<27} {}", margin, arg.0, arg.1.ty);
 
                 for arg in args {
-                    println!("{}{:<27} {}", margin, arg.0, arg.1.ty.0);
+                    println!("{}{:<27} {}", margin, arg.0, arg.1.ty);
                 }
             }
         }
@@ -125,14 +125,14 @@ pub fn hiffy_list(hubris: &HubrisArchive, filter: Vec<String>) -> Result<()> {
         match idol::lookup_reply(hubris, module, op.0) {
             Ok((_, idol::IdolError::CLike(e))) => match &op.1.reply {
                 Reply::Result { ok, .. } => {
-                    println!("{}{:<27} {}", margin, "<ok>", ok.ty.0);
+                    println!("{}{:<27} {}", margin, "<ok>", ok.ty);
                     println!("{}{:<27} {}", margin, "<error>", e.name);
                 }
                 _ => warn!("mismatch on reply: found {op:?}"),
             },
             Ok((_, idol::IdolError::Complex(t))) => match &op.1.reply {
                 Reply::Result { ok, .. } => {
-                    println!("{}{:<27} {}", margin, "<ok>", ok.ty.0);
+                    println!("{}{:<27} {}", margin, "<ok>", ok.ty);
                     println!("{}{:<27} {}", margin, "<error>", t.name);
                 }
                 _ => warn!("mismatch on reply: found {op:?}"),
@@ -143,10 +143,10 @@ pub fn hiffy_list(hubris: &HubrisArchive, filter: Vec<String>) -> Result<()> {
                     //
                     // This is possible if the only error is ServerDeath
                     //
-                    println!("{}{:<27} {}", margin, "<ok>", ok.ty.0);
+                    println!("{}{:<27} {}", margin, "<ok>", ok.ty);
                 }
                 Reply::Simple(ok) => {
-                    println!("{}{:<27} {}", margin, "<ok>", ok.ty.0);
+                    println!("{}{:<27} {}", margin, "<ok>", ok.ty);
                 }
             },
             Err(e) => {

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -27,7 +27,7 @@ use fallible_iterator::FallibleIterator;
 use gimli::UnwindSection;
 use goblin::elf::Elf;
 use humpty::DumpTask;
-use idol::syntax::Interface;
+use idol::syntax::send::Interface;
 use multimap::MultiMap;
 use num_traits::FromPrimitive;
 use rustc_demangle::demangle;

--- a/humility-idol/src/lib.rs
+++ b/humility-idol/src/lib.rs
@@ -8,7 +8,7 @@
 //! `HubrisIdol` trait on `HubrisArchive`, which adds a `get_idol_command`
 //! function to easily look up an Idol command by name.
 
-use ::idol::syntax::{AttributedTy, Operation, RecvStrategy, Reply};
+use ::idol::syntax::send::{AttributedTy, Operation, RecvStrategy, Reply};
 use anyhow::{Context, Result, anyhow, bail};
 use hubpack::SerializedSize;
 use humility::hubris::*;
@@ -110,7 +110,7 @@ impl<'a> IdolOperation<'a> {
             // Find the expected name of the argument in the struct, based
             // on its encoding strategy (with a special case for `bool`, which
             // is packed into a single `u8`).
-            let ty = &arg.1.ty.0;
+            let ty = &arg.1.ty;
             let arg_name = match arg.1.recv {
                 RecvStrategy::FromBytes if ty != "bool" => arg.0.to_string(),
                 _ => format!("raw_{}", arg.0),
@@ -166,7 +166,7 @@ impl<'a> IdolOperation<'a> {
         //
         // The easiest option is if we're doing `FromBytes`, which encodes
         // the value directly (with a special case for booleans).
-        let ty = &arg.1.ty.0;
+        let ty = &arg.1.ty;
         if matches!(arg.1.recv, RecvStrategy::FromBytes) {
             if ty != "bool" {
                 call_arg(hubris, member, val, payload)?;
@@ -839,25 +839,26 @@ pub fn lookup_reply<'a>(
 
     match reply {
         Reply::Result { ok, err } => {
-            let err = match err {
-                ::idol::syntax::Error::CLike(t) => {
-                    let t = m.lookup_enum_byname(hubris, &t.0)?.ok_or_else(
-                        || anyhow!("failed to find error type {reply:?}"),
-                    )?;
+            let err =
+                match err {
+                    ::idol::syntax::Error::CLike(t) => {
+                        let t = m.lookup_enum_byname(hubris, t)?.ok_or_else(
+                            || anyhow!("failed to find error type {reply:?}"),
+                        )?;
 
-                    IdolError::CLike(t)
-                }
-                ::idol::syntax::Error::ServerDeath => IdolError::None,
-                ::idol::syntax::Error::Complex(t) => {
-                    let t = m.lookup_enum_byname(hubris, &t.0)?.ok_or_else(
-                        || anyhow!("failed to find error type {reply:?}"),
-                    )?;
-                    IdolError::Complex(t)
-                }
-            };
-            Ok((lookup_ok(&ok.ty.0)?, err))
+                        IdolError::CLike(t)
+                    }
+                    ::idol::syntax::Error::ServerDeath => IdolError::None,
+                    ::idol::syntax::Error::Complex(t) => {
+                        let t = m.lookup_enum_byname(hubris, t)?.ok_or_else(
+                            || anyhow!("failed to find error type {reply:?}"),
+                        )?;
+                        IdolError::Complex(t)
+                    }
+                };
+            Ok((lookup_ok(&ok.ty)?, err))
         }
-        Reply::Simple(ok) => Ok((lookup_ok(&ok.ty.0)?, IdolError::None)),
+        Reply::Simple(ok) => Ok((lookup_ok(&ok.ty)?, IdolError::None)),
     }
 }
 


### PR DESCRIPTION
We now deserialize to a `GenericInterface<String, String>` (i.e. using strings for both names and types).

See https://github.com/oxidecomputer/idolatry/pull/76 for additional context.