### PR TITLE
Switch back to upstream capstone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,20 +360,21 @@ dependencies = [
 
 [[package]]
 name = "capstone"
-version = "0.10.0"
-source = "git+https://github.com/oxidecomputer/capstone-rs.git#77296e0e16411109f131b98d773e4c9ecc6bdcfe"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f442ae0f2f3f1b923334b4a5386c95c69c1cfa072bafa23d6fae6d9682eb1dd4"
 dependencies = [
  "capstone-sys",
- "libc",
+ "static_assertions",
 ]
 
 [[package]]
 name = "capstone-sys"
-version = "0.14.0"
-source = "git+https://github.com/oxidecomputer/capstone-rs.git#77296e0e16411109f131b98d773e4c9ecc6bdcfe"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,12 +110,6 @@ vsc7448-types = { git = "https://github.com/oxidecomputer/vsc7448.git" }
 #
 probe-rs = { git = "https://github.com/oxidecomputer/probe-rs.git", branch = "oxide-v0.12.0" }
 
-#
-# We need the fix for https://github.com/capstone-rust/capstone-rs/issues/84,
-# which upstream seems uninterested in fixing.
-#
-capstone = {git = "https://github.com/oxidecomputer/capstone-rs.git"}
-
 # Local `path`-based deps
 humility = { path = "./humility-core", package = "humility-core" }
 humility-arch-arm = { path = "./humility-arch-arm" }
@@ -199,6 +193,7 @@ addr2line = "0.26"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
 bitfield = "0.19.4"
 byteorder = "1.3.4"
+capstone = "0.14.0"
 cargo-readme = "3.3.1"
 cargo_metadata = "0.23.1"
 chrono = "0.4.38"


### PR DESCRIPTION
(staged on #650)

This PR switches us to upstream `capstone-rs`, because https://github.com/capstone-rust/capstone-rs/issues/84 has been fixed!