### PR TITLE
Update serde-xml-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4085,14 +4085,14 @@ dependencies = [
 
 [[package]]
 name = "serde-xml-rs"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
 dependencies = [
  "log",
  "serde",
- "thiserror 1.0.69",
- "xml-rs",
+ "thiserror 2.0.18",
+ "xml",
 ]
 
 [[package]]
@@ -5331,10 +5331,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.28"
+name = "xml"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
 
 [[package]]
 name = "xtask"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ rustc-demangle = "0.1.21"
 scroll = "0.13"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0"
-serde-xml-rs = "0.5.1"
+serde-xml-rs = "0.8.2"
 sha2 = "0.11.0"
 splitty = "1.0.2"
 srec = "0.2"

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -682,9 +682,8 @@ struct Aardvark {
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(transparent)]
 struct AardvarkWrite {
-    #[serde(rename = "$value")]
     value: String,
 }
 


### PR DESCRIPTION
(staged on top of #644)

This updates `serde-xml-rs`, which tweaks how it parses value types in an XML tag.

There's an integration test (`humility-bin/tests/cmd/rencm.toml`) which verifies that this works.