### PR TITLE
Bump humpty, serde, lzss, zerocopy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,7 +1231,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1654,7 +1654,7 @@ dependencies = [
  "lzss",
  "num-traits",
  "parse_int",
- "zerocopy 0.6.6",
+ "zerocopy",
  "zip",
 ]
 
@@ -1672,7 +1672,7 @@ dependencies = [
  "humility-doppel",
  "serde",
  "serde_json",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ dependencies = [
  "indexmap 1.9.3",
  "parse_int",
  "serde",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1837,7 +1837,7 @@ dependencies = [
  "parse_int",
  "serde",
  "serde_json",
- "zerocopy 0.6.6",
+ "zerocopy",
  "zip",
 ]
 
@@ -1873,7 +1873,7 @@ dependencies = [
  "idol",
  "parse_int",
  "pmbus",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1978,7 +1978,7 @@ dependencies = [
  "num-traits",
  "parse_int",
  "pmbus",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2200,7 +2200,7 @@ dependencies = [
  "pmbus",
  "strum 0.25.0",
  "strum_macros 0.25.3",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2247,7 +2247,7 @@ dependencies = [
  "parse_int",
  "raw-cpuid",
  "termimad 0.21.1",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "serde",
  "tlvc",
  "tlvc-text",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2479,7 +2479,7 @@ dependencies = [
  "thiserror",
  "toml 0.5.11",
  "winapi",
- "zerocopy 0.6.6",
+ "zerocopy",
  "zip",
 ]
 
@@ -2506,7 +2506,7 @@ dependencies = [
  "humility-core",
  "indexmap 1.9.3",
  "serde",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2526,7 +2526,7 @@ dependencies = [
  "lzss",
  "num-traits",
  "rand",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2543,7 +2543,7 @@ dependencies = [
  "parse_int",
  "postcard",
  "thiserror",
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2654,15 +2654,16 @@ dependencies = [
 
 [[package]]
 name = "humpty"
-version = "0.1.3"
-source = "git+https://github.com/oxidecomputer/humpty#f6871f6d8844c3d2ee09c467f50b9f186652cb41"
+version = "0.1.5"
+source = "git+https://github.com/oxidecomputer/humpty#c19ec79a6ae7f5618cd742106b845137942649df"
 dependencies = [
  "hubpack",
  "lzss",
  "serde",
  "serde-big-array",
  "static_assertions",
- "zerocopy 0.6.6",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -2944,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "lzss"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e2b9a6124e5200c13bb5c5d1124bf93b451bff69b651912810039e36ca97eb"
+checksum = "ffcbd9e87fc27b574d4e37d4bf0d302828391f80ea3762dfce02d808fa257a01"
 dependencies = [
  "void",
 ]
@@ -3825,10 +3826,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -3854,10 +3856,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.160"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4314,8 +4325,8 @@ version = "0.4.0"
 source = "git+https://github.com/oxidecomputer/tlvc#2f69360ddcb07ad6072cb720bb1fac9f58a2ddec"
 dependencies = [
  "crc",
- "zerocopy 0.8.48",
- "zerocopy-derive 0.8.48",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4326,7 +4337,7 @@ dependencies = [
  "ron 0.8.0",
  "serde",
  "tlvc",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4908,32 +4919,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,8 +91,8 @@ rust-version = "1.89" # if this changes, edit ci.yaml as well!
 # `git`-based deps
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.3" }
-idol = {git = "https://github.com/oxidecomputer/idolatry.git" }
+humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.5" }
+idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }
 ipcc-data = { git = "https://github.com/oxidecomputer/ipcc-rs" }
 measurement-token = { git = "https://github.com/oxidecomputer/lpc55_support", default-features = false }
@@ -226,7 +226,7 @@ jep106 = "0.2"
 lazy_static = "1.4.0"
 libc = "0.2"
 log = {version = "0.4.8", features = ["std"]}
-lzss = "0.8"
+lzss = "0.9"
 multimap = "0.8.1"
 num-derive = "0.4"
 num-traits = "0.2"
@@ -248,7 +248,7 @@ ron = "0.7"
 rusb = "0.8.1"
 rustc-demangle = "0.1.21"
 scroll = "0.13"
-serde = { version = "1.0.126", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
 serde-xml-rs = "0.5.1"
 sha2 = "0.10.1"
@@ -265,7 +265,7 @@ thiserror = "1.0"
 toml = "0.5"
 trycmd = "0.13.2"
 winapi = "0.3.9"
-zerocopy = "0.6.1"
+zerocopy = { version = "0.8", features = ["derive"] }
 zip = "0.6.4"
 
 [profile.release]

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -514,7 +514,7 @@ fn dump_via_agent(
                     );
                 }
 
-                humpty::DumpLzss::decompress(
+                humpty::DumpLzss::decompress_stack(
                     lzss::SliceReader::new(&bytes[0..compressed]),
                     lzss::SliceWriter::new(&mut output),
                 )?;

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -15,7 +15,7 @@ use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 use anyhow::{Context, Result, anyhow};
 use std::collections::VecDeque;
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 use clap::{CommandFactory, Parser};
 
@@ -54,7 +54,7 @@ struct Flags {
 /// Raw ereport header
 ///
 /// This must agree with the SP's implementation in `snitch_core::Store`
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 #[repr(C)]
 struct EreportHeader {
     data_len: zerocopy::byteorder::little_endian::U16,
@@ -116,9 +116,9 @@ pub fn ereport_dump(
     let mut buf_data = buf_data.as_slice();
     let mut current_ena = earliest_ena;
     while !buf_data.is_empty() {
-        let header =
-            EreportHeader::read_from_prefix(buf_data).ok_or_else(|| {
-                anyhow!("could not get ereport header from buffer")
+        let (header, _) =
+            EreportHeader::read_from_prefix(buf_data).map_err(|e| {
+                anyhow!("could not get ereport header from buffer: {e}")
             })?;
         buf_data = &buf_data[HEADER_SIZE..];
         let (ereport_data, next) =
@@ -234,7 +234,7 @@ fn try_recover_ereport(
     }
     let buf = &*buf.make_contiguous();
 
-    let header = EreportHeader::read_from_prefix(buf).unwrap(); // size checked
+    let (header, _) = EreportHeader::read_from_prefix(buf).unwrap(); // size checked
     let task =
         hubris.lookup_module(HubrisTask::Task(header.task.into())).ok()?;
     let contents = ciborium::from_reader(&buf[HEADER_SIZE..]).ok()?;

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -107,7 +107,7 @@ use humility_cli::{ExecutionContext, Subcommand};
 use humility_cmd::CommandKind;
 use humility_idol::{self as idol, HubrisIdol};
 use zerocopy::{
-    AsBytes, FromBytes,
+    FromBytes, Immutable, IntoBytes, KnownLayout,
     byteorder::{BigEndian, U16, U32},
 };
 
@@ -204,8 +204,10 @@ impl<'a> IbcHandler<'a> {
         for (i, r) in results.iter().skip(3).enumerate() {
             match r {
                 Ok(r) => {
-                    events.push(IbcEvent::read_from(&r[1..]).ok_or_else(
-                        || anyhow!("Failed to decode IbcEvent from {r:?}"),
+                    events.push(IbcEvent::read_from_bytes(&r[1..]).map_err(
+                        |e| {
+                            anyhow!("Failed to decode IbcEvent from {r:?}: {e}")
+                        },
                     )?);
                 }
                 Err(e) => bail!("Failed to read event {i}: {e}"),
@@ -491,7 +493,7 @@ impl<'a> IbcHandler<'a> {
 /// any further.
 ///
 /// See page 19 of the BMR491 technical specification
-#[derive(Copy, Clone, Debug, FromBytes)]
+#[derive(Copy, Clone, Debug, FromBytes, KnownLayout, Immutable)]
 #[repr(C, packed)]
 struct IbcEvent {
     event_id: U16<BigEndian>,

--- a/cmd/rendmp/src/blackbox.rs
+++ b/cmd/rendmp/src/blackbox.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::fmt::{Display, Formatter};
-use zerocopy::FromBytes;
+use zerocopy::{FromBytes, Immutable, KnownLayout};
 
 type U32 = zerocopy::byteorder::U32<zerocopy::BE>;
 type U16 = zerocopy::byteorder::U16<zerocopy::BE>;
@@ -38,7 +38,7 @@ fn format_faults_desc<T: Into<u32> + std::fmt::Binary + Copy>(
 }
 
 /// Uptime (0.1 sec / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct Uptime(U32);
 impl Display for Uptime {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -46,7 +46,7 @@ impl Display for Uptime {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct ControllerFaultGen2(U32);
 impl Display for ControllerFaultGen2 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -69,7 +69,7 @@ impl Display for ControllerFaultGen2 {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct RailFault(U32);
 impl Display for RailFault {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -99,7 +99,7 @@ impl Display for RailFault {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct PhaseFaultA(U32);
 impl Display for PhaseFaultA {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -116,7 +116,7 @@ impl Display for PhaseFaultA {
         write!(f, "{}", faults.join(" | "))
     }
 }
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct PhaseFaultB(U32);
 impl Display for PhaseFaultB {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -134,7 +134,7 @@ impl Display for PhaseFaultB {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct AdcFault(U16);
 impl Display for AdcFault {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -150,7 +150,7 @@ impl Display for AdcFault {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusWord(U16);
 impl Display for StatusWord {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -177,7 +177,7 @@ impl Display for StatusWord {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusCml(u8);
 impl Display for StatusCml {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -248,7 +248,7 @@ impl Display for StatusCml {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusMfr(u8);
 impl Display for StatusMfr {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -286,7 +286,7 @@ impl Display for StatusMfr {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusVout(u8);
 impl Display for StatusVout {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -314,7 +314,7 @@ impl Display for StatusVout {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusIout(u8);
 impl Display for StatusIout {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -347,7 +347,7 @@ impl Display for StatusIout {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusTemperature(u8);
 impl Display for StatusTemperature {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -363,7 +363,7 @@ impl Display for StatusTemperature {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct StatusInput(u8);
 impl Display for StatusInput {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -406,7 +406,7 @@ impl Display for StatusInput {
 }
 
 /// Temperature (direct format 2°C / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct Temperature(u8);
 impl Display for Temperature {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -415,7 +415,7 @@ impl Display for Temperature {
 }
 
 /// Voltage (direct format 10 mV / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct VoltageIn(I16);
 impl Display for VoltageIn {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -424,7 +424,7 @@ impl Display for VoltageIn {
 }
 
 /// Voltage (direct format 1 mV / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct VoltageOut(I16);
 impl Display for VoltageOut {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -433,7 +433,7 @@ impl Display for VoltageOut {
 }
 
 /// Current (direct format 0.1A / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct CurrentOut(I16);
 impl Display for CurrentOut {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -442,7 +442,7 @@ impl Display for CurrentOut {
 }
 
 /// Current (direct format 10 mA / LSB)
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct CurrentIn(I16);
 impl Display for CurrentIn {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -450,7 +450,7 @@ impl Display for CurrentIn {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct PhaseFault(U32);
 impl Display for PhaseFault {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -469,7 +469,7 @@ impl Display for PhaseFault {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 #[repr(C)]
 pub struct BlackboxRamGen2 {
     rail0_uptime: Uptime,
@@ -622,7 +622,7 @@ impl Display for BlackboxRamGen2 {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 struct ControllerFaultGen2p5(U32);
 impl Display for ControllerFaultGen2p5 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
@@ -645,7 +645,7 @@ impl Display for ControllerFaultGen2p5 {
     }
 }
 
-#[derive(Debug, FromBytes)]
+#[derive(Debug, FromBytes, KnownLayout, Immutable)]
 #[repr(C)]
 pub struct BlackboxRamGen2p5 {
     rail0_uptime: Uptime,
@@ -776,7 +776,7 @@ impl Display for BlackboxRamGen2p5 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use zerocopy::{AsBytes, FromBytes};
+    use zerocopy::{FromBytes, IntoBytes};
 
     #[test]
     fn test_blackbox_size() {
@@ -807,7 +807,7 @@ mod test {
             0x15, 0xDA, 0x00, 0x00, 0x00, 0x88, 0x00, 0x15, 0xDB, 0x08, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEC, 0x83, 0xED, 0x2E,
         ];
-        let bb = BlackboxRamGen2p5::read_from(d.as_slice()).unwrap();
+        let bb = BlackboxRamGen2p5::read_from_bytes(d.as_slice()).unwrap();
         println!("{bb}");
 
         println!("\n----------------------------------------");
@@ -820,7 +820,7 @@ mod test {
             0x5b007000, 0x7f00bd00, 0x3a290180, 0x88000000, 0x27482900, 0x0,
             0x0, 0x5d655649,
         ];
-        let bb = BlackboxRamGen2p5::read_from(d.as_bytes()).unwrap();
+        let bb = BlackboxRamGen2p5::read_from_bytes(d.as_bytes()).unwrap();
         println!("{bb}");
     }
 }

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -168,7 +168,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 use strum::VariantNames;
 use strum_macros::EnumVariantNames;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 mod blackbox;
 
@@ -1156,16 +1156,18 @@ fn rendmp_blackbox(
             match e.disc() {
                 "Gen2p5" => println!(
                     "{}",
-                    blackbox::BlackboxRamGen2p5::read_from(data.as_slice())
-                        .ok_or_else(|| anyhow!(
-                            "could not load blackbox from bytes"
-                        ))?,
+                    blackbox::BlackboxRamGen2p5::read_from_bytes(
+                        data.as_slice()
+                    )
+                    .map_err(|e| anyhow!(
+                        "could not load blackbox from bytes: {e}"
+                    ))?,
                 ),
                 "Gen2" => println!(
                     "{}",
-                    blackbox::BlackboxRamGen2::read_from(data.as_slice())
-                        .ok_or_else(|| anyhow!(
-                            "could not load blackbox from bytes"
+                    blackbox::BlackboxRamGen2::read_from_bytes(data.as_slice())
+                        .map_err(|e| anyhow!(
+                            "could not load blackbox from bytes: {e}"
                         ))?,
                 ),
                 v => bail!("unknown blackbox gen: {v:?}"),

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -32,7 +32,7 @@ use multimap::MultiMap;
 use num_traits::FromPrimitive;
 use rustc_demangle::demangle;
 use scroll::{IOwrite, Pwrite};
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{FromBytes, IntoBytes};
 
 const OXIDE_NT_NAME: &str = "Oxide Computer Company";
 const OXIDE_NT_BASE: u32 = 0x1de << 20;
@@ -1850,12 +1850,13 @@ impl HubrisArchive {
                             }
                             OXIDE_NT_HUBRIS_TASK => {
                                 match DumpTask::read_from_prefix(note.desc) {
-                                    Some(task) => {
+                                    Ok((task, _)) => {
                                         self.task_dump = Some(task);
                                     }
-                                    None => {
+                                    Err(e) => {
                                         bail!(
-                                            "unrecognized task {:?}", note.desc
+                                            "unrecognized task {:?} ({e})",
+                                             note.desc
                                         );
                                     }
                                 }

--- a/humility-doppel/src/lib.rs
+++ b/humility-doppel/src/lib.rs
@@ -38,7 +38,9 @@ use humility::reflect::{self, Base, Load, Ptr, Value};
 use indexmap::IndexMap;
 use std::convert::TryInto;
 use std::fmt;
-use zerocopy::{AsBytes, LittleEndian, U16, U32, U64};
+use zerocopy::{
+    Immutable, IntoBytes, KnownLayout, LittleEndian, U16, U32, U64,
+};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Load)]
 pub struct TaskDesc {
@@ -420,7 +422,7 @@ impl<T: humility::reflect::Load> humility::reflect::Load for MaybeUninit<T> {
 }
 
 /// Double of the struct from `udprpc`
-#[derive(Copy, Clone, Debug, AsBytes)]
+#[derive(Copy, Clone, Debug, IntoBytes, Immutable)]
 #[repr(C)]
 pub struct RpcHeader {
     pub image_id: U64<LittleEndian>,
@@ -434,7 +436,7 @@ pub struct RpcHeader {
 pub mod hiffy {
     use super::*;
 
-    #[derive(Copy, Clone, Debug, AsBytes)]
+    #[derive(Copy, Clone, Debug, IntoBytes, Immutable, KnownLayout)]
     #[repr(C)]
     pub struct RpcHeader {
         pub image_id: U64<LittleEndian>,

--- a/humility-dump-agent/src/lib.rs
+++ b/humility-dump-agent/src/lib.rs
@@ -40,8 +40,8 @@ pub use hiffy::HiffyDumpAgent;
 pub use udp::UdpDumpAgent;
 
 fn parse_dump_header(buf: &[u8]) -> Result<(DumpAreaHeader, Option<DumpTask>)> {
-    let header = DumpAreaHeader::read_from_prefix(buf)
-        .ok_or_else(|| anyhow!("failed to parse dump area"))?;
+    let (header, _) = DumpAreaHeader::read_from_prefix(buf)
+        .map_err(|e| anyhow!("failed to parse dump area: {e}"))?;
 
     if header.magic != humpty::DUMP_MAGIC {
         bail!("bad magic at in dump area: {header:x?}");
@@ -272,7 +272,7 @@ impl DumpAgentCore {
                     let mut contents = vec![0; len];
                     let limit = offset + data.compressed_length as usize;
 
-                    humpty::DumpLzss::decompress(
+                    humpty::DumpLzss::decompress_stack(
                         lzss::SliceReader::new(&dump[offset..limit]),
                         lzss::SliceWriter::new(&mut contents),
                     )?;
@@ -479,8 +479,8 @@ pub trait DumpAgentExt {
         progress: &mut dyn FnMut(usize),
     ) -> Result<(DumpAreaHeader, Vec<u8>)> {
         let val = self.read_dump_area_start(index)?;
-        let header = DumpAreaHeader::read_from_prefix(val.as_slice())
-            .ok_or_else(|| anyhow!("failed to read parse header"))?;
+        let (header, _) = DumpAreaHeader::read_from_prefix(val.as_slice())
+            .map_err(|e| anyhow!("failed to read parse header: {e}"))?;
 
         if header.magic != humpty::DUMP_MAGIC {
             bail!("bad magic at dump offset {:#x}: {:x?}", index, header);

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::thread;
 use std::time::{Duration, Instant};
-use zerocopy::{AsBytes, U16, U64};
+use zerocopy::{IntoBytes, U16, U64};
 
 #[derive(Debug, PartialEq)]
 enum State {


### PR DESCRIPTION
(staged on top of #634)

This PR bumps a bunch of crates which want to be updated together.  Most of the textual changes are updating `zerocopy` derives and APIs.