### PR TITLE
Fix `udprpc` buffer copy

### DIFF
--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -697,9 +697,13 @@ impl<'a> HiffyContext<'a> {
             if code != 0 {
                 return Err(Failure::FunctionError(code));
             }
-            rval[0..nreply as usize]
-                .copy_from_slice(&buf[5..(5 + nreply as usize)]);
+            // The reply may be shorter than `nreply` bytes, if this is an Idol
+            // call that uses serialization for its return type.  `buf` has
+            // already been trimmed based on actual reply length.
+            let reply = &buf[5..];
+            rval[0..][..reply.len()].copy_from_slice(reply);
 
+            // Return the original `nreply`, to match the Hubris implementation
             Ok(nreply.try_into().unwrap())
         }
         ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In https://github.com/oxidecomputer/humility/pull/608, we changed the `udprpc` backend to truncate the returned buffer based on the actual number of bytes received.  However, we still tried to copy `nreply` bytes out of that buffer.  This fails if the reply type has been serialized (e.g. with Hubpack) and is shorter than the maximal `nreply`.

This PR changes the implementation to extract and copy the (variable-size) reply portion of the buffer, instead of a fixed `nbytes`-sized chunk.

Fixes #653, tested on `niles`