### PR TITLE
Bump `gimli` and `addr2line`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,15 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.25.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
  "cpp_demangle",
  "fallible-iterator 0.3.0",
- "gimli 0.32.3",
+ "gimli 0.33.0",
  "memmap2",
- "object 0.37.3",
+ "object 0.39.1",
  "rustc-demangle",
  "smallvec",
  "typed-arena",
@@ -622,9 +622,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -1188,11 +1188,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator 0.3.0",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "stable_deref_trait",
 ]
@@ -1248,6 +1249,12 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashbrown"
@@ -1395,7 +1402,6 @@ dependencies = [
  "colored",
  "csv",
  "env_logger",
- "fallible-iterator 0.3.0",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2440,8 +2446,7 @@ dependencies = [
  "bitfield",
  "capstone",
  "clap 3.2.25",
- "fallible-iterator 0.3.0",
- "gimli 0.32.3",
+ "gimli 0.33.0",
  "goblin",
  "hubpack",
  "humility-arch-arm",
@@ -3179,9 +3184,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "flate2",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ cmd-vpd = { path = "./cmd/vpd", package = "humility-cmd-vpd" }
 cmd-writeword = { path = "./cmd/writeword", package = "humility-cmd-writeword" }
 
 # crates.io deps
-addr2line = "0.25"
+addr2line = "0.26"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 bitfield = "0.13.2"
 byteorder = "1.3.4"
@@ -212,8 +212,7 @@ crossterm = "0.20.0"
 csv = "1.1.3"
 ctrlc = "3.1.5"
 env_logger = "0.9.0"
-fallible-iterator = "0.3.0"
-gimli = "0.32.0"
+gimli = "0.33.0"
 goblin = "0.10"
 hex = "0.4.3"
 hubpack = "0.1.1"

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -92,7 +92,6 @@ cmd-validate = { workspace = true }
 cmd-vpd = { workspace = true }
 cmd-writeword = { workspace = true }
 
-fallible-iterator = { workspace = true }
 log = { workspace = true }
 env_logger = { workspace = true }
 bitfield = { workspace = true }

--- a/humility-bin/tests/cmd/registers-s/registers-s.flash-ram-mismatch.0.stderr
+++ b/humility-bin/tests/cmd/registers-s/registers-s.flash-ram-mismatch.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address.
+humility: stack unwind failed: no unwind info for address

--- a/humility-bin/tests/cmd/registers-s/registers-s.in_bootloader.0.stderr
+++ b/humility-bin/tests/cmd/registers-s/registers-s.in_bootloader.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address.
+humility: stack unwind failed: no unwind info for address

--- a/humility-bin/tests/cmd/registers-s/registers-s.spoopy.0.stderr
+++ b/humility-bin/tests/cmd/registers-s/registers-s.spoopy.0.stderr
@@ -1,2 +1,2 @@
 humility: attached to dump
-humility: stack unwind failed: Do not have unwind info for the given address.
+humility: stack unwind failed: no unwind info for address

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -9,7 +9,6 @@ addr2line.workspace = true
 anyhow.workspace = true
 bitfield.workspace = true
 clap.workspace = true
-fallible-iterator.workspace = true
 gimli.workspace = true
 goblin.workspace = true
 hubpack.workspace = true

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -23,7 +23,6 @@ use std::time::Instant;
 use crate::{msg, warn};
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use capstone::InsnGroupType;
-use fallible_iterator::FallibleIterator;
 use gimli::UnwindSection;
 use goblin::elf::Elf;
 use humpty::DumpTask;
@@ -4422,15 +4421,13 @@ impl HubrisObjectLoader {
         while let Some(header) = iter.next()? {
             let unit = dwarf.unit(header)?;
             let mut entries = unit.entries();
-            let mut depth = 0;
             let mut stack: Vec<HubrisGoff> = vec![];
 
             let mut array = None;
             let mut ns = vec![];
 
-            while let Some((delta, entry)) = entries.next_dfs()? {
-                depth += delta;
-
+            while let Some(entry) = entries.next_dfs()? {
+                let depth = entry.depth;
                 //
                 // See if our depth has become shallower than our namespace,
                 // trimming it until it fits.
@@ -4490,9 +4487,7 @@ impl HubrisObjectLoader {
                     }
 
                     gimli::constants::DW_TAG_array_type => {
-                        let mut attrs = entry.attrs();
-
-                        while let Some(attr) = attrs.next()? {
+                        for attr in entry.attrs() {
                             if attr.name() != gimli::constants::DW_AT_type {
                                 continue;
                             }
@@ -4758,11 +4753,7 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> HubrisGoff {
-        let goff = match entry.offset().to_unit_section_offset(unit) {
-            gimli::UnitSectionOffset::DebugInfoOffset(o) => o.0,
-            gimli::UnitSectionOffset::DebugTypesOffset(o) => o.0,
-        };
-
+        let goff = entry.offset().to_unit_section_offset(unit).0;
         HubrisGoff { object: self.current, goff }
     }
 
@@ -4772,12 +4763,11 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
         let mut size = None;
         let mut name = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -4814,13 +4804,12 @@ impl HubrisObjectLoader {
         entry: &gimli::DebuggingInformationEntry<R, usize>,
         parent: HubrisGoff,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let mut name = None;
         let mut offset = None;
         let mut goff = None;
         let member = self.dwarf_goff(unit, entry);
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -4917,10 +4906,7 @@ impl HubrisObjectLoader {
     ) -> Option<HubrisGoff> {
         let goff = match value {
             gimli::AttributeValue::UnitRef(offs) => {
-                match offs.to_unit_section_offset(unit) {
-                    gimli::UnitSectionOffset::DebugInfoOffset(o) => o.0,
-                    gimli::UnitSectionOffset::DebugTypesOffset(o) => o.0,
-                }
+                offs.to_unit_section_offset(unit).0
             }
 
             gimli::AttributeValue::DebugInfoRef(offs) => offs.0,
@@ -4940,10 +4926,9 @@ impl HubrisObjectLoader {
         parent: HubrisGoff,
     ) -> Result<()> {
         let goff = self.dwarf_goff(unit, entry);
-        let mut attrs = entry.attrs();
         let mut value = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             if attr.name() == gimli::constants::DW_AT_discr_value {
                 value = attr.value().udata_value().map(Tag::Unsigned);
 
@@ -4971,7 +4956,6 @@ impl HubrisObjectLoader {
         entry: &gimli::DebuggingInformationEntry<R, usize>,
         goff: HubrisGoff,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let mut discr = None;
 
         //
@@ -4988,7 +4972,7 @@ impl HubrisObjectLoader {
             .expect("structs vs structs_byname inconsistency")
             .retain(|&g| g != goff);
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             if attr.name() == gimli::constants::DW_AT_discr {
                 discr = self.dwarf_value_goff(unit, &attr.value());
             }
@@ -5020,11 +5004,10 @@ impl HubrisObjectLoader {
         parent: HubrisGoff,
     ) -> Result<()> {
         let goff = self.dwarf_goff(unit, entry);
-        let mut attrs = entry.attrs();
         let mut value = None;
         let mut name = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -5077,12 +5060,11 @@ impl HubrisObjectLoader {
         goff: HubrisGoff,
         namespace: Option<NamespaceId>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let mut name = None;
         let mut size = None;
         let mut dgoff = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -5139,7 +5121,8 @@ impl HubrisObjectLoader {
 
         let count_attr = entry
             .attrs()
-            .find(|attr| Ok(attr.name() == gimli::constants::DW_AT_count))?;
+            .iter()
+            .find(|attr| attr.name() == gimli::constants::DW_AT_count);
         let count = count_attr.and_then(|a| a.udata_value());
 
         if let Some(count) = count {
@@ -5158,13 +5141,12 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
         let mut size = None;
         let mut encoding = None;
         let mut name = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -5219,12 +5201,11 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
         let mut underlying = None;
         let mut name = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_type => {
                     underlying = self.dwarf_value_goff(unit, &attr.value());
@@ -5252,13 +5233,11 @@ impl HubrisObjectLoader {
         depth: isize,
         namespace: &mut Vec<(NamespaceId, isize)>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
-
         //
         // For a new namespace, create an entry in our namespaces vector,
         // and push a tuple consisting of the identifer and our depth.
         //
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             if attr.name() == gimli::constants::DW_AT_name {
                 if let Some(name) = dwarf_name(dwarf, attr.value()) {
                     namespace.push((
@@ -5283,13 +5262,12 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let mut file = None;
         let mut line = None;
 
         let goff = self.dwarf_goff(unit, entry);
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match (attr.name(), attr.value()) {
                 (
                     gimli::constants::DW_AT_decl_file,
@@ -5356,12 +5334,11 @@ impl HubrisObjectLoader {
         entry: &gimli::DebuggingInformationEntry<R, usize>,
         namespace: Option<NamespaceId>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
         let mut name = None;
         let mut size = None;
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());
@@ -5405,14 +5382,13 @@ impl HubrisObjectLoader {
         //
         // Iterate over our attributes looking for addresses
         //
-        let mut attrs = entry.attrs();
         let mut low: Option<u64> = None;
         let mut high: Option<u64> = None;
         let mut origin: Option<HubrisGoff> = None;
 
         let goff = self.dwarf_goff(unit, entry);
 
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match (attr.name(), attr.value()) {
                 (
                     gimli::constants::DW_AT_low_pc,
@@ -5451,8 +5427,7 @@ impl HubrisObjectLoader {
             }
         };
 
-        let mut attrs = entry.attrs();
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             if let (
                 gimli::constants::DW_AT_ranges,
                 gimli::AttributeValue::RangeListsRef(r),
@@ -5462,7 +5437,7 @@ impl HubrisObjectLoader {
                     gimli::RangeListsOffset(r.0),
                     unit.encoding(),
                 )?;
-                let raw_ranges: Vec<_> = raw_ranges.collect()?;
+                let raw_ranges = raw_ranges.collect::<Result<Vec<_>, _>>()?;
 
                 for r in raw_ranges {
                     if let gimli::RawRngListEntry::AddressOrOffsetPair {
@@ -5501,8 +5476,7 @@ impl HubrisObjectLoader {
         let goff = self.dwarf_goff(unit, entry);
 
         // Iterate over the attributes in the DIE.
-        let mut attrs = entry.attrs();
-        while let Some(attr) = attrs.next()? {
+        for attr in entry.attrs() {
             match (attr.name(), attr.value()) {
                 (
                     gimli::constants::DW_AT_low_pc,
@@ -5563,7 +5537,6 @@ impl HubrisObjectLoader {
         unit: &gimli::Unit<R>,
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> Result<()> {
-        let mut attrs = entry.attrs();
         let goff = self.dwarf_goff(unit, entry);
         let mut name = None;
         let mut linkage_name = None;
@@ -5571,7 +5544,7 @@ impl HubrisObjectLoader {
         let mut tgoff = None;
         let mut dwarf_location = None;
 
-        'attrloop: while let Some(attr) = attrs.next()? {
+        'attrloop: for attr in entry.attrs() {
             match attr.name() {
                 gimli::constants::DW_AT_name => {
                     name = dwarf_name(dwarf, attr.value());


### PR DESCRIPTION
These two are tightly coupled, so I'm bringing them in together.  Nothing too surprising here, just a few API changes (and a slightly different error message when `addr2line` fails).