### PR TITLE
Hubtools and loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,18 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.8.48",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,31 +348,11 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -436,7 +404,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "serde",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1475,7 +1443,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1492,15 +1460,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1527,6 +1486,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -1607,22 +1569,22 @@ dependencies = [
 [[package]]
 name = "hubtools"
 version = "0.4.8"
-source = "git+https://github.com/oxidecomputer/hubtools.git#09074a55dbf73c90f63020e04daa17495b85e1cc"
+source = "git+https://github.com/oxidecomputer/hubtools.git#5e41fbe7560b27eaa25bce3b322f7a612fac8f41"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.2",
  "hex",
  "lpc55_areas",
  "lpc55_sign",
- "object 0.30.4",
- "path-slash 0.1.5",
+ "object 0.39.1",
+ "path-slash",
  "rsa",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tlvc",
  "tlvc-text",
- "toml 0.7.8",
+ "toml",
  "x509-cert",
- "zerocopy 0.6.6",
- "zip 0.6.6",
+ "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -1746,7 +1708,7 @@ dependencies = [
  "scroll 0.13.0",
  "serde",
  "spd",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "trycmd",
 ]
 
@@ -1919,8 +1881,8 @@ dependencies = [
  "lzss",
  "num-traits",
  "parse_int",
- "zerocopy 0.8.48",
- "zip 8.6.0",
+ "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -1937,7 +1899,7 @@ dependencies = [
  "humility-doppel",
  "serde",
  "serde_json",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1962,7 +1924,7 @@ dependencies = [
  "humility-cli",
  "humility-cmd",
  "humility-log",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -1981,7 +1943,7 @@ dependencies = [
  "ihex",
  "num-traits",
  "parse_int",
- "path-slash 0.2.1",
+ "path-slash",
  "ron 0.12.1",
  "srec",
  "tempfile",
@@ -2002,7 +1964,7 @@ dependencies = [
  "indexmap 2.14.0",
  "parse_int",
  "serde",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2088,8 +2050,8 @@ dependencies = [
  "parse_int",
  "serde",
  "serde_json",
- "zerocopy 0.8.48",
- "zip 8.6.0",
+ "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -2124,7 +2086,7 @@ dependencies = [
  "idol",
  "parse_int",
  "pmbus",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2229,7 +2191,7 @@ dependencies = [
  "num-traits",
  "parse_int",
  "pmbus",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2376,9 +2338,9 @@ dependencies = [
  "ihex",
  "log",
  "parse_int",
- "path-slash 0.2.1",
+ "path-slash",
  "tempfile",
- "zip 8.6.0",
+ "zip",
 ]
 
 [[package]]
@@ -2439,7 +2401,7 @@ dependencies = [
  "pmbus",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2482,7 +2444,7 @@ dependencies = [
  "parse_int",
  "raw-cpuid",
  "termimad 0.34.1",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2660,7 +2622,7 @@ dependencies = [
  "serde",
  "tlvc",
  "tlvc-text",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2712,10 +2674,10 @@ dependencies = [
  "serde_json",
  "strsim 0.11.1",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml",
  "winapi",
- "zerocopy 0.8.48",
- "zip 8.6.0",
+ "zerocopy",
+ "zip",
 ]
 
 [[package]]
@@ -2741,7 +2703,7 @@ dependencies = [
  "humility-core",
  "indexmap 2.14.0",
  "serde",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2761,7 +2723,7 @@ dependencies = [
  "lzss",
  "num-traits",
  "rand 0.10.1",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2778,7 +2740,7 @@ dependencies = [
  "parse_int",
  "postcard",
  "thiserror 2.0.18",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2896,8 +2858,8 @@ dependencies = [
  "serde",
  "serde-big-array",
  "static_assertions",
- "zerocopy 0.8.48",
- "zerocopy-derive 0.8.48",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -3053,7 +3015,7 @@ dependencies = [
  "binrw",
  "derive_more 0.99.20",
  "indexmap 2.14.0",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3333,7 +3295,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "x509-cert",
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3611,23 +3573,14 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
-dependencies = [
- "crc32fast",
- "hashbrown 0.13.2",
- "indexmap 1.9.3",
- "memchr",
-]
-
-[[package]]
-name = "object"
 version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
+ "crc32fast",
  "flate2",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
  "memchr",
  "ruzstd",
 ]
@@ -3734,12 +3687,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "path-slash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
 
 [[package]]
 name = "path-slash"
@@ -3990,7 +3937,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.48",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4583,15 +4530,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5189,8 +5127,8 @@ version = "0.4.0"
 source = "git+https://github.com/oxidecomputer/tlvc#2f69360ddcb07ad6072cb720bb1fac9f58a2ddec"
 dependencies = [
  "crc",
- "zerocopy 0.8.48",
- "zerocopy-derive 0.8.48",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -5201,19 +5139,7 @@ dependencies = [
  "ron 0.8.1",
  "serde",
  "tlvc",
- "zerocopy 0.8.48",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.19.15",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5224,20 +5150,11 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.2",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -5262,25 +5179,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.14.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -5302,7 +5206,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit 0.14.4",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5903,15 +5807,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
@@ -6058,32 +5953,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive 0.8.48",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -6119,24 +5993,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "bzip2 0.4.4",
- "crc32fast",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "zip"
 version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
- "bzip2 0.6.1",
+ "bzip2",
  "constant_time_eq",
  "crc32fast",
  "deflate64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "hubtools",
  "humility-core",
  "humility-net-core",
  "humility-probes-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "memmap2",
  "object 0.39.1",
  "rustc-demangle",
- "smallvec",
+ "smallvec 1.15.1",
  "typed-arena",
 ]
 
@@ -33,6 +33,18 @@ dependencies = [
  "cipher",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -141,6 +153,15 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "array-init"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
@@ -188,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,7 +229,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4b52fe7fbd9e207b879c52c5af7efd861c2f4e234ab4f744b0bdc04a863623"
 dependencies = [
- "array-init",
+ "array-init 2.1.0",
  "binrw_derive",
  "bytemuck",
 ]
@@ -333,11 +360,31 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -389,7 +436,7 @@ dependencies = [
  "percent-encoding",
  "regex",
  "serde",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -521,6 +568,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
@@ -597,6 +645,12 @@ dependencies = [
  "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -699,6 +753,12 @@ checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
+
+[[package]]
+name = "crc-any"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ec9ff5f7965e4d7280bd5482acd20aadb50d632cf6c1d74493856b011fa73"
 
 [[package]]
 name = "crc-catalog"
@@ -993,6 +1053,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
 ]
 
@@ -1054,7 +1139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.1",
  "ctutils",
  "zeroize",
@@ -1221,6 +1306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1287,6 +1378,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1373,7 +1475,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -1390,6 +1492,15 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1491,6 +1602,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "hubtools"
+version = "0.4.8"
+source = "git+https://github.com/oxidecomputer/hubtools.git#09074a55dbf73c90f63020e04daa17495b85e1cc"
+dependencies = [
+ "digest 0.10.7",
+ "hex",
+ "lpc55_areas",
+ "lpc55_sign",
+ "object 0.30.4",
+ "path-slash 0.1.5",
+ "rsa",
+ "thiserror 1.0.69",
+ "tlvc",
+ "tlvc-text",
+ "toml 0.7.8",
+ "x509-cert",
+ "zerocopy 0.6.6",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -1614,7 +1746,7 @@ dependencies = [
  "scroll 0.13.0",
  "serde",
  "spd",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "trycmd",
 ]
 
@@ -1787,8 +1919,8 @@ dependencies = [
  "lzss",
  "num-traits",
  "parse_int",
- "zerocopy",
- "zip",
+ "zerocopy 0.8.48",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1805,7 +1937,7 @@ dependencies = [
  "humility-doppel",
  "serde",
  "serde_json",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -1830,7 +1962,7 @@ dependencies = [
  "humility-cli",
  "humility-cmd",
  "humility-log",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1849,7 +1981,7 @@ dependencies = [
  "ihex",
  "num-traits",
  "parse_int",
- "path-slash",
+ "path-slash 0.2.1",
  "ron 0.12.1",
  "srec",
  "tempfile",
@@ -1870,7 +2002,7 @@ dependencies = [
  "indexmap 2.14.0",
  "parse_int",
  "serde",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -1956,8 +2088,8 @@ dependencies = [
  "parse_int",
  "serde",
  "serde_json",
- "zerocopy",
- "zip",
+ "zerocopy 0.8.48",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -1992,7 +2124,7 @@ dependencies = [
  "idol",
  "parse_int",
  "pmbus",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2097,7 +2229,7 @@ dependencies = [
  "num-traits",
  "parse_int",
  "pmbus",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2244,9 +2376,9 @@ dependencies = [
  "ihex",
  "log",
  "parse_int",
- "path-slash",
+ "path-slash 0.2.1",
  "tempfile",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -2307,7 +2439,7 @@ dependencies = [
  "pmbus",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2350,7 +2482,7 @@ dependencies = [
  "parse_int",
  "raw-cpuid",
  "termimad 0.34.1",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2528,7 +2660,7 @@ dependencies = [
  "serde",
  "tlvc",
  "tlvc-text",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2556,6 +2688,7 @@ dependencies = [
  "gimli 0.33.0",
  "goblin",
  "hubpack",
+ "hubtools",
  "humility-arch-arm",
  "humility-log",
  "humility_load_derive",
@@ -2579,10 +2712,10 @@ dependencies = [
  "serde_json",
  "strsim 0.11.1",
  "thiserror 2.0.18",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "winapi",
- "zerocopy",
- "zip",
+ "zerocopy 0.8.48",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -2608,7 +2741,7 @@ dependencies = [
  "humility-core",
  "indexmap 2.14.0",
  "serde",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2628,7 +2761,7 @@ dependencies = [
  "lzss",
  "num-traits",
  "rand 0.10.1",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2645,7 +2778,7 @@ dependencies = [
  "parse_int",
  "postcard",
  "thiserror 2.0.18",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -2763,8 +2896,8 @@ dependencies = [
  "serde",
  "serde-big-array",
  "static_assertions",
- "zerocopy",
- "zerocopy-derive",
+ "zerocopy 0.8.48",
+ "zerocopy-derive 0.8.48",
 ]
 
 [[package]]
@@ -2920,7 +3053,7 @@ dependencies = [
  "binrw",
  "derive_more 0.99.20",
  "indexmap 2.14.0",
- "zerocopy",
+ "zerocopy 0.8.48",
 ]
 
 [[package]]
@@ -3074,6 +3207,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -3165,6 +3301,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lpc55_areas"
+version = "0.2.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "bitfield 0.19.4",
+ "clap",
+ "packed_struct",
+ "serde",
+]
+
+[[package]]
+name = "lpc55_sign"
+version = "0.3.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support#fc64732faf5511850b35f1734d572b9953d73374"
+dependencies = [
+ "byteorder",
+ "const-oid 0.9.6",
+ "crc-any",
+ "der",
+ "env_logger",
+ "hex",
+ "log",
+ "lpc55_areas",
+ "num-traits",
+ "packed_struct",
+ "pem-rfc7468",
+ "rsa",
+ "serde",
+ "serde-hex",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "x509-cert",
+ "zerocopy 0.8.48",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3372,12 @@ dependencies = [
  "nix",
  "winapi",
 ]
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "measurement-token"
@@ -3317,6 +3495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3515,23 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+ "smallvec 1.15.1",
+ "zeroize",
+]
 
 [[package]]
 name = "num-conv"
@@ -3361,12 +3562,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3384,6 +3606,18 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.13.2",
+ "indexmap 1.9.3",
  "memchr",
 ]
 
@@ -3436,6 +3670,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "packed_struct"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b29691432cc9eff8b282278473b63df73bea49bc3ec5e67f31a3ae9c3ec190"
+dependencies = [
+ "bitvec",
+ "packed_struct_codegen",
+ "serde",
+]
+
+[[package]]
+name = "packed_struct_codegen"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd6706dfe50d53e0f6aa09e12c034c44faacd23e966ae5a209e8bdb8f179f98"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,7 +3710,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.5.18",
- "smallvec",
+ "smallvec 1.15.1",
  "windows-link",
 ]
 
@@ -3481,6 +3737,12 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-slash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498a099351efa4becc6a19c72aa9270598e8fd274ca47052e37455241c88b696"
+
+[[package]]
+name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
@@ -3493,6 +3755,15 @@ checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.2",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3603,6 +3874,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +3983,15 @@ name = "ppmd-rust"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy 0.8.48",
+]
 
 [[package]]
 name = "prettyplease"
@@ -3791,6 +4092,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -3806,10 +4108,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -4040,6 +4355,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusb"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4530,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init 0.0.4",
+ "serde",
+ "smallvec 0.6.14",
+]
+
+[[package]]
 name = "serde-xml-rs"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4583,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4383,6 +4740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4772,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
 
 [[package]]
 name = "smallvec"
@@ -4455,6 +4831,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -4539,6 +4925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "svg"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +5007,16 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4761,13 +5163,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tlvc"
 version = "0.4.0"
 source = "git+https://github.com/oxidecomputer/tlvc#2f69360ddcb07ad6072cb720bb1fac9f58a2ddec"
 dependencies = [
  "crc",
- "zerocopy",
- "zerocopy-derive",
+ "zerocopy 0.8.48",
+ "zerocopy-derive 0.8.48",
 ]
 
 [[package]]
@@ -4778,7 +5201,19 @@ dependencies = [
  "ron 0.8.1",
  "serde",
  "tlvc",
- "zerocopy",
+ "zerocopy 0.8.48",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -4789,11 +5224,20 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4818,12 +5262,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.5.40",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4845,7 +5302,7 @@ dependencies = [
  "serde",
  "shlex",
  "snapbox",
- "toml_edit",
+ "toml_edit 0.14.4",
 ]
 
 [[package]]
@@ -5446,6 +5903,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
@@ -5554,6 +6020,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "xml"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5580,11 +6058,32 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive 0.6.6",
+]
+
+[[package]]
+name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.8.48",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5603,6 +6102,32 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "bzip2 0.4.4",
+ "crc32fast",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "zip"
@@ -5611,7 +6136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
- "bzip2",
+ "bzip2 0.6.1",
  "constant_time_eq",
  "crc32fast",
  "deflate64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ rust-version = "1.91" # if this changes, edit ci.yaml as well!
 # `git`-based deps
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git" }
 humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.5" }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }

--- a/cmd/extract/src/lib.rs
+++ b/cmd/extract/src/lib.rs
@@ -154,8 +154,8 @@ struct ExtractArgs {
 }
 
 fn extract(context: &mut ExecutionContext) -> Result<()> {
-    let archive = context.cli.raw_archive()?;
     let subargs = ExtractArgs::try_parse_from(&context.cli.cmd)?;
+    let archive = context.cli.raw_archive()?;
 
     if subargs.list {
         let cursor = Cursor::new(archive);

--- a/cmd/extract/src/lib.rs
+++ b/cmd/extract/src/lib.rs
@@ -158,7 +158,10 @@ fn extract(context: &mut ExecutionContext) -> Result<()> {
     let archive = context.cli.raw_archive()?;
 
     if subargs.list {
-        let cursor = Cursor::new(archive);
+        // We convert the archive data back into a `ZipArchive` instead of using
+        // `RawHubrisArchive` functions for speed; the `ZipArchive` can report
+        // file size without uncompressing.
+        let cursor = Cursor::new(archive.zip);
         let mut archive = zip::ZipArchive::new(cursor)?;
 
         println!("{:>12} NAME", "SIZE");
@@ -172,7 +175,7 @@ fn extract(context: &mut ExecutionContext) -> Result<()> {
     }
 
     let buffer = if let Some(ref filename) = subargs.file {
-        let cursor = Cursor::new(archive);
+        let cursor = Cursor::new(archive.zip);
         let mut archive = zip::ZipArchive::new(cursor)?;
         let mut found = vec![];
 
@@ -211,7 +214,7 @@ fn extract(context: &mut ExecutionContext) -> Result<()> {
         file.read_to_end(&mut buffer)?;
         buffer
     } else {
-        archive.to_vec()
+        archive.zip.to_vec()
     };
 
     if let Some(output) = subargs.output {

--- a/humility-cli/Cargo.toml
+++ b/humility-cli/Cargo.toml
@@ -13,10 +13,10 @@ parse_int.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 
-humility.workspace = true
 humility-net-core.workspace = true
-
 humility-probes-core = { workspace = true, optional = true }
+humility.workspace = true
+hubtools.workspace = true
 
 [features]
 default = ["probes"]

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -137,7 +137,7 @@ impl Cli {
         &self,
         doneness: HubrisArchiveDoneness,
     ) -> Result<HubrisArchive> {
-        let mut hubris = HubrisArchive::new();
+        let mut hubris = HubrisArchive::new()?;
         if let Some(archive) = &self.archive {
             hubris.load(archive, doneness).with_context(|| {
                 format!("failed to load archive \"{}\"", archive)

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -4,12 +4,12 @@
 
 pub mod env;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgGroup, ArgMatches, Parser, parser::ValueSource};
 use env::Environment;
 use humility::{
     core::Core,
-    hubris::{HubrisArchive, HubrisArchiveDoneness, HubrisValidate},
+    hubris::{HubrisArchive, HubrisValidate},
     msg, net, warn,
 };
 use std::time::Duration;
@@ -123,31 +123,44 @@ pub struct Cli {
 impl Cli {
     /// Loads an archive based on CLI arguments
     ///
-    /// If `--archive` is specified, then the archive is loaded (and cooked to
-    /// the desired doneness).
+    /// If `--archive` is specified, then that archive is loaded.
     ///
     /// If `--dump` is specified, then the dump is loaded and the archive is
-    /// extracted from the dump (then cooked to the desired doneness).
+    /// extracted from the dump.
     ///
-    /// If neither is specified, then a default archive is returned, which
-    /// returns `false` from [`HubrisArchive::loaded`].
-    // TODO(matt): this is terrible and I want to make it go away, but it won't
-    // happen quite yet.
-    fn load_archive_with_doneness(
-        &self,
-        doneness: HubrisArchiveDoneness,
-    ) -> Result<HubrisArchive> {
-        let mut hubris = HubrisArchive::new()?;
+    /// Otherwise, returns `Ok(None)`
+    pub fn try_archive(&self) -> Result<Option<HubrisArchive>> {
         if let Some(archive) = &self.archive {
-            hubris.load(archive, doneness).with_context(|| {
-                format!("failed to load archive \"{}\"", archive)
-            })?;
+            let data = std::fs::read(archive)?;
+            let raw_archive = hubtools::RawHubrisArchive::from_vec(data)?;
+            HubrisArchive::load(raw_archive, None).map(Some)
         } else if let Some(dump) = &self.dump {
-            hubris
-                .load_dump(dump, doneness)
-                .with_context(|| format!("failed to load dump \"{}\"", dump))?;
+            let (raw_archive, dump_task) = HubrisArchive::load_dump(dump)?;
+            HubrisArchive::load(raw_archive, dump_task).map(Some)
+        } else {
+            Ok(None)
         }
-        Ok(hubris)
+    }
+
+    /// Tries to load a raw archive based on CLI arguments
+    ///
+    /// If `--archive` is specified, then that archive is loaded.
+    ///
+    /// If `--dump` is specified, then the dump is loaded and the archive is
+    /// extracted from the dump.
+    ///
+    /// Otherwise, returns `Ok(None)`
+    fn try_raw_archive(&self) -> Result<Option<hubtools::RawHubrisArchive>> {
+        if let Some(archive) = &self.archive {
+            let data = std::fs::read(archive)?;
+            let raw_archive = hubtools::RawHubrisArchive::from_vec(data)?;
+            Ok(Some(raw_archive))
+        } else if let Some(dump) = &self.dump {
+            let (raw_archive, _) = HubrisArchive::load_dump(dump)?;
+            Ok(Some(raw_archive))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Attaches to a live core
@@ -298,23 +311,13 @@ impl Cli {
     ///
     /// If loading the archive fails, then an error is returned
     pub fn archive(&self) -> Result<HubrisArchive> {
-        let a = self.load_archive_with_doneness(HubrisArchiveDoneness::Cook)?;
-        if !a.loaded() {
+        self.try_archive()?.ok_or_else(|| {
             if self.environment.is_some() {
-                bail!("must provide a Hubris archive, dump, or name");
+                anyhow!("must provide a Hubris archive, dump, or name")
             } else {
-                bail!("must provide a Hubris archive or dump");
+                anyhow!("must provide a Hubris archive or dump")
             }
-        }
-        Ok(a)
-    }
-
-    /// Tries to load an archive
-    ///
-    /// Returns `Ok(None)` if no archive was specified at the CLI.
-    pub fn try_archive(&self) -> Result<Option<HubrisArchive>> {
-        let a = self.load_archive_with_doneness(HubrisArchiveDoneness::Cook)?;
-        if !a.loaded() { Ok(None) } else { Ok(Some(a)) }
+        })
     }
 
     /// Returns a raw archive built from the context's [`Cli`] data
@@ -322,14 +325,14 @@ impl Cli {
     /// The raw archive is equivalent to the bytes of a ZIP file
     ///
     /// If loading the archive fails, then an error is returned
-    pub fn raw_archive(&self) -> Result<Vec<u8>> {
-        let a = self.load_archive_with_doneness(HubrisArchiveDoneness::Raw)?;
-        let out = a.take_raw_archive();
-        if out.is_empty() {
-            bail!("no archive available");
-        } else {
-            Ok(out)
-        }
+    pub fn raw_archive(&self) -> Result<hubtools::RawHubrisArchive> {
+        self.try_raw_archive()?.ok_or_else(|| {
+            if self.environment.is_some() {
+                anyhow!("must provide a Hubris archive, dump, or name")
+            } else {
+                anyhow!("must provide a Hubris archive or dump")
+            }
+        })
     }
 }
 

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -12,6 +12,7 @@ clap.workspace = true
 gimli.workspace = true
 goblin.workspace = true
 hubpack.workspace = true
+hubtools.workspace = true
 humility-arch-arm.workspace = true
 humility-log.workspace = true
 humility_load_derive.workspace = true

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -515,7 +515,7 @@ impl HubrisI2cBusList {
     pub fn lookup_i2c_bus(&self, bus: &str) -> Result<&HubrisI2cBus> {
         self.0
             .iter()
-            .find(|&b| b.name == Some(bus.to_string()))
+            .find(|&b| b.name.as_deref() == Some(bus))
             .ok_or_else(|| anyhow!("couldn't find bus {}", bus))
     }
 
@@ -1369,7 +1369,7 @@ impl HubrisArchive {
 
         // Load the main manifest config file
         let app = hubris.extract_file("app.toml")?;
-        let mut config: HubrisConfig = toml::from_slice(app.as_bytes())?;
+        let mut config: HubrisConfig = toml::from_slice(&app)?;
 
         // Apply TOML patches, if `patches.toml` is present in the archive.
         if let Ok(patches) = hubris.extract_file("patches.toml") {
@@ -1440,6 +1440,8 @@ impl HubrisArchive {
         let mut objects = (0..hubris.file_count()?)
             .into_par_iter()
             .map(|i| -> Result<Option<(usize, String, Vec<u8>)>> {
+                // TODO(matt) once hubtools#65 is merged, this can be made more
+                // efficient; right now, it extracts every file.
                 let (name, data) = hubris.extract_file_by_index(i)?;
                 let path = Path::new(&name);
                 let pieces = path.iter().collect::<Vec<_>>();

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -6,14 +6,12 @@ use capstone::prelude::*;
 use humility_arch_arm::{ARMRegister, presyscall_pushes};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::io::prelude::*;
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map};
 use std::convert::TryInto;
 use std::fmt::{self, Write};
 use std::fs::{self, OpenOptions};
-use std::io::Cursor;
 use std::mem::size_of;
 use std::num::TryFromIntError;
 use std::path::{Path, PathBuf};
@@ -25,6 +23,7 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use capstone::InsnGroupType;
 use gimli::UnwindSection;
 use goblin::elf::Elf;
+use hubtools::{HubrisArchiveBuilder, RawHubrisArchive};
 use humpty::DumpTask;
 use idol::syntax::send::Interface;
 use multimap::MultiMap;
@@ -532,21 +531,14 @@ impl HubrisFlashMap {
     ///
     /// This will fail if the `HubrisArchive` is fake, i.e. contains zero bytes.
     pub fn new(hubris: &HubrisArchive) -> Result<Self> {
-        if hubris.archive().is_empty() {
+        if hubris.raw_bytes().is_empty() {
             bail!("archive is required for network use but was not provided");
         }
         //
         // We want to read in the "final.elf" from our archive and use that
         // to determine the memory that constitutes flash.
         //
-        let cursor = Cursor::new(hubris.archive());
-        let mut archive = zip::ZipArchive::new(cursor)?;
-        let mut file = archive
-            .by_name("img/final.elf")
-            .map_err(|e| anyhow!("failed to find final.elf: {}", e))?;
-
-        let mut contents = Vec::new();
-        file.read_to_end(&mut contents)?;
+        let contents = hubris.hubris_archive.extract_file("img/final.elf")?;
 
         let elf = Elf::parse(&contents).map_err(|e| {
             anyhow!("failed to parse final.elf as an ELF file: {}", e)
@@ -690,8 +682,10 @@ impl Namespaces {
 }
 
 pub struct HubrisArchive {
+    hubris_archive: RawHubrisArchive,
+
     // the entire archive
-    archive: Vec<u8>,
+    raw_bytes: Vec<u8>,
 
     // constructed manifest
     pub manifest: HubrisManifest,
@@ -797,9 +791,12 @@ pub struct HubrisArchive {
 #[rustfmt::skip::macros(anyhow, bail)]
 impl HubrisArchive {
     #[expect(clippy::new_without_default)]
-    pub fn new() -> HubrisArchive {
-        Self {
-            archive: Vec::new(),
+    pub fn new() -> Result<HubrisArchive> {
+        Ok(Self {
+            raw_bytes: Vec::new(),
+            hubris_archive: RawHubrisArchive::from_vec(
+                HubrisArchiveBuilder::with_fake_image().build_to_vec()?,
+            )?,
             imageid: None,
             manifest: Default::default(),
             loaded: BTreeMap::new(),
@@ -831,7 +828,7 @@ impl HubrisArchive {
             definitions: MultiMap::new(),
             namespaces: Namespaces::new(),
             extern_regions: ExternRegions::new(),
-        }
+        })
     }
 
     pub fn instr_len(&self, addr: u32) -> Option<u32> {
@@ -1257,48 +1254,40 @@ impl HubrisArchive {
     }
 
     fn load_archive(&mut self, archive: &[u8]) -> Result<()> {
-        let cursor = Cursor::new(archive);
-        let mut archive = zip::ZipArchive::new(cursor)?;
-        let manifest = &mut self.manifest;
+        let hubris = RawHubrisArchive::from_vec(archive.to_vec())?;
 
-        macro_rules! byname {
-            ($name:tt) => {
-                archive
-                    .by_name($name)
-                    .map_err(|e| anyhow!("failed to find \"{}\": {}", $name, e))
-            };
+        // Check the version early and bail if we don't match/can't read
+        let archive_version = hubris.archive_version();
+        if archive_version > MAX_HUBRIS_VERSION {
+            bail!("\
+                        Hubris archive version is unsupported.\n\
+                        Humility supports v{} and earlier; archive is v{}.\n\
+                        Please update Humility.",
+                        MAX_HUBRIS_VERSION, archive_version)
         }
 
         //
         // First, we'll load aspects of configuration.
         //
-        manifest.version = Some(str::from_utf8(archive.comment())?.to_string());
-
-        if let Ok(mut file) = archive.by_name("git-rev") {
-            let mut gitrev = String::new();
-            file.read_to_string(&mut gitrev)
-                .context("failed reading `git-rev`")?;
-            manifest.gitrev = Some(gitrev);
+        let manifest = &mut self.manifest;
+        if let Ok(git_rev) = hubris.extract_file("git-rev") {
+            manifest.gitrev = Some(std::str::from_utf8(&git_rev)?.to_string());
         }
 
-        if let Ok(mut file) = archive.by_name("image-name") {
-            let mut image = String::new();
-            file.read_to_string(&mut image)
-                .context("failed reading `image-name`")?;
-            manifest.image = Some(image);
+        if let Ok(image_name) = hubris.extract_file("image-name") {
+            manifest.image =
+                Some(std::str::from_utf8(&image_name)?.to_string());
         }
 
-        let mut app = String::new();
-        byname!("app.toml")?.read_to_string(&mut app)?;
+        manifest.version =
+            Some(format!("hubris build archive v{}", archive_version));
+        let app = hubris.extract_file("app.toml")?;
 
         let mut config: HubrisConfig = toml::from_slice(app.as_bytes())?;
 
         // Apply TOML patches, if `patches.toml` is present in the archive.
-        if let Ok(mut patches) = byname!("patches.toml") {
-            let mut patch_str = String::new();
-            patches.read_to_string(&mut patch_str)?;
-            let patches: HubrisConfigPatches =
-                toml::from_slice(patch_str.as_bytes())?;
+        if let Ok(patches) = hubris.extract_file("patches.toml") {
+            let patches: HubrisConfigPatches = toml::from_slice(&patches)?;
             config.name = patches.name;
             for (task, features) in patches.features {
                 config
@@ -1338,8 +1327,6 @@ impl HubrisArchive {
                 None => chip,
             };
 
-            let mut chip = String::new();
-
             //
             // Ideally, we would hard-fail if we didn't find this file in
             // the archive -- but there was a small window of time in which
@@ -1347,11 +1334,9 @@ impl HubrisArchive {
             // recoverable -- but anything that relies on the presence of
             // peripherals in the TOML will fail.
             //
-            if let Ok(mut file) = archive.by_name(path) {
-                file.read_to_string(&mut chip)?;
-
+            if let Ok(chip) = hubris.extract_file(path) {
                 let peripherals: IndexMap<String, HubrisConfigPeripheral> =
-                    toml::from_slice(chip.as_bytes())?;
+                    toml::from_slice(&chip)?;
 
                 self.load_config(&config, Some(&peripherals))?;
             } else {
@@ -1366,10 +1351,12 @@ impl HubrisArchive {
         // forward slash: regardless of platform, paths within a ZIP archive
         // use the forward slash as a separator.
         //
-        let mut buffer = Vec::new();
-        byname!("elf/kernel")?.read_to_end(&mut buffer)?;
         let mut loader = HubrisObjectLoader::new(self.current)?;
-        loader.load_object("kernel", HubrisTask::Kernel, &buffer)?;
+        loader.load_object(
+            "kernel",
+            HubrisTask::Kernel,
+            &hubris.extract_file("elf/kernel")?,
+        )?;
         self.merge(loader)?;
 
         //
@@ -1378,13 +1365,11 @@ impl HubrisArchive {
         // resulting tuple for later sorting.
         //
         use rayon::prelude::*;
-        let mut objects = (0..archive.len())
+        let mut objects = (0..hubris.file_count()?)
             .into_par_iter()
             .map(|i| -> Result<Option<(usize, String, Vec<u8>)>> {
-                // ZipArchive is cheap to clone since the backing is cheap
-                let mut archive = archive.clone();
-                let mut file = archive.by_index(i)?;
-                let path = Path::new(file.name());
+                let (name, data) = hubris.extract_file_by_index(i)?;
+                let path = Path::new(&name);
                 let pieces = path.iter().collect::<Vec<_>>();
 
                 //
@@ -1395,13 +1380,11 @@ impl HubrisArchive {
                     return Ok(None);
                 }
 
-                let mut buffer = Vec::new();
-                file.read_to_end(&mut buffer)?;
-                let filename = Path::new(file.name());
+                let filename = Path::new(&name);
                 Ok(Some((
                     i,
                     filename.file_name().unwrap().to_str().unwrap().to_owned(),
-                    buffer,
+                    data,
                 )))
             })
             .filter_map(|f| f.transpose())
@@ -1438,7 +1421,7 @@ impl HubrisArchive {
         //
         // Now that we have loaded our tasks, load our extern regions.
         //
-        self.extern_regions = ExternRegions::load(self, &mut archive, &config)?;
+        self.extern_regions = ExternRegions::load(self, &hubris, &config)?;
 
         //
         // Post-process our enums and structs to add their fully scoped names.
@@ -1475,6 +1458,7 @@ impl HubrisArchive {
             self.structs_byname.insert(name.clone(), *goff);
         }
 
+        self.hubris_archive = hubris;
         Ok(())
     }
 
@@ -1557,77 +1541,28 @@ impl HubrisArchive {
         //
         let contents = fs::read(archive)?;
 
-        let cursor = Cursor::new(&contents);
-        let archive = zip::ZipArchive::new(cursor)?;
-        let comment = str::from_utf8(archive.comment())
-            .context("Failed to decode comment string")?;
-        Self::check_version(comment)?;
-
         if doneness == HubrisArchiveDoneness::Cook {
             self.load_archive(&contents)?;
         }
 
-        self.archive = contents;
-        Ok(())
-    }
-
-    fn check_version(comment: &str) -> Result<()> {
-        match comment.strip_prefix("hubris build archive v") {
-            Some(v) => {
-                let archive_version = match v {
-                    // Special-case for older archives
-                    "1.0.0" => 1,
-                    // There was no v1, just v1.0.0
-                    "1" => bail!("Invalid archive version 'v1'"),
-                    // Otherwise, expect an integer
-                    v => v.parse().with_context(|| {
-                        format!("Failed to parse version string {}", v)
-                    })?,
-                };
-                if archive_version > MAX_HUBRIS_VERSION {
-                    bail!("\
-                        Hubris archive version is unsupported.\n\
-                        Humility supports v{} and earlier; archive is v{}.\n\
-                        Please update Humility.",
-                        MAX_HUBRIS_VERSION, v)
-                }
-            }
-            None => {
-                bail!(
-                    "Could not parse hubris archive version from '{}'",
-                    comment)
-            }
-        }
+        self.raw_bytes = contents;
         Ok(())
     }
 
     pub fn load_flash_config(&self) -> Result<HubrisFlashConfig> {
-        let cursor = Cursor::new(&self.archive);
-        let mut archive = zip::ZipArchive::new(cursor)?;
-
-        macro_rules! slurp {
-            ($name:tt) => {{
-                let mut buffer = Vec::new();
-                archive
-                    .by_name($name)
-                    .map_err(|e| {
-                        anyhow!("failed to find \"{}\": {}", $name, e)
-                    })?
-                    .read_to_end(&mut buffer)?;
-                buffer
-            }};
-        }
-
-        let flash_ron = archive.by_name("img/flash.ron").map_err(|_| {
-            anyhow!(
+        let flash_ron = self
+            .hubris_archive
+            .extract_file("img/flash.ron")
+            .map_err(|_| {
+                anyhow!(
                 "could not find img/flash.ron in archive; \
                 does archive pre-date addition of flash information?"
             )
-        })?;
+            })?;
 
         let config: HubrisFlashMeta = ron::options::Options::default()
             .with_default_extension(ron::extensions::Extensions::IMPLICIT_SOME)
-            .from_reader(flash_ron)?;
+            .from_bytes(&flash_ron)?;
 
         // This is incredibly ugly! It also gives us backwards compatibility!
         let chip: Option<String> = match config.chip {
@@ -1637,7 +1572,7 @@ impl HubrisArchive {
 
         Ok(HubrisFlashConfig {
             metadata: config,
-            elf: slurp!("img/final.elf"),
+            elf: self.hubris_archive.extract_file("img/final.elf")?,
             chip,
         })
     }
@@ -1656,7 +1591,7 @@ impl HubrisArchive {
 
     /// Destroys the `HubrisArchive`, returning the raw archive data
     pub fn take_raw_archive(self) -> Vec<u8> {
-        self.archive
+        self.hubris_archive.zip
     }
 
     pub fn load_dump(
@@ -1686,7 +1621,7 @@ impl HubrisArchive {
                                     self.load_archive(note.desc)?;
                                 }
 
-                                self.archive = note.desc.to_vec();
+                                self.raw_bytes = note.desc.to_vec();
                             }
                             OXIDE_NT_HUBRIS_TASK => {
                                 match DumpTask::read_from_prefix(note.desc) {
@@ -2279,13 +2214,8 @@ impl HubrisArchive {
 
         // We don't use final.elf for much and don't keep it around in a
         // convenient buffer. So, go get it out of the archive.
-        let cursor = Cursor::new(self.archive());
-        let mut archive = zip::ZipArchive::new(cursor)?;
-        let mut elf_file = archive
-            .by_name("img/final.elf")
-            .context("could not find final.elf in archive!")?;
-        let mut file_contents = vec![];
-        elf_file.read_to_end(&mut file_contents)?;
+        let file_contents =
+            self.hubris_archive.extract_file("img/final.elf")?;
 
         let elf =
             Elf::parse(&file_contents).context("busted final ELF object")?;
@@ -3312,7 +3242,7 @@ impl HubrisArchive {
 
         notes.push(goblin::elf::note::Nhdr32 {
             n_namesz: (oxide.len() + 1) as u32,
-            n_descsz: self.archive.len() as u32,
+            n_descsz: self.raw_bytes.len() as u32,
             n_type: OXIDE_NT_HUBRIS_ARCHIVE,
         });
 
@@ -3426,7 +3356,7 @@ impl HubrisArchive {
                 }
 
                 OXIDE_NT_HUBRIS_ARCHIVE => {
-                    file.write_all(&self.archive)?;
+                    file.write_all(&self.raw_bytes)?;
                 }
 
                 OXIDE_NT_HUBRIS_TASK => {
@@ -3490,15 +3420,12 @@ impl HubrisArchive {
     }
 
     pub fn extract_file_to(&self, filename: &str, target: &Path) -> Result<()> {
-        let cursor = Cursor::new(self.archive.as_slice());
-        let mut archive = zip::ZipArchive::new(cursor)?;
-        let mut file = archive
-            .by_name(filename)
+        let bytes = self
+            .hubris_archive
+            .extract_file(filename)
             .map_err(|e| anyhow!("failed to find '{}': {}", filename, e))?;
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)?;
 
-        std::fs::write(target, &buffer).map_err(Into::into)
+        std::fs::write(target, &bytes).map_err(Into::into)
     }
 
     pub fn lookup_feature(&self, feature: &str) -> Result<Vec<HubrisTask>> {
@@ -3674,8 +3601,12 @@ impl HubrisArchive {
         }
     }
 
-    pub fn archive(&self) -> &[u8] {
-        &self.archive
+    pub fn hubris_archive(&self) -> &RawHubrisArchive {
+        &self.hubris_archive
+    }
+
+    pub fn raw_bytes(&self) -> &[u8] {
+        &self.raw_bytes
     }
 
     /// Reads the auxiliary flash data from a Hubris archive
@@ -3683,18 +3614,12 @@ impl HubrisArchive {
     /// Returns `Ok(Some(...))` if the data is loaded, `Ok(None)` if the file
     /// is missing, or `Err(...)` if a zip file error occurred.
     pub fn read_file(&self, name: &str) -> Result<Option<Vec<u8>>> {
-        let archive = self.archive();
-        let cursor = Cursor::new(archive);
-        let mut archive = zip::ZipArchive::new(cursor)?;
-        let file = archive.by_name(name);
-        match file {
-            Ok(mut f) => {
-                let mut buffer = Vec::new();
-                f.read_to_end(&mut buffer)?;
-                Ok(Some(buffer))
-            }
-            Err(zip::result::ZipError::FileNotFound) => Ok(None),
-            Err(e) => bail!("Failed to extract {}: {}", name, e),
+        match self.hubris_archive.extract_file(name) {
+            Ok(s) => Ok(Some(s)),
+            Err(hubtools::Error::ZipError(
+                zip::result::ZipError::FileNotFound,
+            )) => Ok(None),
+            Err(e) => bail!("Failed to extract {name}: {e}"),
         }
     }
 
@@ -6533,15 +6458,13 @@ impl ExternRegions {
     ///
     fn load(
         hubris: &HubrisArchive,
-        archive: &mut zip::ZipArchive<Cursor<&[u8]>>,
+        archive: &RawHubrisArchive,
         config: &HubrisConfig,
     ) -> Result<Self> {
-        match archive.by_name("memory.toml") {
-            Ok(mut file) => {
-                let mut memory = String::new();
-                file.read_to_string(&mut memory)?;
+        match archive.extract_file("memory.toml") {
+            Ok(file) => {
                 let all_memories: IndexMap<String, Vec<HubrisMemoryRegion>> =
-                    toml::from_slice(memory.as_bytes())?;
+                    toml::from_slice(&file)?;
 
                 //
                 // We have our memory metadata but it includes all memories

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3635,7 +3635,7 @@ impl HubrisArchive {
 /// meant to be used for parallel loading, after which point everything is
 /// merged using `HubrisArchive::merge`.
 struct HubrisObjectLoader {
-    current: u32,
+    object_id: u32,
 
     // image ID
     imageid: Option<(u32, Vec<u8>)>,
@@ -3727,9 +3727,9 @@ struct HubrisObjectLoader {
 }
 
 impl HubrisObjectLoader {
-    fn new(current: u32) -> Result<Self> {
+    fn new(object_id: u32) -> Result<Self> {
         Ok(Self {
-            current,
+            object_id,
             imageid: None,
             arrays: HashMap::new(),
             variables: MultiMap::new(),
@@ -3881,7 +3881,7 @@ impl HubrisObjectLoader {
         let offset = textsec.sh_offset as u32;
         let textsize = textsec.sh_size as u32;
 
-        log::trace!("loading {} as object {}", object, self.current);
+        log::trace!("loading {} as object {}", object, self.object_id);
 
         for sym in elf.syms.iter() {
             if sym.st_name == 0 {
@@ -4045,7 +4045,7 @@ impl HubrisObjectLoader {
             textsec.sh_addr as u32,
             HubrisModule {
                 name: String::from(object),
-                object: self.current,
+                object: self.object_id,
                 textbase: (textsec.sh_addr as u32),
                 textsize,
                 memsize: memsz as u32,
@@ -4517,7 +4517,7 @@ impl HubrisObjectLoader {
         entry: &gimli::DebuggingInformationEntry<R, usize>,
     ) -> HubrisGoff {
         let goff = entry.offset().to_unit_section_offset(unit).0;
-        HubrisGoff { object: self.current, goff }
+        HubrisGoff { object: self.object_id, goff }
     }
 
     fn dwarf_union<R: gimli::Reader<Offset = usize>>(
@@ -4679,7 +4679,7 @@ impl HubrisObjectLoader {
             }
         };
 
-        Some(HubrisGoff { object: self.current, goff })
+        Some(HubrisGoff { object: self.object_id, goff })
     }
 
     fn dwarf_variant<R: gimli::Reader<Offset = usize>>(

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Result, anyhow, bail, ensure};
 use capstone::InsnGroupType;
 use gimli::UnwindSection;
 use goblin::elf::Elf;
-use hubtools::{HubrisArchiveBuilder, RawHubrisArchive};
+use hubtools::RawHubrisArchive;
 use humpty::DumpTask;
 use idol::syntax::send::Interface;
 use multimap::MultiMap;
@@ -40,7 +40,7 @@ pub const OXIDE_NT_HUBRIS_TASK: u32 = OXIDE_NT_BASE + 3;
 
 const MAX_HUBRIS_VERSION: u32 = 11;
 
-#[derive(Default, Debug, Serialize)]
+#[derive(Debug, Serialize)]
 pub struct HubrisManifest {
     pub version: Option<String>,
     pub gitrev: Option<String>,
@@ -55,7 +55,7 @@ pub struct HubrisManifest {
     pub peripherals: BTreeMap<String, u32>,
     pub peripherals_byaddr: BTreeMap<u32, String>,
     pub i2c_devices: Vec<HubrisI2cDevice>,
-    pub i2c_buses: Vec<HubrisI2cBus>,
+    pub i2c_buses: HubrisI2cBusList,
     pub sensors: Vec<HubrisSensor>,
     pub sockets: Vec<HubrisSocket>,
     pub auxflash: Option<HubrisConfigAuxflash>,
@@ -67,6 +67,481 @@ impl HubrisManifest {
             anyhow!("couldn't find socket with owner {:?}", task)
         })
     }
+
+    /// Loads a manifest from a `HubrisConfig` and revision
+    fn from_config(
+        config: &HubrisConfig,
+        rev: HubrisManifestRev,
+    ) -> Result<Self> {
+        let board = Some(config.board.clone());
+        let name = Some(config.name.clone());
+        let target = Some(config.target.clone());
+        let features = match config.kernel.features {
+            Some(ref features) => features.clone(),
+            None => vec![],
+        };
+        let auxflash = config.config.as_ref().and_then(|c| c.auxflash.clone());
+
+        let mut named_interrupts = HashMap::new();
+
+        let mut peripherals = BTreeMap::new();
+        let mut peripherals_byaddr = BTreeMap::new();
+        if let Some(periphs) = config.peripherals.as_ref() {
+            for (name, p) in periphs {
+                peripherals.insert(name.clone(), p.address);
+                peripherals_byaddr.insert(p.address, name.clone());
+
+                if let Some(ref interrupts) = p.interrupts {
+                    for (interrupt, irq) in interrupts {
+                        named_interrupts
+                            .insert(format!("{}.{}", name, interrupt), *irq);
+                    }
+                }
+            }
+        }
+
+        let mut task_features = HashMap::new();
+        let mut task_irqs = HashMap::new();
+        let mut task_notifications = HashMap::new();
+        for (name, task) in &config.tasks {
+            if let Some(ref features) = task.features {
+                task_features.insert(name.clone(), features.clone());
+            }
+
+            if let Some(ref interrupts) = task.interrupts {
+                let mut this_task_irqs = vec![];
+
+                for (irq_str, notification) in interrupts {
+                    let irq = match irq_str.parse::<u32>() {
+                        Ok(irq_num) => irq_num,
+                        Err(_) => {
+                            //
+                            // If our IRQ number doesn't parse, it may be
+                            // because it's named; look it up before failing.
+                            //
+                            match named_interrupts.get(irq_str) {
+                                Some(irq_num) => *irq_num,
+                                None => {
+                                    bail!(
+                                        "unrecognized irq {} on task {}",
+                                        irq_str,
+                                        name
+                                    )
+                                }
+                            }
+                        }
+                    };
+                    let notification = match notification {
+                        HubrisTaskInterrupt::Mask(i) => *i,
+                        HubrisTaskInterrupt::Named(name) => match task
+                            .notifications
+                            .iter()
+                            .position(|n| n == name)
+                        {
+                            Some(i) => 1 << i,
+                            None => bail!(
+                                "could not find notification '{name}' \
+                                 (options are {:?})",
+                                task.notifications
+                            ),
+                        },
+                    };
+
+                    this_task_irqs.push((notification, irq));
+                }
+
+                task_irqs.insert(name.clone(), this_task_irqs);
+            }
+
+            task_notifications.insert(name.clone(), task.notifications.clone());
+        }
+
+        let mut sockets = vec![];
+        let mut sensors = vec![];
+        let mut i2c_devices = vec![];
+        let mut i2c_buses = HubrisI2cBusList(vec![]);
+        if let Some(ref config) = config.config {
+            if let Some(i2c) = config.i2c.as_ref() {
+                let cfg = HubrisManifestI2cConfig::from_config(i2c)?;
+                i2c_buses = cfg.i2c_buses;
+                i2c_devices = cfg.i2c_devices;
+                sensors.extend(cfg.sensors);
+            }
+
+            if let Some(sensor) = config.sensor.as_ref() {
+                sensors.extend(Self::load_sensor_config(sensor));
+            }
+            if let Some(net) = config.net.as_ref() {
+                sockets = net
+                    .sockets
+                    .iter()
+                    .map(|(name, cfg)| HubrisSocket {
+                        name: name.clone(),
+                        kind: cfg.kind.clone(),
+                        owner: cfg.owner.clone(),
+                        port: cfg.port,
+                        tx: cfg.tx,
+                        rx: cfg.rx,
+                    })
+                    .collect();
+            }
+        }
+
+        // Destructure the `HubrisManifestRev`
+        let HubrisManifestRev { version, gitrev, image } = rev;
+
+        Ok(Self {
+            version,
+            gitrev,
+            board,
+            features,
+            task_features,
+            image,
+            name,
+            target,
+            task_irqs,
+            task_notifications,
+            peripherals,
+            peripherals_byaddr,
+            auxflash,
+            sockets,
+            sensors,
+            i2c_buses,
+            i2c_devices,
+        })
+    }
+
+    fn load_sensor_config(sensor: &HubrisConfigSensor) -> Vec<HubrisSensor> {
+        let mut out = vec![];
+        for device in &sensor.devices {
+            for (kind, &count) in &device.sensors {
+                for i in 0..count {
+                    out.push(HubrisSensor {
+                        name: device.name.clone(),
+                        kind: HubrisSensorKind::from(kind.as_str()),
+                        device: HubrisSensorDevice::Other(
+                            device.device.clone(),
+                            i,
+                        ),
+                    });
+                }
+            }
+        }
+        out
+    }
+}
+
+struct HubrisManifestI2cConfig {
+    pub i2c_devices: Vec<HubrisI2cDevice>,
+    pub i2c_buses: HubrisI2cBusList,
+    pub sensors: Vec<HubrisSensor>,
+}
+
+impl HubrisManifestI2cConfig {
+    fn from_config(i2c: &HubrisConfigI2c) -> Result<Self> {
+        let mut i2c_buses = Vec::new();
+        let mut i2c_devices = Vec::new();
+        let mut sensors = Vec::new();
+        let mut buses = HashMap::new();
+
+        if let Some(ref controllers) = i2c.controllers {
+            for controller in controllers {
+                for (index, (name, port)) in controller.ports.iter().enumerate()
+                {
+                    i2c_buses.push(HubrisI2cBus {
+                        controller: controller.controller,
+                        port: HubrisI2cPort {
+                            name: name.clone(),
+                            index: index as u8,
+                        },
+                        name: port.name.as_ref().cloned(),
+                        description: port.description.as_ref().cloned(),
+                        target: controller.target.unwrap_or(false),
+                    });
+                }
+            }
+        }
+
+        let i2c_buses = HubrisI2cBusList(i2c_buses);
+        for bus in &i2c_buses.0 {
+            if let Some(ref name) = bus.name {
+                buses.insert(name, bus);
+            }
+        }
+
+        let sensor_name = |d: &HubrisConfigI2cDevice,
+                           idx: usize,
+                           kind: &HubrisSensorKind|
+         -> Result<String> {
+            if let Some(pmbus) = &d.pmbus {
+                if let Some(rails) = &pmbus.rails {
+                    if idx < rails.len() {
+                        return Ok(rails[idx].clone());
+                    } else {
+                        bail!("sensor count exceeds rails for {:?}", d);
+                    }
+                }
+            } else if d.power.is_some()
+                && d.power
+                    .as_ref()
+                    .unwrap()
+                    .sensors
+                    .as_ref()
+                    .is_none_or(|s| s.contains(kind))
+                && let Some(rails) = &d.power.as_ref().unwrap().rails
+            {
+                if idx < rails.len() {
+                    return Ok(rails[idx].clone());
+                } else {
+                    bail!("sensor count exceeds rails for {:?}", d);
+                }
+            }
+
+            if let Some(names) = &d.sensors.as_ref().unwrap().names {
+                if idx >= names.len() {
+                    bail!(
+                        "name array is too short ({}) for sensor index ({})",
+                        names.len(),
+                        idx
+                    );
+                } else {
+                    Ok(names[idx].clone())
+                }
+            } else if let Some(name) = &d.name {
+                if idx == 0 {
+                    Ok(name.clone())
+                } else {
+                    Ok(format!("{}#{}", name, idx))
+                }
+            } else if idx == 0 {
+                Ok(d.device.clone())
+            } else {
+                Ok(format!("{}#{}", d.device, idx))
+            }
+        };
+        let get_sensor = |d: &HubrisConfigI2cDevice,
+                          i: usize,
+                          ndx: usize,
+                          kind: HubrisSensorKind|
+         -> Result<HubrisSensor> {
+            let name = sensor_name(d, i, &kind)?;
+            Ok(HubrisSensor {
+                name,
+                kind,
+                device: HubrisSensorDevice::I2c(ndx),
+            })
+        };
+
+        if let Some(ref devices) = i2c.devices {
+            for device in devices {
+                let name = &device.device;
+
+                let (controller, port) = match &device.bus {
+                    Some(bus) => match buses.get(&bus) {
+                        Some(bus) => (bus.controller, &bus.port),
+                        None => {
+                            //
+                            // This really shouldn't happen: we have
+                            // a bus that doesn't exist.
+                            //
+                            bail!("{}: unknown bus {}", name, bus);
+                        }
+                    },
+                    None => match (device.controller, &device.port) {
+                        (Some(controller), Some(port)) => (
+                            controller,
+                            i2c_buses.lookup_i2c_port(controller, port)?,
+                        ),
+                        (None, _) => {
+                            bail!("{}: missing controller", name);
+                        }
+                        (Some(controller), None) => {
+                            (controller, i2c_buses.i2c_port(controller)?)
+                        }
+                    },
+                };
+
+                let port = port.clone();
+
+                if let Some(dev_sensors) = &device.sensors {
+                    let ndx = i2c_devices.len();
+
+                    for i in 0..dev_sensors.temperature {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::Temperature,
+                        )?);
+                    }
+
+                    for i in 0..dev_sensors.power {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::Power,
+                        )?);
+                    }
+                    for i in 0..dev_sensors.current {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::Current,
+                        )?);
+                    }
+                    for i in 0..dev_sensors.voltage {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::Voltage,
+                        )?);
+                    }
+                    for i in 0..dev_sensors.input_current {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::InputCurrent,
+                        )?);
+                    }
+                    for i in 0..dev_sensors.input_voltage {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::InputVoltage,
+                        )?);
+                    }
+
+                    for i in 0..dev_sensors.speed {
+                        sensors.push(get_sensor(
+                            device,
+                            i,
+                            ndx,
+                            HubrisSensorKind::Speed,
+                        )?);
+                    }
+                }
+
+                i2c_devices.push(HubrisI2cDevice {
+                    device: device.device.clone(),
+                    name: device.name.clone(),
+                    controller,
+                    port,
+                    mux: device.mux,
+                    segment: device.segment,
+                    address: device.address,
+                    description: device.description.clone(),
+                    class: HubrisI2cDeviceClass::from(device),
+                    removable: device.removable.unwrap_or(false),
+                });
+            }
+        }
+
+        Ok(Self { i2c_devices, i2c_buses, sensors })
+    }
+}
+
+/// Wrapper around a `Vec<HubrisI2cBus>` with a few helper functions
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+pub struct HubrisI2cBusList(Vec<HubrisI2cBus>);
+
+impl HubrisI2cBusList {
+    /// For a given controller and port name, return the matching port (if any)
+    pub fn lookup_i2c_port(
+        &self,
+        controller: u8,
+        port: &str,
+    ) -> Result<&HubrisI2cPort> {
+        let mut found = false;
+
+        for bus in &self.0 {
+            if bus.controller != controller {
+                continue;
+            }
+
+            found = true;
+
+            if bus.port.name.eq_ignore_ascii_case(port) {
+                return Ok(&bus.port);
+            }
+        }
+
+        if !found {
+            bail!("unknown I2C controller {}", controller);
+        }
+
+        let ports = self
+            .0
+            .iter()
+            .filter(|bus| bus.controller == controller)
+            .map(|bus| bus.port.name.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        bail!("invalid port \"{}\" (must be one of: {})", port, ports);
+    }
+
+    pub fn i2c_port(&self, controller: u8) -> Result<&HubrisI2cPort> {
+        let found = self
+            .0
+            .iter()
+            .filter(|bus| bus.controller == controller)
+            .collect::<Vec<_>>();
+
+        if found.is_empty() {
+            bail!("unknown I2C controller {}", controller);
+        } else if found.len() == 1 {
+            Ok(&found[0].port)
+        } else {
+            let ports = found
+                .iter()
+                .map(|bus| bus.port.name.clone())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            bail!(
+                "I2C{} has multiple ports; expected one of: {}",
+                controller,
+                ports
+            )
+        }
+    }
+
+    pub fn lookup_i2c_bus(&self, bus: &str) -> Result<&HubrisI2cBus> {
+        self.0
+            .iter()
+            .find(|&b| b.name == Some(bus.to_string()))
+            .ok_or_else(|| anyhow!("couldn't find bus {}", bus))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<'a> IntoIterator for &'a HubrisI2cBusList {
+    type Item = &'a HubrisI2cBus;
+    type IntoIter = std::slice::Iter<'a, HubrisI2cBus>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+/// Portions of the [`HubrisManifest`] that are loaded from archive files
+#[derive(Default)]
+pub struct HubrisManifestRev {
+    pub version: Option<String>,
+    pub gitrev: Option<String>,
+    pub image: Option<String>,
 }
 
 //
@@ -531,9 +1006,6 @@ impl HubrisFlashMap {
     ///
     /// This will fail if the `HubrisArchive` is fake, i.e. contains zero bytes.
     pub fn new(hubris: &HubrisArchive) -> Result<Self> {
-        if hubris.raw_bytes().is_empty() {
-            bail!("archive is required for network use but was not provided");
-        }
         //
         // We want to read in the "final.elf" from our archive and use that
         // to determine the memory that constitutes flash.
@@ -599,14 +1071,6 @@ pub struct HubrisFlashConfig {
     pub metadata: HubrisFlashMeta,
     pub elf: Vec<u8>,
     pub chip: Option<String>,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum HubrisArchiveDoneness {
-    /// Fully load archive
-    Cook,
-    /// Load archive into memory, but do not otherwise process
-    Raw,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -682,10 +1146,11 @@ impl Namespaces {
 }
 
 pub struct HubrisArchive {
+    /// Raw archive
     hubris_archive: RawHubrisArchive,
 
-    // the entire archive
-    raw_bytes: Vec<u8>,
+    /// Number of tasks (not including the kernel)
+    ntasks: usize,
 
     // constructed manifest
     pub manifest: HubrisManifest,
@@ -695,9 +1160,6 @@ pub struct HubrisArchive {
 
     // loaded regions
     loaded: BTreeMap<u32, HubrisRegion>,
-
-    // current object
-    current: u32,
 
     // non-None if a dump of a single task
     task_dump: Option<DumpTask>,
@@ -790,47 +1252,6 @@ pub struct HubrisArchive {
 
 #[rustfmt::skip::macros(anyhow, bail)]
 impl HubrisArchive {
-    #[expect(clippy::new_without_default)]
-    pub fn new() -> Result<HubrisArchive> {
-        Ok(Self {
-            raw_bytes: Vec::new(),
-            hubris_archive: RawHubrisArchive::from_vec(
-                HubrisArchiveBuilder::with_fake_image().build_to_vec()?,
-            )?,
-            imageid: None,
-            manifest: Default::default(),
-            loaded: BTreeMap::new(),
-            current: 0,
-            task_dump: None,
-            instrs: HashMap::new(),
-            syscall_pushes: HashMap::new(),
-            modules: BTreeMap::new(),
-            tasks: HashMap::new(),
-            frames: HashMap::new(),
-            src: HashMap::new(),
-            dsyms: BTreeMap::new(),
-            esyms: BTreeMap::new(),
-            esyms_byname: MultiMap::new(),
-            inlined: BTreeMap::new(),
-            subprograms: HashMap::new(),
-            basetypes: HashMap::new(),
-            basetypes_byname: HashMap::new(),
-            ptrtypes: HashMap::new(),
-            structs: HashMap::new(),
-            structs_byname: MultiMap::new(),
-            enums: HashMap::new(),
-            addr2line: HashMap::new(),
-            enums_byname: MultiMap::new(),
-            arrays: HashMap::new(),
-            variables: MultiMap::new(),
-            qualified_variables: MultiMap::new(),
-            unions: HashMap::new(),
-            definitions: MultiMap::new(),
-            namespaces: Namespaces::new(),
-            extern_regions: ExternRegions::new(),
-        })
-    }
-
     pub fn instr_len(&self, addr: u32) -> Option<u32> {
         self.instrs.get(&addr).map(|instr| instr.0.len() as u32)
     }
@@ -916,373 +1337,38 @@ impl HubrisArchive {
         inlined
     }
 
-    fn load_sensor_config(
-        &mut self,
-        sensor: &HubrisConfigSensor,
-    ) -> Result<()> {
-        for device in &sensor.devices {
-            for (kind, &count) in &device.sensors {
-                for i in 0..count {
-                    self.manifest.sensors.push(HubrisSensor {
-                        name: device.name.clone(),
-                        kind: HubrisSensorKind::from(kind.as_str()),
-                        device: HubrisSensorDevice::Other(
-                            device.device.clone(),
-                            i,
-                        ),
-                    });
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn load_i2c_config(&mut self, i2c: &HubrisConfigI2c) -> Result<()> {
-        let mut buses = HashMap::new();
-
-        if let Some(ref controllers) = i2c.controllers {
-            for controller in controllers {
-                for (index, (name, port)) in controller.ports.iter().enumerate()
-                {
-                    self.manifest.i2c_buses.push(HubrisI2cBus {
-                        controller: controller.controller,
-                        port: HubrisI2cPort {
-                            name: name.clone(),
-                            index: index as u8,
-                        },
-                        name: port.name.as_ref().cloned(),
-                        description: port.description.as_ref().cloned(),
-                        target: controller.target.unwrap_or(false),
-                    });
-                }
-            }
-        }
-
-        for bus in &self.manifest.i2c_buses {
-            if let Some(ref name) = bus.name {
-                buses.insert(name, bus);
-            }
-        }
-
-        let sensor_name = |d: &HubrisConfigI2cDevice,
-                           idx: usize,
-                           kind: &HubrisSensorKind|
-         -> Result<String> {
-            if let Some(pmbus) = &d.pmbus {
-                if let Some(rails) = &pmbus.rails {
-                    if idx < rails.len() {
-                        return Ok(rails[idx].clone());
-                    } else {
-                        bail!("sensor count exceeds rails for {:?}", d);
-                    }
-                }
-            } else if d.power.is_some()
-                && d.power
-                    .as_ref()
-                    .unwrap()
-                    .sensors
-                    .as_ref()
-                    .is_none_or(|s| s.contains(kind))
-                && let Some(rails) = &d.power.as_ref().unwrap().rails
-            {
-                if idx < rails.len() {
-                    return Ok(rails[idx].clone());
-                } else {
-                    bail!("sensor count exceeds rails for {:?}", d);
-                }
-            }
-
-            if let Some(names) = &d.sensors.as_ref().unwrap().names {
-                if idx >= names.len() {
-                    bail!(
-                        "name array is too short ({}) for sensor index ({})",
-                        names.len(),
-                        idx
-                    );
-                } else {
-                    Ok(names[idx].clone())
-                }
-            } else if let Some(name) = &d.name {
-                if idx == 0 {
-                    Ok(name.clone())
-                } else {
-                    Ok(format!("{}#{}", name, idx))
-                }
-            } else if idx == 0 {
-                Ok(d.device.clone())
-            } else {
-                Ok(format!("{}#{}", d.device, idx))
-            }
-        };
-        let get_sensor = |d: &HubrisConfigI2cDevice,
-                          i: usize,
-                          ndx: usize,
-                          kind: HubrisSensorKind|
-         -> Result<HubrisSensor> {
-            let name = sensor_name(d, i, &kind)?;
-            Ok(HubrisSensor {
-                name,
-                kind,
-                device: HubrisSensorDevice::I2c(ndx),
-            })
-        };
-
-        if let Some(ref devices) = i2c.devices {
-            for device in devices {
-                let name = &device.device;
-
-                let (controller, port) = match &device.bus {
-                    Some(bus) => match buses.get(&bus) {
-                        Some(bus) => (bus.controller, &bus.port),
-                        None => {
-                            //
-                            // This really shouldn't happen: we have
-                            // a bus that doesn't exist.
-                            //
-                            bail!("{}: unknown bus {}", name, bus);
-                        }
-                    },
-                    None => match (device.controller, &device.port) {
-                        (Some(controller), Some(port)) => (
-                            controller,
-                            self.lookup_i2c_port(controller, port)?,
-                        ),
-                        (None, _) => {
-                            bail!("{}: missing controller", name);
-                        }
-                        (Some(controller), None) => {
-                            (controller, self.i2c_port(controller)?)
-                        }
-                    },
-                };
-
-                let port = port.clone();
-
-                if let Some(sensors) = &device.sensors {
-                    let ndx = self.manifest.i2c_devices.len();
-
-                    for i in 0..sensors.temperature {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::Temperature,
-                        )?);
-                    }
-
-                    for i in 0..sensors.power {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::Power,
-                        )?);
-                    }
-                    for i in 0..sensors.current {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::Current,
-                        )?);
-                    }
-                    for i in 0..sensors.voltage {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::Voltage,
-                        )?);
-                    }
-                    for i in 0..sensors.input_current {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::InputCurrent,
-                        )?);
-                    }
-                    for i in 0..sensors.input_voltage {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::InputVoltage,
-                        )?);
-                    }
-
-                    for i in 0..sensors.speed {
-                        self.manifest.sensors.push(get_sensor(
-                            device,
-                            i,
-                            ndx,
-                            HubrisSensorKind::Speed,
-                        )?);
-                    }
-                }
-
-                self.manifest.i2c_devices.push(HubrisI2cDevice {
-                    device: device.device.clone(),
-                    name: device.name.clone(),
-                    controller,
-                    port,
-                    mux: device.mux,
-                    segment: device.segment,
-                    address: device.address,
-                    description: device.description.clone(),
-                    class: HubrisI2cDeviceClass::from(device),
-                    removable: device.removable.unwrap_or(false),
-                });
-            }
-        }
-
-        Ok(())
-    }
-
-    fn load_config(
-        &mut self,
-        config: &HubrisConfig,
-        peripherals: Option<&IndexMap<String, HubrisConfigPeripheral>>,
-    ) -> Result<()> {
-        self.manifest.board = Some(config.board.clone());
-        self.manifest.name = Some(config.name.clone());
-        self.manifest.target = Some(config.target.clone());
-        self.manifest.features = match config.kernel.features {
-            Some(ref features) => features.clone(),
-            None => vec![],
-        };
-        self.manifest.auxflash =
-            config.config.as_ref().and_then(|c| c.auxflash.clone());
-
-        let mut named_interrupts = HashMap::new();
-
-        if let Some(peripherals) = peripherals {
-            for (name, p) in peripherals {
-                self.manifest.peripherals.insert(name.clone(), p.address);
-                self.manifest
-                    .peripherals_byaddr
-                    .insert(p.address, name.clone());
-
-                if let Some(ref interrupts) = p.interrupts {
-                    for (interrupt, irq) in interrupts {
-                        named_interrupts
-                            .insert(format!("{}.{}", name, interrupt), *irq);
-                    }
-                }
-            }
-        }
-
-        for (name, task) in &config.tasks {
-            if let Some(ref features) = task.features {
-                self.manifest
-                    .task_features
-                    .insert(name.clone(), features.clone());
-            }
-
-            if let Some(ref interrupts) = task.interrupts {
-                let mut task_irqs = vec![];
-
-                for (irq_str, notification) in interrupts {
-                    let irq = match irq_str.parse::<u32>() {
-                        Ok(irq_num) => irq_num,
-                        Err(_) => {
-                            //
-                            // If our IRQ number doesn't parse, it may be
-                            // because it's named; look it up before failing.
-                            //
-                            match named_interrupts.get(irq_str) {
-                                Some(irq_num) => *irq_num,
-                                None => {
-                                    bail!(
-                                        "unrecognized irq {} on task {}",
-                                        irq_str, name
-                                    )
-                                }
-                            }
-                        }
-                    };
-                    let notification = match notification {
-                        HubrisTaskInterrupt::Mask(i) => *i,
-                        HubrisTaskInterrupt::Named(name) => match task
-                            .notifications
-                            .iter()
-                            .position(|n| n == name)
-                        {
-                            Some(i) => 1 << i,
-                            None => bail!(
-                                "could not find notification '{name}' \
-                                 (options are {:?})",
-                                task.notifications),
-                        },
-                    };
-
-                    task_irqs.push((notification, irq));
-                }
-
-                self.manifest.task_irqs.insert(name.clone(), task_irqs);
-            }
-
-            self.manifest
-                .task_notifications
-                .insert(name.clone(), task.notifications.clone());
-        }
-
-        if let Some(ref config) = config.config {
-            if let Some(i2c) = config.i2c.as_ref() {
-                self.load_i2c_config(i2c)?;
-            }
-            if let Some(sensor) = config.sensor.as_ref() {
-                self.load_sensor_config(sensor)?;
-            }
-            if let Some(net) = config.net.as_ref() {
-                self.manifest.sockets = net
-                    .sockets
-                    .iter()
-                    .map(|(name, cfg)| HubrisSocket {
-                        name: name.clone(),
-                        kind: cfg.kind.clone(),
-                        owner: cfg.owner.clone(),
-                        port: cfg.port,
-                        tx: cfg.tx,
-                        rx: cfg.rx,
-                    })
-                    .collect();
-            }
-        }
-
-        Ok(())
-    }
-
-    fn load_archive(&mut self, archive: &[u8]) -> Result<()> {
-        let hubris = RawHubrisArchive::from_vec(archive.to_vec())?;
-
+    pub fn load(
+        hubris: RawHubrisArchive,
+        task_dump: Option<DumpTask>,
+    ) -> Result<Self> {
         // Check the version early and bail if we don't match/can't read
         let archive_version = hubris.archive_version();
         if archive_version > MAX_HUBRIS_VERSION {
             bail!("\
-                        Hubris archive version is unsupported.\n\
-                        Humility supports v{} and earlier; archive is v{}.\n\
-                        Please update Humility.",
-                        MAX_HUBRIS_VERSION, archive_version)
+                Hubris archive version is unsupported.\n\
+                Humility supports v{} and earlier; archive is v{}.\n\
+                Please update Humility.",
+                MAX_HUBRIS_VERSION, archive_version
+            );
         }
 
-        //
         // First, we'll load aspects of configuration.
-        //
-        let manifest = &mut self.manifest;
+        let mut manifest_rev = HubrisManifestRev::default();
         if let Ok(git_rev) = hubris.extract_file("git-rev") {
-            manifest.gitrev = Some(std::str::from_utf8(&git_rev)?.to_string());
+            manifest_rev.gitrev =
+                Some(std::str::from_utf8(&git_rev)?.to_string());
         }
 
         if let Ok(image_name) = hubris.extract_file("image-name") {
-            manifest.image =
+            manifest_rev.image =
                 Some(std::str::from_utf8(&image_name)?.to_string());
         }
 
-        manifest.version =
+        manifest_rev.version =
             Some(format!("hubris build archive v{}", archive_version));
-        let app = hubris.extract_file("app.toml")?;
 
+        // Load the main manifest config file
+        let app = hubris.extract_file("app.toml")?;
         let mut config: HubrisConfig = toml::from_slice(app.as_bytes())?;
 
         // Apply TOML patches, if `patches.toml` is present in the archive.
@@ -1300,22 +1386,13 @@ impl HubrisArchive {
             }
         }
 
-        let config = config; // remove mutability
-
-        //
-        // Before we load our config, we need to find where our peripherals
-        // are located (if we have any).  If they are hanging off our config,
-        // use that -- but if we have a newer archive that contains a referred
-        // chip, pull in the TOML that it points to instead.
-        //
-        if let Some(ref peripherals) = config.peripherals {
-            self.load_config(&config, Some(peripherals))?;
-        } else if let Some(ref chip) = config.chip {
-            //
+        // Hot-patch the `peripherals` member of config
+        if config.peripherals.is_none()
+            && let Some(chip) = &config.chip
+        {
             // Paths are relative, so we always pull the basename -- and
             // paths within a ZIP archive always use the forward slash
             // as a separator.
-            //
             let path = match chip.rsplit('/').next() {
                 // Newer archive files may include the chip peripherals with
                 // the generic name "chip.toml" instead of something like
@@ -1327,37 +1404,32 @@ impl HubrisArchive {
                 None => chip,
             };
 
-            //
             // Ideally, we would hard-fail if we didn't find this file in
             // the archive -- but there was a small window of time in which
             // the chip TOML was not properly in the archive.  This is still
             // recoverable -- but anything that relies on the presence of
             // peripherals in the TOML will fail.
-            //
             if let Ok(chip) = hubris.extract_file(path) {
-                let peripherals: IndexMap<String, HubrisConfigPeripheral> =
-                    toml::from_slice(&chip)?;
-
-                self.load_config(&config, Some(&peripherals))?;
-            } else {
-                self.load_config(&config, None)?;
+                config.peripherals = toml::from_slice(&chip)?;
             }
-        } else {
-            self.load_config(&config, None)?;
         }
+
+        let config = config; // remove mutability
+
+        // Build the manifest, now that we've got a complete config
+        let manifest = HubrisManifest::from_config(&config, manifest_rev)?;
 
         //
         // Next up is the kernel.  Note that we refer to it explicitly with a
         // forward slash: regardless of platform, paths within a ZIP archive
         // use the forward slash as a separator.
         //
-        let mut loader = HubrisObjectLoader::new(self.current)?;
+        let mut loader = HubrisObjectLoader::new(0)?;
         loader.load_object(
             "kernel",
             HubrisTask::Kernel,
             &hubris.extract_file("elf/kernel")?,
         )?;
-        self.merge(loader)?;
 
         //
         // Find and unzip tasks in parallel.  Note that into_par_iter discards
@@ -1407,146 +1479,92 @@ impl HubrisArchive {
             .into_par_iter()
             .map(|(id, name, buf)| {
                 let id: u32 = id.try_into().unwrap();
-                let mut loader = HubrisObjectLoader::new(self.current + id)?;
+                let mut loader = HubrisObjectLoader::new(id + 1)?;
                 loader.load_object(&name, HubrisTask::Task(id), &buf)?;
                 Ok(loader)
             })
             .collect::<Result<Vec<_>>>()?;
 
-        for loader in files {
-            self.merge(loader)?;
+        let ntasks = files.len();
+        for f in files {
+            loader.merge(f)?;
         }
-        assert_eq!(self.current as usize, self.tasks.len());
 
         //
         // Now that we have loaded our tasks, load our extern regions.
         //
-        self.extern_regions = ExternRegions::load(self, &hubris, &config)?;
+        let extern_regions =
+            ExternRegions::load(&loader.tasks, &hubris, &config)?;
 
         //
         // Post-process our enums and structs to add their fully scoped names.
         //
         let mut work = BTreeSet::new();
 
-        for (name, enums) in self.enums_byname.iter_all() {
+        for (name, enums) in loader.enums_byname.iter_all() {
             for goff in enums.iter() {
-                let n = self.enums.get(goff).unwrap().namespace;
+                let n = loader.enums.get(goff).unwrap().namespace;
 
-                if let Some(full) = self.namespaces.to_full_name(n, name)? {
+                if let Some(full) = loader.namespaces.to_full_name(n, name)? {
                     work.insert((full, *goff));
                 }
             }
         }
 
         for (name, goff) in work.iter() {
-            self.enums_byname.insert(name.clone(), *goff);
+            loader.enums_byname.insert(name.clone(), *goff);
         }
 
         let mut work = BTreeSet::new();
 
-        for (name, structs) in self.structs_byname.iter_all() {
+        for (name, structs) in loader.structs_byname.iter_all() {
             for goff in structs.iter() {
-                let n = self.structs.get(goff).unwrap().namespace;
+                let n = loader.structs.get(goff).unwrap().namespace;
 
-                if let Some(full) = self.namespaces.to_full_name(n, name)? {
+                if let Some(full) = loader.namespaces.to_full_name(n, name)? {
                     work.insert((full, *goff));
                 }
             }
         }
 
         for (name, goff) in work.iter() {
-            self.structs_byname.insert(name.clone(), *goff);
+            loader.structs_byname.insert(name.clone(), *goff);
         }
 
-        self.hubris_archive = hubris;
-        Ok(())
-    }
-
-    fn merge(&mut self, loader: HubrisObjectLoader) -> Result<()> {
-        if loader.imageid.is_some() {
-            self.imageid = loader.imageid;
-        }
-        self.esyms_byname.extend(loader.esyms_byname);
-
-        self.esyms.extend(loader.esyms);
-        self.tasks.extend(loader.tasks);
-        self.modules.extend(loader.modules);
-        self.frames.extend(loader.frames);
-        self.loaded.extend(loader.loaded);
-        self.instrs.extend(loader.instrs);
-        self.syscall_pushes.extend(loader.syscall_pushes);
-        self.unions.extend(loader.unions);
-        self.src.extend(loader.src);
-        self.enums_byname.extend(loader.enums_byname);
-        self.structs_byname.extend(loader.structs_byname);
-        self.arrays.extend(loader.arrays);
-        self.basetypes.extend(loader.basetypes);
-        self.addr2line.extend(loader.addr2line);
-        self.basetypes_byname.extend(loader.basetypes_byname);
-        self.ptrtypes.extend(loader.ptrtypes);
-        self.inlined.extend(loader.inlined);
-        self.subprograms.extend(loader.subprograms);
-        self.dsyms.extend(loader.dsyms);
-        self.variables.extend(loader.variables);
-        self.qualified_variables.extend(loader.qualified_variables);
-        self.definitions.extend(loader.definitions);
-
-        // Namespaces need to be shifted when merging into the global namespaces
-        // vec.  This change applies to the `namespace` member in structs and
-        // enums, as well as the `namespaces` table itself.
-        let ns_offset = self.namespaces.0.len();
-
-        self.namespaces.0.extend(loader.namespaces.0.into_iter().map(
-            |mut v| {
-                if let Some(n) = &mut v.parent {
-                    n.0 += ns_offset;
-                }
-                v
-            },
-        ));
-        self.structs.extend(loader.structs.into_iter().map(|(goff, mut s)| {
-            if let Some(n) = &mut s.namespace {
-                n.0 += ns_offset;
-            }
-            (goff, s)
-        }));
-        self.enums.extend(loader.enums.into_iter().map(|(goff, mut s)| {
-            if let Some(n) = &mut s.namespace {
-                n.0 += ns_offset;
-            }
-            (goff, s)
-        }));
-
-        self.current += 1;
-        Ok(())
-    }
-
-    pub fn load(
-        &mut self,
-        archive: &str,
-        doneness: HubrisArchiveDoneness,
-    ) -> Result<()> {
-        let metadata = fs::metadata(archive)?;
-
-        if metadata.is_dir() {
-            bail!("a directory as an archive is deprecated; \
-                use archive instead");
-        }
-
-        //
-        // We read the entire archive into memory (and hold onto it) -- we
-        // are going to need most of it anyway, and we want to have
-        // the entire archive in memory to be able to write it out to
-        // any generated dump.
-        //
-        let contents = fs::read(archive)?;
-
-        if doneness == HubrisArchiveDoneness::Cook {
-            self.load_archive(&contents)?;
-        }
-
-        self.raw_bytes = contents;
-        Ok(())
+        Ok(Self {
+            hubris_archive: hubris,
+            imageid: loader.imageid,
+            manifest,
+            loaded: loader.loaded,
+            task_dump,
+            ntasks,
+            instrs: loader.instrs,
+            syscall_pushes: loader.syscall_pushes,
+            modules: loader.modules,
+            tasks: loader.tasks,
+            frames: loader.frames,
+            src: loader.src,
+            dsyms: loader.dsyms,
+            esyms: loader.esyms,
+            esyms_byname: loader.esyms_byname,
+            inlined: loader.inlined,
+            subprograms: loader.subprograms,
+            basetypes: loader.basetypes,
+            basetypes_byname: loader.basetypes_byname,
+            ptrtypes: loader.ptrtypes,
+            structs: loader.structs,
+            structs_byname: loader.structs_byname,
+            enums: loader.enums,
+            addr2line: loader.addr2line,
+            enums_byname: loader.enums_byname,
+            arrays: loader.arrays,
+            variables: loader.variables,
+            qualified_variables: loader.qualified_variables,
+            unions: loader.unions,
+            definitions: loader.definitions,
+            namespaces: loader.namespaces,
+            extern_regions,
+        })
     }
 
     pub fn load_flash_config(&self) -> Result<HubrisFlashConfig> {
@@ -1594,19 +1612,21 @@ impl HubrisArchive {
         self.hubris_archive.zip
     }
 
+    /// Helper function to load a dump into a [`RawHubrisArchive`]
+    ///
+    /// Returns a tuple of `(raw archive, dump task)`; the second field is
+    /// `Some(..)` if this is a single-task dump.
     pub fn load_dump(
-        &mut self,
         dumpfile: &str,
-        doneness: HubrisArchiveDoneness,
-    ) -> Result<()> {
-        //
+    ) -> Result<(RawHubrisArchive, Option<DumpTask>)> {
         // We expect the dump to be an ELF core dump.
-        //
         let contents = fs::read(dumpfile)?;
         let elf = Elf::parse(&contents).map_err(|e| {
             anyhow!("failed to parse {} as an ELF file: {}", dumpfile, e)
         })?;
 
+        let mut task_dump = None;
+        let mut archive = None;
         if let Some(notes) = elf.iter_note_headers(&contents) {
             for note in notes {
                 match note {
@@ -1617,20 +1637,24 @@ impl HubrisArchive {
 
                         match note.n_type {
                             OXIDE_NT_HUBRIS_ARCHIVE => {
-                                if doneness == HubrisArchiveDoneness::Cook {
-                                    self.load_archive(note.desc)?;
+                                if archive.is_some() {
+                                    bail!("multiple OXIDE_NT_HUBRIS_ARCHIVE found in dump");
                                 }
-
-                                self.raw_bytes = note.desc.to_vec();
+                                archive = Some(RawHubrisArchive::from_vec(
+                                    note.desc.to_vec(),
+                                )?);
                             }
                             OXIDE_NT_HUBRIS_TASK => {
                                 match DumpTask::read_from_prefix(note.desc) {
                                     Ok((task, _)) => {
-                                        self.task_dump = Some(task);
+                                        if task_dump.is_some() {
+                                            bail!("multiple OXIDE_NT_HUBRIS_TASK found in dump");
+                                        }
+                                        task_dump = Some(task);
                                     }
                                     Err(e) => {
                                         bail!(
-                                            "unrecognized task {:?} ({e})",
+                                            "could not read task {:?} ({e})",
                                              note.desc
                                         );
                                     }
@@ -1651,7 +1675,10 @@ impl HubrisArchive {
             }
         }
 
-        Ok(())
+        let Some(archive) = archive else {
+            bail!("could not find archive in dump");
+        };
+        Ok((archive, task_dump))
     }
 
     pub fn loaded(&self) -> bool {
@@ -1949,7 +1976,7 @@ impl HubrisArchive {
     }
 
     pub fn ntasks(&self) -> usize {
-        if self.current >= 1 { self.current as usize - 1 } else { 0 }
+        self.ntasks
     }
 
     /// If this is a dump from a single task, returns that task -- or None
@@ -2061,16 +2088,6 @@ impl HubrisArchive {
         criteria: HubrisValidate,
     ) -> Result<()> {
         let ntasks = self.ntasks();
-
-        if self.current == 0 {
-            //
-            // If we have no objects, we were never loaded -- and we consider
-            // this to be validated because it will give no answers rather
-            // than wrong ones.
-            //
-            return Ok(());
-        }
-
         if core.is_net() || core.is_archive() {
             return Ok(());
         }
@@ -3242,7 +3259,7 @@ impl HubrisArchive {
 
         notes.push(goblin::elf::note::Nhdr32 {
             n_namesz: (oxide.len() + 1) as u32,
-            n_descsz: self.raw_bytes.len() as u32,
+            n_descsz: self.hubris_archive.zip.len() as u32,
             n_type: OXIDE_NT_HUBRIS_ARCHIVE,
         });
 
@@ -3356,7 +3373,7 @@ impl HubrisArchive {
                 }
 
                 OXIDE_NT_HUBRIS_ARCHIVE => {
-                    file.write_all(&self.raw_bytes)?;
+                    file.write_all(&self.hubris_archive.zip)?;
                 }
 
                 OXIDE_NT_HUBRIS_TASK => {
@@ -3495,78 +3512,23 @@ impl HubrisArchive {
     }
 
     pub fn lookup_i2c_bus(&self, bus: &str) -> Result<&HubrisI2cBus> {
-        self.manifest
-            .i2c_buses
-            .iter()
-            .find(|&b| b.name == Some(bus.to_string()))
-            .ok_or_else(|| anyhow!("couldn't find bus {}", bus))
+        self.manifest.i2c_buses.lookup_i2c_bus(bus)
     }
 
-    ///
-    /// For a given controller and port name, return the matching port
-    /// (if any)
+    /// For a given controller and port name, return the matching port (if any)
     pub fn lookup_i2c_port(
         &self,
         controller: u8,
         port: &str,
     ) -> Result<&HubrisI2cPort> {
-        let mut found = false;
-
-        for bus in &self.manifest.i2c_buses {
-            if bus.controller != controller {
-                continue;
-            }
-
-            found = true;
-
-            if bus.port.name.eq_ignore_ascii_case(port) {
-                return Ok(&bus.port);
-            }
-        }
-
-        if !found {
-            bail!("unknown I2C controller {}", controller);
-        }
-
-        let ports = self
-            .manifest
-            .i2c_buses
-            .iter()
-            .filter(|bus| bus.controller == controller)
-            .map(|bus| bus.port.name.clone())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        bail!("invalid port \"{}\" (must be one of: {})", port, ports);
+        self.manifest.i2c_buses.lookup_i2c_port(controller, port)
     }
 
     ///
     /// For a given controller, return its port if there is only one, failing
     /// if there is more than one port.
     pub fn i2c_port(&self, controller: u8) -> Result<&HubrisI2cPort> {
-        let found = self
-            .manifest
-            .i2c_buses
-            .iter()
-            .filter(|bus| bus.controller == controller)
-            .collect::<Vec<_>>();
-
-        if found.is_empty() {
-            bail!("unknown I2C controller {}", controller);
-        } else if found.len() == 1 {
-            Ok(&found[0].port)
-        } else {
-            let ports = found
-                .iter()
-                .map(|bus| bus.port.name.clone())
-                .collect::<Vec<_>>()
-                .join(", ");
-
-            bail!(
-                "I2C{} has multiple ports; expected one of: {}",
-                controller, ports
-            )
-        }
+        self.manifest.i2c_buses.i2c_port(controller)
     }
 
     pub fn clock(
@@ -3603,10 +3565,6 @@ impl HubrisArchive {
 
     pub fn hubris_archive(&self) -> &RawHubrisArchive {
         &self.hubris_archive
-    }
-
-    pub fn raw_bytes(&self) -> &[u8] {
-        &self.raw_bytes
     }
 
     /// Reads the auxiliary flash data from a Hubris archive
@@ -3800,6 +3758,64 @@ impl HubrisObjectLoader {
             subprograms: HashMap::new(),
             syscall_pushes: HashMap::new(),
         })
+    }
+
+    fn merge(&mut self, loader: HubrisObjectLoader) -> Result<()> {
+        if loader.imageid.is_some() {
+            self.imageid = loader.imageid;
+        }
+        self.esyms_byname.extend(loader.esyms_byname);
+
+        self.esyms.extend(loader.esyms);
+        self.tasks.extend(loader.tasks);
+        self.modules.extend(loader.modules);
+        self.frames.extend(loader.frames);
+        self.loaded.extend(loader.loaded);
+        self.instrs.extend(loader.instrs);
+        self.syscall_pushes.extend(loader.syscall_pushes);
+        self.unions.extend(loader.unions);
+        self.src.extend(loader.src);
+        self.enums_byname.extend(loader.enums_byname);
+        self.structs_byname.extend(loader.structs_byname);
+        self.arrays.extend(loader.arrays);
+        self.basetypes.extend(loader.basetypes);
+        self.addr2line.extend(loader.addr2line);
+        self.basetypes_byname.extend(loader.basetypes_byname);
+        self.ptrtypes.extend(loader.ptrtypes);
+        self.inlined.extend(loader.inlined);
+        self.subprograms.extend(loader.subprograms);
+        self.dsyms.extend(loader.dsyms);
+        self.variables.extend(loader.variables);
+        self.qualified_variables.extend(loader.qualified_variables);
+        self.definitions.extend(loader.definitions);
+
+        // Namespaces need to be shifted when merging into the global namespaces
+        // vec.  This change applies to the `namespace` member in structs and
+        // enums, as well as the `namespaces` table itself.
+        let ns_offset = self.namespaces.0.len();
+
+        self.namespaces.0.extend(loader.namespaces.0.into_iter().map(
+            |mut v| {
+                if let Some(n) = &mut v.parent {
+                    n.0 += ns_offset;
+                }
+                v
+            },
+        ));
+        self.structs.extend(loader.structs.into_iter().map(|(goff, mut s)| {
+            if let Some(n) = &mut s.namespace {
+                n.0 += ns_offset;
+            }
+            (goff, s)
+        }));
+        self.enums.extend(loader.enums.into_iter().map(|(goff, mut s)| {
+            if let Some(n) = &mut s.namespace {
+                n.0 += ns_offset;
+            }
+            (goff, s)
+        }));
+
+        Ok(())
     }
 
     fn load_object(
@@ -6435,9 +6451,6 @@ pub enum HubrisValidate {
 //
 #[derive(Debug)]
 enum ExternRegions {
-    /// We have not yet loaded any external regions
-    Unloaded,
-
     /// We have the metadata to correlate addresses to regions
     ByAddress(HashMap<u32, String>),
 
@@ -6447,17 +6460,13 @@ enum ExternRegions {
 }
 
 impl ExternRegions {
-    fn new() -> Self {
-        ExternRegions::Unloaded
-    }
-
     ///
     /// Load external regions from the archive.  Based on the presence of
     /// archive metadata, this will construct the necessary structures to
     /// correlate address to external region.
     ///
     fn load(
-        hubris: &HubrisArchive,
+        tasks: &HashMap<String, HubrisTask>,
         archive: &RawHubrisArchive,
         config: &HubrisConfig,
     ) -> Result<Self> {
@@ -6504,7 +6513,7 @@ impl ExternRegions {
 
                 for (name, task) in &config.tasks {
                     if task.extern_regions.is_some() {
-                        set.insert(hubris.lookup_task(name).unwrap());
+                        set.insert(tasks.get(name).copied().unwrap());
                     }
                 }
 
@@ -6522,7 +6531,6 @@ impl ExternRegions {
         match self {
             ExternRegions::ByAddress(map) => map.contains_key(&address),
             ExternRegions::ByTask(set) => dma && set.contains(&task),
-            ExternRegions::Unloaded => panic!("no archive has been loaded"),
         }
     }
 


### PR DESCRIPTION
(staged on #656)

This PR is based on #633 (using `hubtools` for Hubris archive manipulation), with two changes:

- It's rebased to be in the big stack o' refactoring PRs
- It changes how archives are loaded

The idea behind the second change is simple.  In our existing code, we construct a default `HubrisArchive`, then incrementally populate it; if you are given a `HubrisArchive`, you do not know if it is valid or not.  This feels like a C-style "allocate then populate" workflow, but is not idiomatic in Rust.  This PR changes archive construction so that a `HubrisArchive` is valid by the time you get it.

To start, the only way to build a `HubrisArchive` is now from a `hubtools::RawHubrisArchive`.  During construction, functions which used to mutate a half-populated archive (taking `&mut self`) are now methods which return data.  Some functions are moved around: constructing the `HubrisManifest` is moved into methods on that type, instead of on the `HubrisArchive` itself.  Same for I2C: I introduced a new `HubrisManifestI2cConfig` and `HubrisI2cBusList` to contain I2C data and methods for building it.  There's a lot of code moving around, but not many logic changes.

Along the way, this eliminates the notion of "archive doneness": a `HubrisArchive` is fully populated, and if you don't like that, you can get the `RawHubrisArchive` instead.

(Apologies for the size of this PR; I tried to do minimal changes, but each fix required changing something else until I had done the full refactoring)