### PR TITLE
Update to clap 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,17 +155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,7 +368,7 @@ version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "755f2bb7858a521023b39b9decd6b1e5b30e384f3b97517819f6f41df4a49c1e"
 dependencies = [
- "clap 4.6.1",
+ "clap",
  "lazy_static",
  "percent-encoding",
  "regex",
@@ -495,29 +484,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_derive 3.2.25",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
- "clap_derive 4.6.1",
+ "clap_derive",
 ]
 
 [[package]]
@@ -528,21 +500,8 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
- "clap_lex 1.1.0",
+ "clap_lex",
  "strsim 0.11.1",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -555,15 +514,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1459,15 +1409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,7 +1509,7 @@ dependencies = [
  "anyhow",
  "bitfield 0.19.4",
  "cargo_metadata",
- "clap 3.2.25",
+ "clap",
  "colored",
  "csv",
  "env_logger",
@@ -1656,7 +1597,7 @@ name = "humility-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-core",
  "indexmap 2.14.0",
  "parse_int",
@@ -1670,7 +1611,7 @@ name = "humility-cmd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-core",
  "humility-net-core",
@@ -1682,7 +1623,7 @@ name = "humility-cmd-auxflash"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-auxflash",
@@ -1700,7 +1641,7 @@ name = "humility-cmd-console-proxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "crossbeam-channel",
  "humility-cli",
  "humility-cmd",
@@ -1716,7 +1657,7 @@ name = "humility-cmd-counters"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "humility-cli",
  "humility-cmd",
@@ -1732,7 +1673,7 @@ name = "humility-cmd-dashboard"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "crossterm 0.29.0",
  "hif",
  "humility-cli",
@@ -1751,7 +1692,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-cortex",
@@ -1764,7 +1705,7 @@ name = "humility-cmd-diagnose"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -1778,7 +1719,7 @@ name = "humility-cmd-discover"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hubpack",
  "humility-cli",
@@ -1795,7 +1736,7 @@ dependencies = [
  "anyhow",
  "cargo-readme",
  "cargo_metadata",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "termimad 0.34.1",
@@ -1806,7 +1747,7 @@ name = "humility-cmd-dump"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "goblin",
  "hubpack",
  "humility-arch-arm",
@@ -1831,7 +1772,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "hex",
  "humility-cli",
  "humility-cmd",
@@ -1847,7 +1788,7 @@ name = "humility-cmd-exec"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-log",
@@ -1860,7 +1801,7 @@ name = "humility-cmd-extract"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-log",
@@ -1872,7 +1813,7 @@ name = "humility-cmd-flash"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "goblin",
  "humility-auxflash",
  "humility-cli",
@@ -1894,7 +1835,7 @@ name = "humility-cmd-gdb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "ctrlc",
  "humility-cli",
  "humility-cmd",
@@ -1907,7 +1848,7 @@ name = "humility-cmd-gimlet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "gimlet-inspector-protocol",
  "hubpack",
@@ -1925,7 +1866,7 @@ name = "humility-cmd-gpio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -1938,7 +1879,7 @@ name = "humility-cmd-hash"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -1954,7 +1895,7 @@ name = "humility-cmd-hiffy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -1972,7 +1913,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -1990,7 +1931,7 @@ name = "humility-cmd-hydrate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hubpack",
  "humility-arch-arm",
@@ -2012,7 +1953,7 @@ name = "humility-cmd-i2c"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2028,7 +1969,7 @@ name = "humility-cmd-ibc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2047,7 +1988,7 @@ name = "humility-cmd-jefe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2060,7 +2001,7 @@ name = "humility-cmd-lpc55gpio"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2073,7 +2014,7 @@ name = "humility-cmd-lsusb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2085,7 +2026,7 @@ name = "humility-cmd-manifest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2097,7 +2038,7 @@ name = "humility-cmd-map"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2108,7 +2049,7 @@ name = "humility-cmd-monorail"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2129,7 +2070,7 @@ name = "humility-cmd-mwocp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2152,7 +2093,7 @@ name = "humility-cmd-net"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2168,7 +2109,7 @@ name = "humility-cmd-openocd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "ctrlc",
  "humility-cli",
  "humility-cmd",
@@ -2180,7 +2121,7 @@ name = "humility-cmd-pmbus"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2200,7 +2141,7 @@ name = "humility-cmd-power"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2218,7 +2159,7 @@ name = "humility-cmd-powershelf"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2237,7 +2178,7 @@ name = "humility-cmd-probe"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-arch-arm",
  "humility-cli",
  "humility-cmd",
@@ -2251,7 +2192,7 @@ name = "humility-cmd-qspi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2269,7 +2210,7 @@ name = "humility-cmd-readmem"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2283,7 +2224,7 @@ name = "humility-cmd-readvar"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2294,7 +2235,7 @@ name = "humility-cmd-rebootleby"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-arch-arm",
  "humility-cli",
  "humility-cmd",
@@ -2313,7 +2254,7 @@ name = "humility-cmd-registers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-arch-arm",
  "humility-cli",
  "humility-cmd",
@@ -2328,7 +2269,7 @@ name = "humility-cmd-rencm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "csv",
  "hif",
  "humility-cli",
@@ -2348,7 +2289,7 @@ name = "humility-cmd-rendmp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2378,7 +2319,7 @@ name = "humility-cmd-reset"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2390,7 +2331,7 @@ name = "humility-cmd-ringbuf"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2402,7 +2343,7 @@ name = "humility-cmd-sbrmi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2421,7 +2362,7 @@ name = "humility-cmd-sensors"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2439,7 +2380,7 @@ name = "humility-cmd-spctrl"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2452,7 +2393,7 @@ name = "humility-cmd-spd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2471,7 +2412,7 @@ name = "humility-cmd-spi"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2485,7 +2426,7 @@ name = "humility-cmd-stackmargin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2496,7 +2437,7 @@ name = "humility-cmd-stmsecure"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-arch-arm",
  "humility-cli",
  "humility-cmd",
@@ -2509,7 +2450,7 @@ name = "humility-cmd-tasks"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-arch-arm",
  "humility-cli",
  "humility-cmd",
@@ -2526,7 +2467,7 @@ name = "humility-cmd-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2543,7 +2484,7 @@ name = "humility-cmd-tofino-eeprom"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2558,7 +2499,7 @@ name = "humility-cmd-validate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "colored",
  "hif",
  "humility-cli",
@@ -2576,7 +2517,7 @@ name = "humility-cmd-vpd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "hif",
  "humility-cli",
  "humility-cmd",
@@ -2599,7 +2540,7 @@ name = "humility-cmd-writeword"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.25",
+ "clap",
  "humility-cli",
  "humility-cmd",
  "humility-core",
@@ -2615,7 +2556,7 @@ dependencies = [
  "anyhow",
  "bitfield 0.19.4",
  "capstone",
- "clap 3.2.25",
+ "clap",
  "gimli 0.33.0",
  "goblin",
  "hubpack",
@@ -3425,12 +3366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,30 +3588,6 @@ dependencies = [
  "base64 0.13.1",
  "jep106 0.2.10",
  "serde",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -4495,15 +4406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termimad"
 version = "0.25.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4543,12 +4445,6 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 
 [[package]]
 name = "thiserror"
@@ -5354,7 +5250,7 @@ dependencies = [
  "anyhow",
  "cargo-readme",
  "cargo_metadata",
- "clap 3.2.25",
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ cargo-readme = "3.3.1"
 cargo_metadata = "0.23.1"
 chrono = "0.4.38"
 ciborium = "0.2.2"
-clap = { version = "3.0.12", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env", "deprecated"] }
 colored = "3.1.1"
 crc-any = "2.3.5"
 crossbeam-channel = "0.5.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ cargo-readme = "3.3.1"
 cargo_metadata = "0.23.1"
 chrono = "0.4.38"
 ciborium = "0.2.2"
-clap = { version = "3.2", features = ["derive", "env", "deprecated"] }
+clap = { version = "4", features = ["derive", "env"] }
 colored = "3.1.1"
 crc-any = "2.3.5"
 crossbeam-channel = "0.5.6"

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -24,7 +24,7 @@ struct AuxFlashArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -12,7 +12,7 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 
 use humility_auxflash::AuxFlashHandler;
@@ -100,8 +100,7 @@ fn auxflash_status(mut worker: AuxFlashHandler, verbose: bool) -> Result<()> {
 
 fn auxflash(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = AuxFlashArgs::try_parse_from(subargs)?;
+    let subargs = AuxFlashArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut worker = AuxFlashHandler::new(hubris, core, subargs.timeout)?;
 

--- a/cmd/console-proxy/src/lib.rs
+++ b/cmd/console-proxy/src/lib.rs
@@ -67,7 +67,7 @@ enum UartConsoleCommand {
     /// `detach` subcommand.
     Attach {
         #[clap(
-            long = "--no-raw",
+            long = "no-raw",
             help = "do not put terminal in raw mode",
             action = clap::ArgAction::SetFalse,
         )]

--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -18,7 +18,7 @@ use termios::Termios;
 
 use humility::core::Core;
 use humility::hubris::HubrisArchive;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
 
@@ -315,8 +315,7 @@ impl UnrawTermiosGuard {
 
 pub(super) fn console_proxy(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = UartConsoleArgs::try_parse_from(subargs)?;
+    let subargs = UartConsoleArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut worker = UartConsoleHandler::new(
         hubris,

--- a/cmd/counters/src/lib.rs
+++ b/cmd/counters/src/lib.rs
@@ -205,7 +205,7 @@ use colored::Colorize;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect::{self, Load, Value};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_doppel::{CountedRingbuf, CounterVariant, Counters};
 use indexmap::IndexMap;
@@ -325,10 +325,9 @@ const LIST_HINT: &str = "use `humility counters list` to list all \
 
 fn counters(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = CountersArgs::try_parse_from(subargs)?;
+    let subargs = CountersArgs::try_parse_from(&context.cli.cmd)?;
 
     if let Some(Subcmd::Ipc(ipc)) = subargs.command {
         return ipc.ipc_counter_dump(hubris, core);

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -55,7 +55,7 @@ struct DashboardArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -28,7 +28,7 @@ use crossterm::{
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use humility_idol::{self as idol, HubrisIdol};
@@ -733,12 +733,11 @@ fn run_dashboard<B: Backend>(
 }
 
 fn dashboard(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
     let core = &mut **context.core.as_mut().unwrap();
 
-    let subargs = DashboardArgs::try_parse_from(subargs)?;
+    let subargs = DashboardArgs::try_parse_from(&context.cli.cmd)?;
     let dashboard = Dashboard::new(hubris, core, &subargs)?;
 
     // setup terminal

--- a/cmd/debugmailbox/src/lib.rs
+++ b/cmd/debugmailbox/src/lib.rs
@@ -95,7 +95,7 @@ enum DebugMailboxCmd {
         /// Debug credential key name (try `permslip list-keys -t`)
         key_name: String,
         /// Authentication beacon (UM11126 §51.7)
-        #[clap(long, default_value_t = 0, parse(try_from_str = parse_int::parse))]
+        #[clap(long, default_value_t = 0, value_parser = parse_int::parse::<u16>)]
         beacon: u16,
         /// Use ssh-agent to authenticate to permslip
         #[clap(long)]

--- a/cmd/debugmailbox/src/lib.rs
+++ b/cmd/debugmailbox/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use probe_rs::{
     DebugProbeError, DebugProbeSelector, Probe,
@@ -266,8 +266,7 @@ fn read_return<'a>(
 }
 
 fn debugmailboxcmd(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = DebugMailboxArgs::try_parse_from(subargs)?;
+    let subargs = DebugMailboxArgs::try_parse_from(&context.cli.cmd)?;
 
     // Get a list of all available debug probes.
     let probes = Probe::list_all();

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -18,7 +18,7 @@ use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_doppel::{GenOrRestartCount, Task, TaskDesc, TaskState};
@@ -84,10 +84,9 @@ fn section(title: &str) {
 
 fn diagnose(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = DiagnoseArgs::try_parse_from(subargs)?;
+    let subargs = DiagnoseArgs::try_parse_from(&context.cli.cmd)?;
 
     section("Initial Inspection");
 

--- a/cmd/diagnose/src/lib.rs
+++ b/cmd/diagnose/src/lib.rs
@@ -45,7 +45,7 @@ struct DiagnoseArgs {
     /// timeout to wait for interactions with the supervisor task to complete
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/discover/src/lib.rs
+++ b/cmd/discover/src/lib.rs
@@ -57,7 +57,7 @@ struct DiscoverArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 2000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/discover/src/lib.rs
+++ b/cmd/discover/src/lib.rs
@@ -40,11 +40,11 @@ use std::net::{IpAddr, Ipv6Addr, UdpSocket};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, bail};
-use clap::{ArgGroup, IntoApp, Parser};
+use clap::{ArgGroup, CommandFactory, Parser};
 use colored::Colorize;
 use hubpack::SerializedSize;
 use humility::net::decode_iface;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use serde::{Deserialize, Serialize};
 
@@ -312,8 +312,7 @@ fn discover_dump(seen: BTreeSet<Target>, image_id: Option<&[u8]>) {
 }
 
 fn discover_run(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = DiscoverArgs::try_parse_from(subargs)?;
+    let subargs = DiscoverArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
 
     let image_id = hubris.image_id();

--- a/cmd/doc/src/lib.rs
+++ b/cmd/doc/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 
 use anyhow::{Result, bail};
-use clap::{IntoApp, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use clap::{CommandFactory, Parser};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashMap;
 use termimad::*;
@@ -28,8 +28,7 @@ struct DocArgs {
 }
 
 fn doc(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = DocArgs::try_parse_from(subargs)?;
+    let subargs = DocArgs::try_parse_from(&context.cli.cmd)?;
 
     let text = match subargs.command {
         Some(ref cmd) => match cmd_docs(cmd) {

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -93,7 +93,7 @@ struct DumpArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 20000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -70,7 +70,7 @@ use clap::{ArgGroup, CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_dump_agent::{
     DumpAgent, DumpAgentCore, DumpAgentExt, DumpArea, DumpBreakdown,
@@ -856,10 +856,9 @@ fn dump_agent_status(
 
 fn dumpcmd(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = DumpArgs::try_parse_from(subargs)?;
+    let subargs = DumpArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.force_dump_agent && core.is_net() {
         bail!("can only force the dump agent when attached via debug probe");

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -87,7 +87,7 @@ use std::time::Instant;
 #[clap(
     name = "dump", about = env!("CARGO_PKG_DESCRIPTION"),
     group = ArgGroup::new("simulation").multiple(false)
-        .required(false).requires("force-dump-agent")
+        .required(false).requires("force_dump_agent")
 )]
 struct DumpArgs {
     /// sets timeout
@@ -98,7 +98,7 @@ struct DumpArgs {
     timeout: u32,
 
     /// show dump agent status
-    #[clap(long, conflicts_with_all = &["simulation", "task", "extract-all"])]
+    #[clap(long, conflicts_with_all = &["simulation", "task", "extract_all"])]
     dump_agent_status: bool,
 
     /// force use of the dump agent when directly attached with a debug probe
@@ -111,13 +111,13 @@ struct DumpArgs {
 
     /// force manual initiation, leaving target halted
     #[clap(
-        long, requires = "force-dump-agent",
-        conflicts_with_all = &["extract-all", "task"]
+        long, requires = "force_dump_agent",
+        conflicts_with_all = &["extract_all", "task"]
     )]
     force_manual_initiation: bool,
 
     /// force existing in situ dump to be read
-    #[clap(long, conflicts_with_all = &["simulation", "task", "extract-all"])]
+    #[clap(long, conflicts_with_all = &["simulation", "task", "extract_all"])]
     force_read: bool,
 
     /// initialize dump state, clearing any dump at the dump agent
@@ -131,7 +131,7 @@ struct DumpArgs {
     /// overwrite any dump state as part of taking dump
     #[clap(
         long,
-        conflicts_with_all = &["initialize-dump-agent", "simulate-dumper"],
+        conflicts_with_all = &["initialize_dump_agent", "simulate_dumper"],
     )]
     force_overwrite: bool,
 
@@ -142,7 +142,7 @@ struct DumpArgs {
     /// in addition to simulating the dumper, generate a stock dump
     #[clap(
         long, requires = "simulation",
-        conflicts_with_all = &["task", "extract-all"],
+        conflicts_with_all = &["task", "extract_all"],
         value_name = "filename",
     )]
     stock_dumpfile: Option<PathBuf>,
@@ -155,8 +155,8 @@ struct DumpArgs {
     /// simulates a single-task dump
     #[clap(
         long,
-        conflicts_with_all = &["extract", "stock-dumpfile", "list"],
-        requires = "simulate-dumper",
+        conflicts_with_all = &["extract", "stock_dumpfile", "list"],
+        requires = "simulate_dumper",
         value_name = "task",
     )]
     simulate_task_dump: Option<String>,
@@ -561,7 +561,7 @@ fn dump_via_agent(
             {
                 bail!(
                     "there appears to already be one or more dumps in situ; \
-                    list them with --list and extract them with --extract-all"
+                    list them with --list and extract them with --extract_all"
                 )
             }
 

--- a/cmd/ereport/src/lib.rs
+++ b/cmd/ereport/src/lib.rs
@@ -10,7 +10,7 @@ use humility::{
     core::Core,
     hubris::{HubrisArchive, HubrisTask},
 };
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 use anyhow::{Context, Result, anyhow};
@@ -338,10 +338,9 @@ fn pretty_print_value(value: &ciborium::Value, indent: usize, is_key: bool) {
 
 fn ereport(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = EreportArgs::try_parse_from(subargs)?;
+    let subargs = EreportArgs::try_parse_from(&context.cli.cmd)?;
 
     match subargs.cmd {
         EreportCmd::Dump { flags } => ereport_print(hubris, core, flags),

--- a/cmd/exec/src/lib.rs
+++ b/cmd/exec/src/lib.rs
@@ -23,7 +23,7 @@
 
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use humility_log::msg;
 use serde_json::Value;
@@ -72,8 +72,7 @@ fn load_cmds<'a>(
 }
 
 fn exec(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = ExecArgs::try_parse_from(subargs)?;
+    let subargs = ExecArgs::try_parse_from(&context.cli.cmd)?;
     let env = context.environment.as_ref();
 
     let env = match env {

--- a/cmd/extract/src/lib.rs
+++ b/cmd/extract/src/lib.rs
@@ -131,7 +131,7 @@
 
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Command, CommandKind};
 use humility_log::msg;
 use std::fs::File;
@@ -156,8 +156,7 @@ struct ExtractArgs {
 fn extract(context: &mut ExecutionContext) -> Result<()> {
     let hubris = context.archive.as_ref().unwrap();
     let archive = hubris.archive();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = ExtractArgs::try_parse_from(subargs)?;
+    let subargs = ExtractArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.list {
         let cursor = Cursor::new(archive);

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -36,9 +36,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use clap::{CommandFactory, Parser};
 use humility::{core::Core, hubris::*};
 use humility_auxflash::AuxFlashHandler;
-use humility_cli::{
-    Cli, {ExecutionContext, Subcommand},
-};
+use humility_cli::{Cli, ExecutionContext};
 use humility_cmd::{Archive, Command, CommandKind};
 use path_slash::PathExt;
 use std::io::Write;
@@ -347,9 +345,8 @@ fn get_image_state(
 }
 
 fn flashcmd(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_mut().unwrap();
-    let subargs = FlashArgs::try_parse_from(subargs)?;
+    let subargs = FlashArgs::try_parse_from(&context.cli.cmd)?;
 
     let config = hubris.load_flash_config()?;
 

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -68,7 +68,7 @@ struct FlashArgs {
     #[clap(
         long = "reset-delay", short = 'd',
         default_value_t = 100, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u64>
     )]
     reset_delay: u64,
 

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -35,15 +35,15 @@ struct GdbArgs {
     load: bool,
 
     /// when set, runs an OpenOCD process before starting GDB
-    #[clap(long, group = "run_openocd")]
+    #[clap(long, group = "run_openocd_group")]
     run_openocd: bool,
 
     /// specifies the `openocd` executable to run
-    #[clap(long, requires = "run_openocd")]
+    #[clap(long, requires = "run_openocd_group")]
     openocd: Option<String>,
 
     /// specifies the probe serial number to use with OpenOCD
-    #[clap(long, requires = "run_openocd")]
+    #[clap(long, requires = "run_openocd_group")]
     serial: Option<String>,
 
     #[clap(long)]

--- a/cmd/gdb/src/lib.rs
+++ b/cmd/gdb/src/lib.rs
@@ -19,7 +19,7 @@
 
 use std::process::{Command, Stdio};
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command as HumilityCmd, CommandKind};
 
 use anyhow::{Context, Result, bail};
@@ -52,14 +52,13 @@ struct GdbArgs {
 }
 
 fn gdb(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
     if context.cli.probe.is_some() {
         bail!("Cannot specify --probe with `gdb` subcommand");
     }
 
-    let subargs = GdbArgs::try_parse_from(subargs)?;
+    let subargs = GdbArgs::try_parse_from(&context.cli.cmd)?;
     let serial = context.cli.get_probe_serial(subargs.serial.as_deref())?;
 
     let work_dir = tempfile::tempdir()?;

--- a/cmd/gimlet/src/lib.rs
+++ b/cmd/gimlet/src/lib.rs
@@ -17,9 +17,9 @@ use std::net::{SocketAddrV6, UdpSocket};
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
-use clap::{ArgGroup, IntoApp, Parser};
+use clap::{ArgGroup, CommandFactory, Parser};
 use humility::net::ScopedV6Addr;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind, Dumper};
 
 /// This is defined in the gimlet TOML.
@@ -113,8 +113,7 @@ fn run(context: &mut ExecutionContext) -> Result<()> {
                 "the `--ip <IP>` argument is required with `humility gimlet`"
             )
         })?;
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = Args::try_parse_from(subargs)?;
+    let subargs = Args::try_parse_from(&context.cli.cmd)?;
 
     let mut client =
         Client::new(ip, subargs.port, Duration::from_millis(subargs.timeout))?;

--- a/cmd/gimlet/src/lib.rs
+++ b/cmd/gimlet/src/lib.rs
@@ -34,7 +34,7 @@ struct Args {
     /// How long to wait for a response from the target, in milliseconds.
     #[clap(
         long, short = 'T', default_value_t = 2000, value_name = "ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u64>
     )]
     timeout: u64,
 

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -92,7 +92,7 @@
 //! ```
 //!
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::HiffyContext;
 use std::str;
@@ -151,9 +151,8 @@ struct GpioArgs {
 
 fn gpio(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
-    let subargs = GpioArgs::try_parse_from(subargs)?;
+    let subargs = GpioArgs::try_parse_from(&context.cli.cmd)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
     let gpio_toggle = context.get_function("GpioToggle", 2)?;

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -109,7 +109,7 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -19,7 +19,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgGroup, CommandFactory, Parser};
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use sha2::{Digest, Sha256};
@@ -94,9 +94,8 @@ struct HashArgs {
 
 fn hash(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
 
-    let subargs = HashArgs::try_parse_from(subargs)?;
+    let subargs = HashArgs::try_parse_from(&context.cli.cmd)?;
     let archive = context.archive.as_ref().unwrap();
     let mut context = HiffyContext::new(archive, core, subargs.timeout)?;
     let scratch_size = context.scratch_size();

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -83,7 +83,7 @@ struct HashArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -50,7 +50,7 @@ use anyhow::{Context, Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
 use humility::warn;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use humility_hiffy::*;
 use humility_idol as idol;
@@ -201,10 +201,9 @@ pub fn hiffy_list(hubris: &HubrisArchive, filter: Vec<String>) -> Result<()> {
 
 fn hiffy(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = HiffyArgs::try_parse_from(subargs)?;
+    let subargs = HiffyArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.list {
         hiffy_list(hubris, subargs.filter)?;

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -63,7 +63,7 @@ struct HiffyArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -105,7 +105,7 @@ use chrono::DateTime;
 use clap::{CommandFactory, Parser};
 
 use humility::{core::Core, hubris::HubrisArchive, reflect, reflect::Load};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_doppel as doppel;
 use humility_hiffy::HiffyContext;
@@ -467,8 +467,7 @@ fn host_last_post_code(
 }
 
 fn host(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = HostArgs::try_parse_from(subargs)?;
+    let subargs = HostArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
 

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -18,10 +18,10 @@
 //! lowest available value); use `--out` to specify a different path name.
 
 use anyhow::{Context, Result, anyhow, bail};
-use clap::{ArgGroup, IntoApp, Parser};
+use clap::{ArgGroup, CommandFactory, Parser};
 use humility::hubris::HubrisFlashMap;
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use humility_log::msg;
 use std::{collections::BTreeMap, io::Read, path::PathBuf};
@@ -109,8 +109,7 @@ impl humility::core::Core for DryCore {
 }
 
 fn run(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = Args::try_parse_from(subargs)?;
+    let subargs = Args::try_parse_from(&context.cli.cmd)?;
     let f = std::fs::File::open(&subargs.file)?;
     let mut z = zip::ZipArchive::new(f)?;
 

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -93,7 +93,7 @@
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use hif::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use humility_hiffy::*;
 use humility_log::msg;
@@ -425,10 +425,9 @@ fn i2c_done(
 
 fn i2c(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = I2cArgs::try_parse_from(subargs)?;
+    let subargs = I2cArgs::try_parse_from(&context.cli.cmd)?;
 
     if !subargs.scan
         && subargs.scanreg.is_none()

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -113,7 +113,7 @@ pub struct I2cArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -126,7 +126,7 @@ pub struct I2cArgs {
     /// have side-effects on unsporting devices
     #[clap(long, short = 'S', value_name = "register",
         conflicts_with_all = &["scan", "register", "device"],
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     scanreg: Option<u8>,
 
@@ -154,7 +154,7 @@ pub struct I2cArgs {
 
     /// specifies register
     #[clap(long, short, value_name = "register",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     register: Option<u8>,
 
@@ -182,7 +182,7 @@ pub struct I2cArgs {
     /// number of bytes to read from (or write to) register
     #[clap(long, short, value_name = "nbytes",
         conflicts_with = "write",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     nbytes: Option<u8>,
 

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -124,7 +124,7 @@ struct IbcArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -103,7 +103,7 @@
 use anyhow::{Result, anyhow, bail};
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_idol::{self as idol, HubrisIdol};
 use zerocopy::{
@@ -516,8 +516,7 @@ struct IbcEvent {
 
 fn ibc(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = IbcArgs::try_parse_from(subargs)?;
+    let subargs = IbcArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut worker = IbcHandler::new(hubris, core, subargs.timeout)?;
 

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -108,7 +108,7 @@ struct JefeArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/jefe/src/lib.rs
+++ b/cmd/jefe/src/lib.rs
@@ -97,7 +97,7 @@
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_jefe::{JefeRequest, send_request};
 use std::num::NonZeroU32;
@@ -133,10 +133,9 @@ struct JefeArgs {
 
 fn jefe(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = JefeArgs::try_parse_from(subargs)?;
+    let subargs = JefeArgs::try_parse_from(&context.cli.cmd)?;
 
     let request = if subargs.fault {
         JefeRequest::Fault

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -119,7 +119,7 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -102,7 +102,7 @@
 //! ```
 //!
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use std::str;
@@ -165,10 +165,9 @@ struct GpioArgs {
 
 fn gpio(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = GpioArgs::try_parse_from(subargs)?;
+    let subargs = GpioArgs::try_parse_from(&context.cli.cmd)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
     let gpio_toggle = context.get_function("GpioToggle", 1)?;

--- a/cmd/lsusb/src/lib.rs
+++ b/cmd/lsusb/src/lib.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result, anyhow};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -21,8 +21,7 @@ struct Args {
 }
 
 fn lsusb(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let _subargs = Args::try_parse_from(subargs)?;
+    let _subargs = Args::try_parse_from(&context.cli.cmd)?;
     let mut targets = if let Some(ref env) = context.cli.environment {
         humility_cli::env::Environment::read(env)
             .with_context(|| {

--- a/cmd/manifest/src/lib.rs
+++ b/cmd/manifest/src/lib.rs
@@ -44,7 +44,7 @@
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashSet;
 
@@ -60,9 +60,8 @@ struct ManifestArgs {
 fn manifestcmd(context: &mut ExecutionContext) -> Result<()> {
     let hubris = context.archive.as_ref().unwrap();
     let manifest = &hubris.manifest;
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
 
-    let subargs = ManifestArgs::try_parse_from(subargs)?;
+    let subargs = ManifestArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.json {
         println!("{}", serde_json::to_string(manifest)?);

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -171,7 +171,7 @@ use std::convert::TryInto;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, CommandKind, Validate};
 use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
@@ -1067,9 +1067,8 @@ fn monorail_counters(
 
 fn monorail(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_mut().unwrap();
-    let subargs = MonorailArgs::try_parse_from(subargs)?;
+    let subargs = MonorailArgs::try_parse_from(&context.cli.cmd)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     match subargs.cmd {
         Command::Info { .. } => panic!("Called monorail with info subcommand"),
@@ -1148,10 +1147,9 @@ fn monorail(context: &mut ExecutionContext) -> Result<()> {
 }
 
 fn monorail_get_info(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
     assert!(!hubris.loaded());
-    let subargs = MonorailArgs::try_parse_from(subargs)?;
+    let subargs = MonorailArgs::try_parse_from(&context.cli.cmd)?;
     match subargs.cmd {
         Command::Info { reg, value } => {
             let reg = parse_reg_or_addr(&reg)?;

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -189,7 +189,7 @@ struct MonorailArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 
@@ -214,7 +214,7 @@ enum Command {
     /// Get info about a particular VSC7448 register
     Info {
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         value: Option<u32>,
     },
     /// Print a table showing port status
@@ -239,7 +239,7 @@ enum Command {
     /// Write to a VSC7448 register
     Write {
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         value: u32,
     },
     /// Subcommand to control PHYs
@@ -264,7 +264,7 @@ enum PhyCommand {
         #[clap(long, short)]
         port: u8,
         reg: String,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u16>)]
         value: u16,
     },
     /// Dumps all PHY registers on the given port

--- a/cmd/mwocp/src/lib.rs
+++ b/cmd/mwocp/src/lib.rs
@@ -34,7 +34,7 @@
 
 use humility::hubris::*;
 use humility::msg;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use humility_i2c::I2cArgs;
@@ -117,12 +117,11 @@ const MWOCP68_CHECKSUM_DELAY: u64 = 2;
 const MWOCP68_REBOOT_DELAY: u64 = 5;
 
 fn mwocp(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_mut().unwrap();
 
     let core = &mut **context.core.as_mut().unwrap();
 
-    let subargs = MwocpArgs::try_parse_from(subargs)?;
+    let subargs = MwocpArgs::try_parse_from(&context.cli.cmd)?;
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 

--- a/cmd/mwocp/src/lib.rs
+++ b/cmd/mwocp/src/lib.rs
@@ -57,7 +57,7 @@ struct MwocpArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -87,7 +87,7 @@ struct DeviceIdentity {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -79,7 +79,7 @@ struct NetArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -44,7 +44,7 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 
 use humility::reflect::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::HiffyContext;
 use humility_idol::HubrisIdol;
@@ -88,8 +88,7 @@ struct NetArgs {
 }
 
 fn net_ip(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = NetArgs::try_parse_from(subargs)?;
+    let subargs = NetArgs::try_parse_from(&context.cli.cmd)?;
 
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
@@ -148,8 +147,7 @@ pub fn mac_to_ip6(mac: [u8; 6]) -> String {
 }
 
 fn net_mac_table(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = NetArgs::try_parse_from(subargs)?;
+    let subargs = NetArgs::try_parse_from(&context.cli.cmd)?;
 
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
@@ -274,8 +272,7 @@ fn net_mac_table(context: &mut ExecutionContext) -> Result<()> {
 }
 
 fn net_status(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = NetArgs::try_parse_from(subargs)?;
+    let subargs = NetArgs::try_parse_from(&context.cli.cmd)?;
 
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
@@ -356,8 +353,7 @@ fn net_counters(
     table: bool,
     diagram: bool,
 ) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = NetArgs::try_parse_from(subargs)?;
+    let subargs = NetArgs::try_parse_from(&context.cli.cmd)?;
 
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
@@ -578,8 +574,7 @@ fn net_counters_diagram(s: &Struct) -> Result<()> {
 }
 
 fn net(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = NetArgs::try_parse_from(subargs)?;
+    let subargs = NetArgs::try_parse_from(&context.cli.cmd)?;
 
     match subargs.cmd {
         NetCommand::Mac => net_mac_table(context)?,

--- a/cmd/openocd/src/lib.rs
+++ b/cmd/openocd/src/lib.rs
@@ -12,7 +12,7 @@
 
 use std::process;
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 
 use anyhow::{Context, Result, bail};
@@ -41,9 +41,7 @@ fn openocd(context: &mut ExecutionContext) -> Result<()> {
         bail!("Cannot specify --probe with `openocd` subcommand");
     }
 
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-
-    let subargs = OcdArgs::try_parse_from(subargs)?;
+    let subargs = OcdArgs::try_parse_from(&context.cli.cmd)?;
     let serial = context.cli.get_probe_serial(subargs.serial.as_deref())?;
 
     let hubris = context.archive.as_ref().unwrap();

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -298,7 +298,7 @@ struct PmbusArgs {
     rail: Option<Vec<String>>,
 
     /// agent to use when executing PMBus operations
-    #[clap(long, default_value_t=Agent::Auto)]
+    #[clap(long, value_enum, default_value_t=Agent::Auto)]
     agent: Agent,
 }
 
@@ -307,17 +307,6 @@ enum Agent {
     Auto,
     Idol,
     I2c,
-}
-
-impl std::fmt::Display for Agent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Auto => "auto",
-            Self::Idol => "idol",
-            Self::I2c => "i2c",
-        };
-        s.fmt(f)
-    }
 }
 
 fn all_commands(

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -190,7 +190,7 @@
 use colored::Colorize;
 use humility::hubris::*;
 use humility::{core::Core, warn};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use humility_i2c::I2cArgs;
@@ -298,15 +298,26 @@ struct PmbusArgs {
     rail: Option<Vec<String>>,
 
     /// agent to use when executing PMBus operations
-    #[clap(long, arg_enum, default_value_t=Agent::Auto)]
+    #[clap(long, default_value_t=Agent::Auto)]
     agent: Agent,
 }
 
-#[derive(clap::ArgEnum, Clone, Debug)]
+#[derive(clap::ValueEnum, Clone, Debug)]
 enum Agent {
     Auto,
     Idol,
     I2c,
+}
+
+impl std::fmt::Display for Agent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Auto => "auto",
+            Self::Idol => "idol",
+            Self::I2c => "i2c",
+        };
+        s.fmt(f)
+    }
 }
 
 fn all_commands(
@@ -1903,9 +1914,8 @@ impl PmbusWorker for IdolWorker<'_> {
 
 #[allow(clippy::print_literal)]
 fn pmbus(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
-    let subargs = PmbusArgs::try_parse_from(subargs)?;
+    let subargs = PmbusArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.list {
         println!(

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -211,7 +211,7 @@ struct PmbusArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -271,7 +271,7 @@ struct PmbusArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -33,7 +33,7 @@ struct PowerArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -20,7 +20,7 @@ use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_hiffy::*;
@@ -118,10 +118,9 @@ fn phase_currents(
 
 fn power(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = PowerArgs::try_parse_from(subargs)?;
+    let subargs = PowerArgs::try_parse_from(&context.cli.cmd)?;
 
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let mut ops = vec![];

--- a/cmd/powershelf/src/lib.rs
+++ b/cmd/powershelf/src/lib.rs
@@ -31,7 +31,7 @@ struct PowershelfArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/powershelf/src/lib.rs
+++ b/cmd/powershelf/src/lib.rs
@@ -14,12 +14,11 @@
 //! indices 0 through 5).
 
 use anyhow::{Context, Result, anyhow};
-use clap::IntoApp;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use hif::*;
 use humility::hubris::HubrisArchive;
 use humility::hubris::HubrisEnum;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_hiffy::*;
@@ -133,10 +132,9 @@ fn interpret_raw_variant(variant: &str, payload: &[u8]) {
 
 fn powershelf_run(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = PowershelfArgs::try_parse_from(subargs)?;
+    let subargs = PowershelfArgs::try_parse_from(&context.cli.cmd)?;
 
     let operation = lookup_operation_enum(hubris)?;
 

--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -90,7 +90,7 @@ use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::HubrisValidate;
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_cortex::debug::*;
@@ -108,8 +108,7 @@ struct ProbeArgs {
 fn probecmd(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
     let hubris = context.archive.as_ref().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = ProbeArgs::try_parse_from(subargs)?;
+    let subargs = ProbeArgs::try_parse_from(&context.cli.cmd)?;
 
     use num_traits::FromPrimitive;
     let mut status = vec![];

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -83,7 +83,7 @@
 //! as well as bulk erase.
 
 use humility::core::Core;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use humility_hiffy::*;
 use humility_idol::{HubrisIdol, IdolArgument};
@@ -483,10 +483,9 @@ fn write(
 
 fn qspi(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = QspiArgs::try_parse_from(subargs)?;
+    let subargs = QspiArgs::try_parse_from(&context.cli.cmd)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
     match subargs.slot {

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -111,7 +111,7 @@ struct QspiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 30000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 
@@ -148,14 +148,14 @@ struct QspiArgs {
 
     /// specify flash address in bytes
     #[clap(long, short, value_name = "address",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<usize>,
         conflicts_with("writefile"),
     )]
     addr: Option<usize>,
 
     /// specify size in bytes
     #[clap(long, short, value_name = "nbytes",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<usize>,
     )]
     nbytes: Option<usize>,
 

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -130,10 +130,8 @@ use std::path::PathBuf;
 // those who yearn to express themselves in terms of octal multiples of
 // kibibytes!
 //
-fn parse_size<T: AsRef<[u8]>>(src: T) -> Result<u64, parse_size::Error> {
-    if let Ok(s) = std::str::from_utf8(src.as_ref())
-        && let Ok(rval) = parse_int::parse::<u64>(s)
-    {
+fn parse_size(src: &str) -> Result<u64, parse_size::Error> {
+    if let Ok(rval) = parse_int::parse::<u64>(src) {
         return Ok(rval);
     }
 
@@ -164,7 +162,7 @@ struct ReadmemArgs {
     address: String,
 
     /// length to read
-    #[clap(parse(try_from_str = parse_size))]
+    #[clap(value_parser = parse_size)]
     length: Option<u64>,
 }
 

--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -118,7 +118,7 @@
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use std::convert::TryInto;
 use std::io::Write;
@@ -168,10 +168,9 @@ struct ReadmemArgs {
 
 fn readmem(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = ReadmemArgs::try_parse_from(subargs)?;
+    let subargs = ReadmemArgs::try_parse_from(&context.cli.cmd)?;
     let max = humility::core::CORE_MAX_READSIZE;
     let size = if subargs.word || subargs.symbol {
         4

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -40,7 +40,7 @@ use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 #[derive(Parser, Debug)]
@@ -101,10 +101,9 @@ fn readvar_dump(
 
 fn readvar(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = ReadvarArgs::try_parse_from(subargs)?;
+    let subargs = ReadvarArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.list {
         println!("{:18} {:<42} {:<10} SIZE", "MODULE", "VARIABLE", "ADDR");

--- a/cmd/rebootleby/src/lib.rs
+++ b/cmd/rebootleby/src/lib.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use std::io::Read;
 use std::ops::RangeInclusive;
@@ -33,8 +33,7 @@ struct Rebootleby {
 }
 
 fn rebootleby(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = Rebootleby::try_parse_from(subargs)?;
+    let subargs = Rebootleby::try_parse_from(&context.cli.cmd)?;
 
     // Load bundle
     let bundle_reader = std::fs::File::open(&subargs.path)

--- a/cmd/registers/src/lib.rs
+++ b/cmd/registers/src/lib.rs
@@ -133,7 +133,7 @@ use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
 use humility_arch_arm::{ARMRegister, ARMRegisterField};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_cortex::debug::*;
 use num_traits::FromPrimitive;
@@ -234,8 +234,7 @@ fn print_reg(reg: ARMRegister, val: u32, fields: &[ARMRegisterField]) {
 
 fn registers(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = RegistersArgs::try_parse_from(subargs)?;
+    let subargs = RegistersArgs::try_parse_from(&context.cli.cmd)?;
     let mut regs = BTreeMap::new();
     let hubris = context.archive.as_ref().unwrap();
 

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -36,7 +36,7 @@ struct RencmArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -52,7 +52,7 @@ struct RencmArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -10,7 +10,7 @@
 
 use humility::core::Core;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{
     Archive, Attach, Command, CommandKind, Dumper, Validate, attach,
 };
@@ -794,8 +794,7 @@ fn rencm_ingest(subargs: &RencmArgs, modules: &[Module]) -> Result<()> {
 }
 
 fn rencm(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = RencmArgs::try_parse_from(subargs)?;
+    let subargs = RencmArgs::try_parse_from(&context.cli.cmd)?;
     let modules = modules();
 
     if subargs.ingest.is_some() {

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -145,7 +145,7 @@
 use humility::hubris::*;
 use humility::reflect::{Base, Value};
 use humility::warn;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use humility_i2c::I2cArgs;
@@ -2307,12 +2307,11 @@ fn restore_default_config<'a>(
 }
 
 fn rendmp(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_mut().unwrap();
 
     let core = &mut **context.core.as_mut().unwrap();
 
-    let subargs = RendmpArgs::try_parse_from(subargs)?;
+    let subargs = RendmpArgs::try_parse_from(&context.cli.cmd)?;
 
     // Workaround for clap#4707
     if subargs.flash.is_none() {

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -220,11 +220,11 @@ struct RendmpArgs {
     phase_check: bool,
 
     /// only check the specified phase(s)
-    #[clap(long, requires = "phase-check", use_value_delimiter = true)]
+    #[clap(long, requires = "phase_check", use_value_delimiter = true)]
     phase: Option<Vec<u8>>,
 
     /// force phase check, even if DIMMs are present
-    #[clap(long, requires = "phase-check")]
+    #[clap(long, requires = "phase_check")]
     force_phase_check: bool,
 
     // NOTE: the arguments below are only valid when --flash is provided.

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -180,7 +180,7 @@ struct RendmpArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -262,7 +262,7 @@ struct DeviceIdentity {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -19,10 +19,10 @@ struct ResetArgs {
     #[clap(long, conflicts_with_all = &["halt"])]
     soft_reset: bool,
     /// Reset and halt instead of continuing
-    #[clap(long, conflicts_with_all = &["soft-reset"])]
+    #[clap(long, conflicts_with_all = &["soft_reset"])]
     halt: bool,
     /// Use measurement token handoff (usually decided automatically)
-    #[clap(long, conflicts_with_all = &["soft-reset", "halt"])]
+    #[clap(long, conflicts_with_all = &["soft_reset", "halt"])]
     use_token: Option<bool>,
 }
 

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -9,7 +9,7 @@
 
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 
 #[derive(Parser, Debug)]
@@ -27,8 +27,7 @@ struct ResetArgs {
 }
 
 fn reset(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = ResetArgs::try_parse_from(subargs)?;
+    let subargs = ResetArgs::try_parse_from(&context.cli.cmd)?;
 
     // `context.archive` is always `Some(..)` even if we have not specified
     // anything on the command line or through environment flags. However, if no

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -105,7 +105,7 @@ struct TotalsOptions {
         long,
         short,
         conflicts_with_all = &[
-            "full-totals",
+            "full_totals",
             "list"
         ],
     )]

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -67,7 +67,7 @@ use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect::{self, Format, Load, Value};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_doppel::{CountedRingbuf, CounterVariant, Ringbuf, StaticCell};
 
@@ -234,10 +234,9 @@ fn taskname<'a>(
 #[allow(clippy::print_literal)]
 fn ringbuf(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = RingbufArgs::try_parse_from(subargs)?;
+    let subargs = RingbufArgs::try_parse_from(&context.cli.cmd)?;
 
     let mut ringbufs = vec![];
 

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -96,7 +96,7 @@ use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_hiffy::*;
@@ -520,8 +520,7 @@ fn mca(
 
 fn sbrmi(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = SbrmiArgs::try_parse_from(subargs)?;
+    let subargs = SbrmiArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -115,13 +115,13 @@ struct SbrmiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 
     /// thread to operate upon
     #[clap(
-        long, short, parse(try_from_str = parse_int::parse),
+        long, short, value_parser = parse_int::parse::<u8>,
         requires = "command",
     )]
     thread: Option<u8>,

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -46,7 +46,7 @@ struct SensorsArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -97,7 +97,7 @@ struct SensorsArgs {
     /// indicate sensors by ID
     #[clap(
         long, short, value_name = "id", use_value_delimiter = true,
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<usize>,
         conflicts_with_all = &["types", "devices", "named"],
     )]
     id: Option<Vec<usize>>,

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -30,7 +30,7 @@ use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect::{self, Load};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_doppel as doppel;
 use humility_hiffy::*;
@@ -533,10 +533,9 @@ fn print(
 
 fn sensors(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = SensorsArgs::try_parse_from(subargs)?;
+    let subargs = SensorsArgs::try_parse_from(&context.cli.cmd)?;
 
     let types = if let Some(ref types) = subargs.types {
         let mut rval = HashSet::new();

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -58,12 +58,12 @@ use hif::*;
 #[clap(name = "subcmd")]
 enum SpCtrlCmd {
     Write {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         addr: u32,
         bytes: String,
     },
     Read {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         addr: u32,
         nbytes: usize,
     },
@@ -76,7 +76,7 @@ struct SpCtrlArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -44,7 +44,7 @@
 //! 0x00000030 | f739ba6f 20067a60 310c4e08 e42eca28 | o.9.`z. .N.1(...
 //! ```
 
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use humility_hiffy::*;
 
@@ -90,8 +90,7 @@ struct SpCtrlArgs {
 
 fn spctrl(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = SpCtrlArgs::try_parse_from(subargs)?;
+    let subargs = SpCtrlArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
     let mut ops = vec![];

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -107,7 +107,7 @@
 //!
 
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::*;
 use humility_i2c::I2cArgs;
@@ -331,11 +331,10 @@ fn set_page(
 }
 
 fn spd(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
     let core = &mut **context.core.as_mut().unwrap();
 
-    let subargs = SpdArgs::try_parse_from(subargs)?;
+    let subargs = SpdArgs::try_parse_from(&context.cli.cmd)?;
 
     // If we have been given no device-related arguments, we will attempt
     // to find the `SPD_DATA` variable or load SPD data from packrat

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -127,7 +127,7 @@ struct SpdArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -137,7 +137,7 @@ struct SpdArgs {
 
     /// specifies an I2C controller
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 
@@ -157,7 +157,7 @@ struct SpdArgs {
 
     /// dump only the specified address
     #[clap(long, short, value_name = "address",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u8>,
     )]
     address: Option<u8>,
 

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -50,7 +50,7 @@ struct SpiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 
@@ -68,7 +68,7 @@ struct SpiArgs {
 
     /// specify number of bytes to read
     #[clap(long, short, value_name = "nbytes",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<usize>,
     )]
     nbytes: Option<usize>,
 

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -80,7 +80,7 @@ struct SpiArgs {
     /// bigendian address
     #[clap(
         long, short = 'A', requires_all = &["read", "write", "discard"],
-        conflicts_with = "littleendian-address"
+        conflicts_with = "littleendian_address"
     )]
     bigendian_address: Option<usize>,
 
@@ -88,7 +88,7 @@ struct SpiArgs {
     /// bigendian address
     #[clap(
         long, short = 'a', requires_all = &["read", "write", "discard"],
-        conflicts_with = "bigendian-address"
+        conflicts_with = "bigendian_address"
     )]
     littleendian_address: Option<usize>,
 

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -33,7 +33,7 @@
 //!
 
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Dumper, Validate};
 use humility_hiffy::*;
 
@@ -172,10 +172,9 @@ pub fn spi_task(
 
 fn spi(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = SpiArgs::try_parse_from(subargs)?;
+    let subargs = SpiArgs::try_parse_from(&context.cli.cmd)?;
     let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
 
     let spi_read = context.get_function("SpiRead", 4)?;

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -30,7 +30,7 @@
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use std::{collections::HashSet, convert::TryInto};
 
@@ -43,8 +43,7 @@ struct StackmarginArgs {
 
 #[rustfmt::skip::macros(println, bail)]
 fn stackmargin(context: &mut ExecutionContext) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = StackmarginArgs::try_parse_from(subargs)?;
+    let subargs = StackmarginArgs::try_parse_from(&context.cli.cmd)?;
 
     let core = &mut **context.core.as_mut().unwrap();
     let hubris = context.archive.as_ref().unwrap();

--- a/cmd/stackmargin/src/lib.rs
+++ b/cmd/stackmargin/src/lib.rs
@@ -38,7 +38,6 @@ use std::{collections::HashSet, convert::TryInto};
 #[clap(name = "stackmargin", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct StackmarginArgs {
     /// Tasks to check (leave empty to check all tasks)
-    #[clap(multiple_occurrences = true)]
     tasks: Vec<String>,
 }
 

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -70,9 +70,9 @@ enum StmSecureArgs {
     /// region before this is programmed otherwise you will brick the device
     /// !!!
     SetSecureRegion {
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         address: u32,
-        #[clap(parse(try_from_str = parse_int::parse))]
+        #[clap(value_parser = parse_int::parse::<u32>)]
         size: u32,
         #[clap(long)]
         doit: bool,

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -31,7 +31,7 @@ use anyhow::{Result, anyhow};
 use clap::{CommandFactory, Parser};
 use humility::core::Core;
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 const FLASH_OPT_KEY1: u32 = 0x0819_2A3B;
@@ -296,9 +296,8 @@ fn stmsecure_swapbanks(core: &mut dyn Core) -> Result<()> {
 #[rustfmt::skip::macros(format)]
 fn stmsecure(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
 
-    let subargs = StmSecureArgs::try_parse_from(subargs)?;
+    let subargs = StmSecureArgs::try_parse_from(&context.cli.cmd)?;
 
     match subargs {
         StmSecureArgs::Status => stmsecure_status(core),

--- a/cmd/tasks/src/lib.rs
+++ b/cmd/tasks/src/lib.rs
@@ -117,7 +117,7 @@ use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect::{self, Format, Load};
 use humility_arch_arm::ARMRegister;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_doppel::{self as doppel, Task, TaskDesc, TaskId, TaskState};
 use num_traits::FromPrimitive;
@@ -185,10 +185,9 @@ fn print_regs(
 
 fn tasks(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = TasksArgs::try_parse_from(subargs)?;
+    let subargs = TasksArgs::try_parse_from(&context.cli.cmd)?;
 
     print_tasks(
         &mut std::io::stdout(),

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -95,7 +95,7 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use hif::*;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Validate};
 use humility_hiffy::*;
@@ -164,10 +164,9 @@ impl fmt::Display for TestResult {
 
 fn test(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
     let hubris = context.archive.as_ref().unwrap();
 
-    let subargs = TestArgs::try_parse_from(subargs)?;
+    let subargs = TestArgs::try_parse_from(&context.cli.cmd)?;
 
     hubris.validate(core, HubrisValidate::Booted)?;
 

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -109,7 +109,7 @@ struct TestArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 3000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -8,7 +8,7 @@
 
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use indicatif::{ProgressBar, ProgressStyle};
 
@@ -148,8 +148,7 @@ impl<'a> EepromHandler<'a> {
 
 fn eeprom(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = EepromArgs::try_parse_from(subargs)?;
+    let subargs = EepromArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
     let mut worker = EepromHandler::new(hubris, core, subargs.timeout)?;
 

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -30,7 +30,7 @@ struct EepromArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -47,7 +47,7 @@ use clap::{CommandFactory, Parser};
 use colored::Colorize;
 use hif::*;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 use humility_hiffy::{HiffyContext, IpcError};
 use humility_i2c::I2cArgs;
@@ -133,8 +133,7 @@ fn list(hubris: &HubrisArchive, hargs: &Option<I2cArgs>) -> Result<()> {
 }
 fn validate(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = ValidateArgs::try_parse_from(subargs)?;
+    let subargs = ValidateArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
 
     let hargs = if subargs.bus.is_some() || subargs.controller.is_some() {

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -59,7 +59,7 @@ struct ValidateArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     timeout: u32,
 
@@ -69,7 +69,7 @@ struct ValidateArgs {
 
     /// specifies an I2C controller to validate
     #[clap(long, short, value_name = "controller",
-        parse(try_from_str = parse_int::parse),
+        value_parser = parse_int::parse::<u8>,
     )]
     controller: Option<u8>,
 

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -132,7 +132,7 @@ struct VpdArgs {
 
     /// list all devices that have VPD (can be combined with --read)
     #[clap(long, short, conflicts_with_all = &[
-        "device", "id", "lock", "lock-all", "erase", "raw", "binary", "loopback"
+        "device", "id", "lock", "lock_all", "erase", "raw", "binary", "loopback"
     ])]
     list: bool,
 
@@ -181,7 +181,7 @@ struct VpdArgs {
     )]
     lock_all: bool,
 
-    #[clap(long, requires = "lock-all")]
+    #[clap(long, requires = "lock_all")]
     allow_missing: bool,
 }
 

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -108,7 +108,7 @@ use hif::*;
 use humility::core::Core;
 use humility::hubris::*;
 use humility::reflect;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::CommandKind;
 use humility_cmd::{Archive, Attach, Command, Dumper, Validate};
 use humility_hiffy::*;
@@ -729,8 +729,7 @@ fn vpd_lock_all(
 
 fn vpd(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let subargs = VpdArgs::try_parse_from(subargs)?;
+    let subargs = VpdArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = context.archive.as_ref().unwrap();
 
     if subargs.list {

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -126,7 +126,7 @@ struct VpdArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>
     )]
     timeout: u32,
 

--- a/cmd/writeword/src/lib.rs
+++ b/cmd/writeword/src/lib.rs
@@ -49,7 +49,7 @@
 
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 
 #[derive(Parser, Debug)]
@@ -66,9 +66,8 @@ struct WritewordArgs {
 
 fn writeword(context: &mut ExecutionContext) -> Result<()> {
     let core = &mut **context.core.as_mut().unwrap();
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
 
-    let subargs = WritewordArgs::try_parse_from(subargs)?;
+    let subargs = WritewordArgs::try_parse_from(&context.cli.cmd)?;
 
     if subargs.address & 0b11 != 0 {
         bail!("address must be word aligned");

--- a/cmd/writeword/src/lib.rs
+++ b/cmd/writeword/src/lib.rs
@@ -56,11 +56,11 @@ use humility_cmd::{Archive, Attach, Command, CommandKind, Validate};
 #[clap(name = "writeword", about = env!("CARGO_PKG_DESCRIPTION"))]
 struct WritewordArgs {
     /// address to write to
-    #[clap(parse(try_from_str = parse_int::parse))]
+    #[clap(value_parser = parse_int::parse::<u32>,)]
     address: u32,
 
     /// value(s) to write
-    #[clap(parse(try_from_str = parse_int::parse))]
+    #[clap(value_parser = parse_int::parse::<u32>)]
     value: Vec<u32>,
 }
 

--- a/humility-bin/src/cmd.rs
+++ b/humility-bin/src/cmd.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result, bail};
 use clap::Command as ClapCommand;
 use humility::hubris::*;
-use humility_cli::{ExecutionContext, Subcommand};
+use humility_cli::ExecutionContext;
 use humility_cmd::{Archive, Command, CommandKind};
 use std::collections::HashMap;
 
@@ -19,8 +19,8 @@ include!(concat!(env!("OUT_DIR"), "/cmds.rs"));
 use crate::cmd_repl;
 
 pub fn init(
-    command: ClapCommand<'static>,
-) -> (HashMap<&'static str, Command>, ClapCommand<'static>) {
+    command: ClapCommand,
+) -> (HashMap<&'static str, Command>, ClapCommand) {
     let mut cmds = HashMap::new();
     let mut rval = command;
 
@@ -43,8 +43,7 @@ pub fn subcommand(
     context: &mut ExecutionContext,
     commands: &HashMap<&'static str, Command>,
 ) -> Result<()> {
-    let Subcommand::Other(subargs) = context.cli.cmd.as_ref().unwrap();
-    let cmd = subargs[0].as_str();
+    let cmd = context.cli.cmd[0].as_str();
 
     let command = commands
         .get(cmd)

--- a/humility-bin/src/main.rs
+++ b/humility-bin/src/main.rs
@@ -7,7 +7,6 @@ use std::ffi::OsString;
 
 use clap::ArgMatches;
 use humility_cli::Cli;
-use humility_cli::Subcommand;
 use humility_cmd::Command;
 
 use anyhow::Result;
@@ -38,13 +37,8 @@ fn main() -> Result<()> {
 
     env_logger::init_from_env(env);
 
-    // stash this away in case we fail
-    let subcmd = match args.cmd.as_ref().unwrap() {
-        Subcommand::Other(v) => v[0].clone(),
-    };
-
     if let Err(err) = cmd::subcommand(&mut context, &commands) {
-        eprintln!("humility {} failed: {:?}", subcmd, err);
+        eprintln!("humility {} failed: {:?}", args.cmd[0], err);
         std::process::exit(1);
     }
 

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -5,9 +5,9 @@ comment above the option declaration for details and rationale.)
 ```
 $ humility --chip -V
 ? failed
-error: The argument '--chip <CHIP>' requires a value but none was supplied
+error: a value is required for '--chip <CHIP>' but none was supplied
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 
@@ -20,9 +20,9 @@ humility 0.12.17
 ```
 $ humility -c -V
 ? failed
-error: The argument '--chip <CHIP>' requires a value but none was supplied
+error: a value is required for '--chip <CHIP>' but none was supplied
 
-For more information try --help
+For more information, try '--help'.
 
 ```
 

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod env;
 
 use anyhow::{Context, Result, bail};
-use clap::{ArgGroup, ArgMatches, Parser, ValueSource};
+use clap::{ArgGroup, ArgMatches, Parser, parser::ValueSource};
 use env::Environment;
 use humility::{core::Core, hubris::HubrisArchive, msg, net, warn};
 
@@ -110,8 +110,9 @@ pub struct Cli {
     )]
     pub list_targets: bool,
 
-    #[clap(subcommand)]
-    pub cmd: Option<Subcommand>,
+    /// Subcommand to execute
+    #[clap(allow_hyphen_values = true)]
+    pub cmd: Vec<String>,
 }
 
 impl Cli {
@@ -161,12 +162,6 @@ impl Cli {
             None => Ok(subargs_serial.map(|s| s.to_owned())),
         }
     }
-}
-
-#[derive(Parser, Debug, Clone)]
-pub enum Subcommand {
-    #[clap(external_subcommand)]
-    Other(Vec<String>),
 }
 
 pub struct ExecutionContext {
@@ -318,7 +313,7 @@ impl ExecutionContext {
             _ => None,
         };
 
-        if cli.cmd.is_none() {
+        if cli.cmd.is_empty() {
             eprintln!("humility failed: subcommand expected (--help to list)");
             std::process::exit(1);
         }

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -111,7 +111,7 @@ pub struct Cli {
     pub list_targets: bool,
 
     /// Subcommand to execute
-    #[clap(allow_hyphen_values = true)]
+    #[clap(trailing_var_arg = true)]
     pub cmd: Vec<String>,
 }
 

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -5,16 +5,16 @@
 pub mod env;
 
 use anyhow::{Context, Result, bail};
-use clap::{AppSettings, ArgGroup, ArgMatches, Parser};
+use clap::{ArgGroup, ArgMatches, Parser, ValueSource};
 use env::Environment;
 use humility::{core::Core, hubris::HubrisArchive, msg, net, warn};
 
 #[derive(Parser, Debug, Clone)]
 #[clap(
     name = "humility", max_term_width = 80,
-    group = ArgGroup::new("hubris").multiple(false)
+    group = ArgGroup::new("hubris").multiple(false),
+    disable_version_flag = true,
 )]
-#[clap(global_setting(AppSettings::NoAutoVersion))]
 pub struct Cli {
     /// verbose messages
     #[clap(long, short)]
@@ -27,7 +27,7 @@ pub struct Cli {
     /// sets timeout for Hubris-related operations
     #[clap(
         long, default_value_t = 2000, value_name = "timeout_ms",
-        parse(try_from_str = parse_int::parse)
+        value_parser = parse_int::parse::<u32>,
     )]
     pub timeout: u32,
 
@@ -248,7 +248,9 @@ impl ExecutionContext {
                 // what is going on.
                 //
                 if cli.archive.is_some() {
-                    let msg = if m.occurrences_of("archive") == 1 {
+                    let msg = if m.value_source("archive")
+                        == Some(ValueSource::CommandLine)
+                    {
                         "archive on command-line"
                     } else {
                         "archive in environment variable"
@@ -330,8 +332,8 @@ impl ExecutionContext {
         //
         if cli.dump.is_some() && cli.archive.is_some() {
             match (
-                m.occurrences_of("dump") == 1,
-                m.occurrences_of("archive") == 1,
+                m.value_source("dump") == Some(ValueSource::CommandLine),
+                m.value_source("archive") == Some(ValueSource::CommandLine),
             ) {
                 (true, true) => {
                     msg!("cannot specify both a dump and an archive");
@@ -341,8 +343,8 @@ impl ExecutionContext {
                 (false, false) => {
                     msg!(
                         "both dump and archive have been set via environment \
-                    variables; unset one of them, or use a command-line option \
-                    to override"
+                        variables; unset one of them, or use a command-line \
+                        option to override"
                     );
                     std::process::exit(1);
                 }

--- a/humility-cmd/src/lib.rs
+++ b/humility-cmd/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Validate {
 }
 
 pub struct Command {
-    pub app: ClapCommand<'static>,
+    pub app: ClapCommand,
     pub name: &'static str,
     pub kind: CommandKind,
     pub run: fn(&mut humility_cli::ExecutionContext) -> Result<()>,


### PR DESCRIPTION
(Staged on #646)

This PR updates `clap` to version 4!

- `parse(try_from_str = parse_int::parse)` becomes `value_parser = parse_int::parse::<u32>`
- Conflicts and dependencies now use the original Rust names (i.e. `requires = "force_dump_agent"` instead of `requires = "force-dump-agent"`)
- I couldn't get the external subcommand to work, so I'm just accumulating `cmd: Vec<String>` in the tail position of the arguments
- `ArgEnum` becomes `ValueEnum`