### PR TITLE
Update cargo-metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.89" # must match Cargo.toml
+          toolchain: "1.91" # must match Cargo.toml
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -101,7 +101,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.89" # must match Cargo.toml
+          toolchain: "1.91" # must match Cargo.toml
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "capstone"
 version = "0.10.0"
 source = "git+https://github.com/oxidecomputer/capstone-rs.git#77296e0e16411109f131b98d773e4c9ecc6bdcfe"
@@ -343,11 +352,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -366,15 +376,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.12.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714a157da7991e23d90686b9524b9e12e0407a108647f52e9328f4b3d51ac7f"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
+ "camino",
  "cargo-platform",
- "semver 0.11.0",
- "semver-parser",
+ "semver",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2471,7 +2482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim 0.10.0",
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.5.11",
  "winapi",
  "zerocopy",
@@ -2537,7 +2548,7 @@ dependencies = [
  "log",
  "parse_int",
  "postcard",
- "thiserror",
+ "thiserror 1.0.69",
  "zerocopy",
 ]
 
@@ -2612,7 +2623,7 @@ dependencies = [
  "parse_int",
  "probe-rs",
  "rusb",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3357,16 +3368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,7 +3488,7 @@ dependencies = [
  "serde_yaml",
  "static_assertions",
  "svg",
- "thiserror",
+ "thiserror 1.0.69",
  "thousands",
 ]
 
@@ -3694,7 +3695,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -3804,7 +3805,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -3921,27 +3922,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
- "pest",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3971,7 +3957,7 @@ checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
 dependencies = [
  "log",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "xml-rs",
 ]
 
@@ -4369,7 +4355,7 @@ dependencies = [
  "crossbeam",
  "crossterm 0.23.2",
  "minimad 0.10.0",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
@@ -4385,7 +4371,7 @@ dependencies = [
  "lazy-regex",
  "minimad 0.13.1",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
@@ -4410,7 +4396,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4418,6 +4413,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4582,12 +4588,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4650,7 +4650,7 @@ dependencies = [
  "postcard",
  "regex",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
  "vsc7448-types",
 ]
 
@@ -4802,7 +4802,7 @@ dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
- "semver 1.0.28",
+ "semver",
 ]
 
 [[package]]
@@ -5144,7 +5144,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.14.0",
  "log",
- "semver 1.0.28",
+ "semver",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.89" # if this changes, edit ci.yaml as well!
+rust-version = "1.91" # if this changes, edit ci.yaml as well!
 
 [workspace.dependencies]
 # `git`-based deps
@@ -201,7 +201,7 @@ anyhow = { version = "1.0.44", features = ["backtrace"] }
 bitfield = "0.13.2"
 byteorder = "1.3.4"
 cargo-readme = "3.3.1"
-cargo_metadata = "0.12.0"
+cargo_metadata = "0.23.1"
 chrono = "0.4.38"
 ciborium = "0.2.2"
 clap = { version = "3.0.12", features = ["derive", "env"] }

--- a/cmd/doc/build.rs
+++ b/cmd/doc/build.rs
@@ -56,17 +56,22 @@ fn cmd_docs(lookup: &str) -> Option<&'static str> {{
     for (cmd, (_, path)) in &cmds {
         println!(
             "cargo:rerun-if-changed={}",
-            path.parent().unwrap().join("src/lib.rs").display()
+            path.parent().unwrap().join("src/lib.rs")
         );
 
         let cmd_path = path.parent().unwrap();
         let mut lib_path = cmd_path.join("src");
         lib_path.push("lib.rs");
-        let mut file = File::open(&lib_path).with_context(|| {
-            format!("failed to open {}", lib_path.display())
-        })?;
+        let mut file = File::open(&lib_path)
+            .with_context(|| format!("failed to open {lib_path}"))?;
         let contents = cargo_readme::generate_readme(
-            cmd_path, &mut file, None, false, true, true, true,
+            cmd_path.as_std_path(),
+            &mut file,
+            None,
+            false,
+            true,
+            true,
+            true,
         )
         .map_err(|error| {
             anyhow!("failed to generate README for {cmd}: {error}")
@@ -110,7 +115,7 @@ fn docs() -> &'static str {{
     )?;
 
     let root = metadata.workspace_root;
-    println!("cargo:rerun-if-changed={}", root.join("README.md.in").display());
+    println!("cargo:rerun-if-changed={}", root.join("README.md.in"));
     let input = std::fs::read(root.join("README.md.in"))?;
 
     output.write_all(&input)?;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -72,11 +72,16 @@ fn make_readme() -> Result<()> {
         let cmd_path = path.parent().unwrap();
         let mut lib_path = cmd_path.join("src");
         lib_path.push("lib.rs");
-        let mut file = std::fs::File::open(&lib_path).with_context(|| {
-            format!("failed to open {}", lib_path.display())
-        })?;
+        let mut file = std::fs::File::open(&lib_path)
+            .with_context(|| format!("failed to open {lib_path}"))?;
         let contents = cargo_readme::generate_readme(
-            cmd_path, &mut file, None, false, true, true, true,
+            cmd_path.as_std_path(),
+            &mut file,
+            None,
+            false,
+            true,
+            true,
+            true,
         )
         .map_err(|error| {
             anyhow::anyhow!("failed to generate README for {cmd}: {error}")


### PR DESCRIPTION
Staged on top of #639 

`cargo_metadata` switched to using `camino::Utf8PathBuf` for paths, which implements `Display` itself (but must be converted to a `std::path::Path` for `cargo-readme` calls)