### PR TITLE
Update path-slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3366,9 +3366,9 @@ dependencies = [
 
 [[package]]
 name = "path-slash"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,7 +231,7 @@ num-traits = "0.2"
 parse-size = { version = "1.0", features = ["std"]}
 parse_int = "0.4.0"
 paste = "0.1"
-path-slash = "0.1.4"
+path-slash = "0.2.1"
 postcard = "0.7.0"
 pretty-hex = "0.4"
 proc-macro2 = "1.0"

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -184,8 +184,8 @@ fn force_openocd(
     // (regardless of platform), so we turn our paths into slash
     // paths.
     //
-    let conf_path = conf.path().to_slash_lossy();
-    let srec_path = srec.path().to_slash_lossy();
+    let conf_path = conf.path().to_slash_lossy().into_owned();
+    let srec_path = srec.path().to_slash_lossy().into_owned();
 
     if subargs.retain || subargs.dryrun {
         humility::msg!("retaining OpenOCD config as {:?}", conf.path());


### PR DESCRIPTION
(staged on top of #642)

`path-slash` switched to returning a `Cow`