### PR TITLE
Generic cells in `doppel`

### DIFF
--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -184,9 +184,9 @@ fn read_qualified_state_buf(
         return Ok(None);
     };
 
-    let as_static_cell: doppel::ClaimOnceCell =
+    let as_static_cell: doppel::ClaimOnceCell<HostStateBuf> =
         reflect::read_variable(hubris, core, var)?;
-    Ok(Some(HostStateBuf::from_value(&as_static_cell.cell.value)?))
+    Ok(Some(as_static_cell.cell.value))
 }
 
 fn print_escaped_ascii(mut bytes: &[u8]) {

--- a/cmd/ringbuf/src/lib.rs
+++ b/cmd/ringbuf/src/lib.rs
@@ -145,9 +145,9 @@ fn ringbuf_dump(
             Ringbuf::from_value(&ringbuf_val).map(|r| (Some(r), None))
         })
         .or_else(|_e| {
-            let cell: StaticCell = StaticCell::from_value(&ringbuf_val)?;
-            let ringbuf = Ringbuf::from_value(&cell.cell.value)?;
-            Ok::<_, anyhow::Error>((Some(ringbuf), None))
+            let cell: StaticCell<Ringbuf> =
+                StaticCell::from_value(&ringbuf_val)?;
+            Ok::<_, anyhow::Error>((Some(cell.cell.value), None))
         })?;
 
     if let (Some(mut counters), false) = (counters, no_totals) {

--- a/humility-doppel/src/lib.rs
+++ b/humility-doppel/src/lib.rs
@@ -387,36 +387,23 @@ pub enum CounterVariant {
 }
 
 #[derive(Clone, Debug, Load)]
-pub struct ClaimOnceCell {
-    pub cell: UnsafeCell,
+pub struct ClaimOnceCell<T: Load> {
+    pub cell: UnsafeCell<T>,
 }
 
 #[derive(Clone, Debug, Load)]
-pub struct StaticCell {
-    pub cell: UnsafeCell,
+pub struct StaticCell<T: Load> {
+    pub cell: UnsafeCell<T>,
 }
 
 #[derive(Clone, Debug, Load)]
-pub struct UnsafeCell {
-    pub value: Value,
-}
-
-#[derive(Clone, Debug)]
-pub struct MaybeUninit<T> {
+pub struct UnsafeCell<T: Load> {
     pub value: T,
 }
 
-impl<T: humility::reflect::Load> humility::reflect::Load for MaybeUninit<T> {
-    fn from_value(v: &Value) -> Result<Self> {
-        let v_struct = v.as_struct()?;
-        anyhow::ensure!(
-            v_struct.name().starts_with("MaybeUninit"),
-            "expected MaybeUninit, got {:?}",
-            v_struct.name()
-        );
-        let value = v_struct.get("value")?;
-        T::from_value(value).map(|value| Self { value })
-    }
+#[derive(Clone, Debug, Load)]
+pub struct MaybeUninit<T: Load> {
+    pub value: T,
 }
 
 /// Double of the struct from `udprpc`
@@ -570,13 +557,9 @@ impl humility::reflect::Load for CounterVariant {
 
         let counter = value.as_struct()?;
         if counter.name().starts_with("AtomicU32") {
-            let cell = UnsafeCell::from_value(&counter["v"])?;
-            return cell
-                .value
-                .as_base()?
-                .as_u32()
-                .map(Self::Single)
-                .ok_or_else(|| anyhow::anyhow!("ringbuf count must be a u32"));
+            let cell = UnsafeCell::<u32>::from_value(&counter["v"])
+                .context("ringbuf count must be a u32")?;
+            return Ok(Self::Single(cell.value));
         }
 
         Ok(Self::Nested(Counters::from_value(value)?))

--- a/humility-doppel/src/lib.rs
+++ b/humility-doppel/src/lib.rs
@@ -387,21 +387,25 @@ pub enum CounterVariant {
 }
 
 #[derive(Clone, Debug, Load)]
+#[load(check_name)]
 pub struct ClaimOnceCell<T: Load> {
     pub cell: UnsafeCell<T>,
 }
 
 #[derive(Clone, Debug, Load)]
+#[load(check_name)]
 pub struct StaticCell<T: Load> {
     pub cell: UnsafeCell<T>,
 }
 
 #[derive(Clone, Debug, Load)]
+#[load(check_name)]
 pub struct UnsafeCell<T: Load> {
     pub value: T,
 }
 
 #[derive(Clone, Debug, Load)]
+#[load(check_name)]
 pub struct MaybeUninit<T: Load> {
     pub value: T,
 }

--- a/humility-spd/src/lib.rs
+++ b/humility-spd/src/lib.rs
@@ -5,7 +5,7 @@
 use humility::hubris::*;
 use humility::{
     reflect,
-    reflect::{Base, Load, Value},
+    reflect::{Base, Value},
 };
 use humility_doppel as doppel;
 
@@ -66,18 +66,11 @@ pub fn spd_lookup(
                 .collect(),
         ))
     } else if let Ok(var) = hubris.lookup_qualified_variable(PACKRAT_BUF_NAME) {
-        let var_ty = hubris.lookup_type(var.goff)?;
-        let mut buf: Vec<u8> = vec![0u8; var.size];
-
-        core.halt()?;
-        core.read_8(var.addr, &mut buf)?;
-        core.run()?;
-
-        let v = reflect::load_value(hubris, &buf, var_ty, 0)?;
-        let as_static_cell = doppel::ClaimOnceCell::from_value(&v)?;
-        let Value::Struct(packrat_bufs) = &as_static_cell.cell.value else {
-            bail!("expected {PACKRAT_BUF_NAME} to be a struct");
-        };
+        let packrat_bufs = reflect::read_variable::<
+            doppel::ClaimOnceCell<reflect::Struct>,
+        >(hubris, core, var)?
+        .cell
+        .value;
         let Ok(Value::Struct(compute_sled_bufs)) = packrat_bufs
             .get("gimlet_bufs")
             .or_else(|_e| packrat_bufs.get("cosmo_bufs"))

--- a/load_derive/src/lib.rs
+++ b/load_derive/src/lib.rs
@@ -31,56 +31,6 @@ pub fn load_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     proc_macro::TokenStream::from(ts)
 }
 
-/// Returns generics to go by the `impl` keyword (e.g. `<T: Load>`)
-fn impl_generics(g: &syn::Generics) -> Option<proc_macro2::TokenStream> {
-    if g.lt_token.is_some() {
-        let iter = g
-            .params
-            .iter()
-            .flat_map(|p| {
-                if let syn::GenericParam::Type(t) = p {
-                    let mut t = t.clone();
-                    t.attrs.clear();
-                    t.eq_token = None;
-                    t.default = None;
-                    Some(quote_spanned!(p.span()=>#t))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        Some(quote_spanned!(g.span()=><#(#iter),*>))
-    } else {
-        None
-    }
-}
-
-/// Returns generics to go by the `struct` keyword (e.g. `<T>`)
-fn struct_generics(g: &syn::Generics) -> Option<proc_macro2::TokenStream> {
-    if g.lt_token.is_some() {
-        let iter = g
-            .params
-            .iter()
-            .flat_map(|p| {
-                if let syn::GenericParam::Type(t) = p {
-                    let mut t = t.clone();
-                    t.attrs.clear();
-                    t.colon_token = None;
-                    t.bounds.clear();
-                    t.eq_token = None;
-                    t.default = None;
-                    Some(quote_spanned!(p.span()=>#t))
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>();
-        Some(quote_spanned!(g.span()=><#(#iter),*>))
-    } else {
-        None
-    }
-}
-
 fn gen_enum(
     ident: &syn::Ident,
     data: &syn::DataEnum,
@@ -195,10 +145,9 @@ fn gen_named_struct(
     });
     let field_defs = field_defs.collect::<proc_macro2::TokenStream>();
 
-    let impl_generics = impl_generics(generics);
-    let struct_generics = struct_generics(generics);
+    let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
     quote_spanned!(ident.span()=>
-        impl #impl_generics humility::reflect::Load for #ident #struct_generics {
+        impl #impl_generics humility::reflect::Load for #ident #ty_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_struct()?;
                 v.check_members(&[#field_name_strs])?;
@@ -231,10 +180,9 @@ fn gen_unnamed_struct(
     });
     let field_uses = field_uses.collect::<proc_macro2::TokenStream>();
 
-    let impl_generics = impl_generics(generics);
-    let struct_generics = struct_generics(generics);
+    let (impl_generics, ty_generics, _where_clause) = generics.split_for_impl();
     quote_spanned!(ident.span()=>
-        impl #impl_generics humility::reflect::Load for #ident #struct_generics {
+        impl #impl_generics humility::reflect::Load for #ident #ty_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_tuple()?;
                 if v.len() != #len {

--- a/load_derive/src/lib.rs
+++ b/load_derive/src/lib.rs
@@ -12,10 +12,10 @@ pub fn load_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let ts = match &input.data {
         syn::Data::Struct(data) => match &data.fields {
             syn::Fields::Named(fields) => {
-                gen_named_struct(&input.ident, fields)
+                gen_named_struct(&input.ident, &input.generics, fields)
             }
             syn::Fields::Unnamed(fields) => {
-                gen_unnamed_struct(&input.ident, fields)
+                gen_unnamed_struct(&input.ident, &input.generics, fields)
             }
             syn::Fields::Unit => {
                 unimplemented!(
@@ -29,6 +29,56 @@ pub fn load_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     };
 
     proc_macro::TokenStream::from(ts)
+}
+
+/// Returns generics to go by the `impl` keyword (e.g. `<T: Load>`)
+fn impl_generics(g: &syn::Generics) -> Option<proc_macro2::TokenStream> {
+    if g.lt_token.is_some() {
+        let iter = g
+            .params
+            .iter()
+            .flat_map(|p| {
+                if let syn::GenericParam::Type(t) = p {
+                    let mut t = t.clone();
+                    t.attrs.clear();
+                    t.eq_token = None;
+                    t.default = None;
+                    Some(quote_spanned!(p.span()=>#t))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        Some(quote_spanned!(g.span()=><#(#iter),*>))
+    } else {
+        None
+    }
+}
+
+/// Returns generics to go by the `struct` keyword (e.g. `<T>`)
+fn struct_generics(g: &syn::Generics) -> Option<proc_macro2::TokenStream> {
+    if g.lt_token.is_some() {
+        let iter = g
+            .params
+            .iter()
+            .flat_map(|p| {
+                if let syn::GenericParam::Type(t) = p {
+                    let mut t = t.clone();
+                    t.attrs.clear();
+                    t.colon_token = None;
+                    t.bounds.clear();
+                    t.eq_token = None;
+                    t.default = None;
+                    Some(quote_spanned!(p.span()=>#t))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        Some(quote_spanned!(g.span()=><#(#iter),*>))
+    } else {
+        None
+    }
 }
 
 fn gen_enum(
@@ -128,6 +178,7 @@ fn gen_enum(
 
 fn gen_named_struct(
     ident: &syn::Ident,
+    generics: &syn::Generics,
     fields: &syn::FieldsNamed,
 ) -> proc_macro2::TokenStream {
     let field_name_strs = fields.named.iter().map(|fld| {
@@ -144,8 +195,10 @@ fn gen_named_struct(
     });
     let field_defs = field_defs.collect::<proc_macro2::TokenStream>();
 
+    let impl_generics = impl_generics(generics);
+    let struct_generics = struct_generics(generics);
     quote_spanned!(ident.span()=>
-        impl humility::reflect::Load for #ident {
+        impl #impl_generics humility::reflect::Load for #ident #struct_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_struct()?;
                 v.check_members(&[#field_name_strs])?;
@@ -159,6 +212,7 @@ fn gen_named_struct(
 
 fn gen_unnamed_struct(
     ident: &syn::Ident,
+    generics: &syn::Generics,
     fields: &syn::FieldsUnnamed,
 ) -> proc_macro2::TokenStream {
     let len = fields.unnamed.len();
@@ -177,8 +231,10 @@ fn gen_unnamed_struct(
     });
     let field_uses = field_uses.collect::<proc_macro2::TokenStream>();
 
+    let impl_generics = impl_generics(generics);
+    let struct_generics = struct_generics(generics);
     quote_spanned!(ident.span()=>
-        impl humility::reflect::Load for #ident {
+        impl #impl_generics humility::reflect::Load for #ident #struct_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_tuple()?;
                 if v.len() != #len {

--- a/load_derive/src/lib.rs
+++ b/load_derive/src/lib.rs
@@ -5,18 +5,30 @@
 use quote::quote_spanned;
 use syn::spanned::Spanned;
 
-#[proc_macro_derive(Load)]
+#[proc_macro_derive(Load, attributes(load))]
 pub fn load_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
 
+    let name_check = if has_check_name(&input.attrs) {
+        Some(gen_name_check(&input.ident))
+    } else {
+        None
+    };
+
     let ts = match &input.data {
         syn::Data::Struct(data) => match &data.fields {
-            syn::Fields::Named(fields) => {
-                gen_named_struct(&input.ident, &input.generics, fields)
-            }
-            syn::Fields::Unnamed(fields) => {
-                gen_unnamed_struct(&input.ident, &input.generics, fields)
-            }
+            syn::Fields::Named(fields) => gen_named_struct(
+                &input.ident,
+                &input.generics,
+                fields,
+                name_check,
+            ),
+            syn::Fields::Unnamed(fields) => gen_unnamed_struct(
+                &input.ident,
+                &input.generics,
+                fields,
+                name_check,
+            ),
             syn::Fields::Unit => {
                 unimplemented!(
                     "unit struct not implemented as DWARF rep \
@@ -24,16 +36,52 @@ pub fn load_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
                 );
             }
         },
-        syn::Data::Enum(data) => gen_enum(&input.ident, data),
+        syn::Data::Enum(data) => gen_enum(&input.ident, data, name_check),
         _ => unimplemented!("unsupported type for derive"),
     };
 
     proc_macro::TokenStream::from(ts)
 }
 
+/// Returns true if the input has a `#[load(check_name)]` attribute.
+fn has_check_name(attrs: &[syn::Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        if !a.path().is_ident("load") {
+            return false;
+        }
+        let mut found = false;
+        let _ = a.parse_nested_meta(|meta| {
+            if meta.path.is_ident("check_name") {
+                found = true;
+            }
+            Ok(())
+        });
+        found
+    })
+}
+
+/// Generates a snippet that checks that the reflected container `v`'s name
+/// matches `ident` (modulo module path prefixes and generic parameters).
+fn gen_name_check(ident: &syn::Ident) -> proc_macro2::TokenStream {
+    quote_spanned!(ident.span()=>
+        {
+            let name: &str = v.name();
+            let stripped = name.split('<').next().unwrap_or(name);
+            let stripped = stripped.rsplit("::").next().unwrap_or(stripped);
+            if stripped != stringify!(#ident) {
+                anyhow::bail!(
+                    "expected reflected type name `{}`, got `{}`",
+                    stringify!(#ident), name,
+                );
+            }
+        }
+    )
+}
+
 fn gen_enum(
     ident: &syn::Ident,
     data: &syn::DataEnum,
+    name_check: Option<proc_macro2::TokenStream>,
 ) -> proc_macro2::TokenStream {
     let mut arms = vec![];
     for variant in &data.variants {
@@ -116,6 +164,7 @@ fn gen_enum(
         impl humility::reflect::Load for #ident {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_enum()?;
+                #name_check
                 match (v.disc(), v.contents()) {
                     #arms
                     _ => anyhow::bail!("unexpected shape for {}: {:?}",
@@ -130,6 +179,7 @@ fn gen_named_struct(
     ident: &syn::Ident,
     generics: &syn::Generics,
     fields: &syn::FieldsNamed,
+    name_check: Option<proc_macro2::TokenStream>,
 ) -> proc_macro2::TokenStream {
     let field_name_strs = fields.named.iter().map(|fld| {
         let name = fld.ident.as_ref().unwrap();
@@ -150,6 +200,7 @@ fn gen_named_struct(
         impl #impl_generics humility::reflect::Load for #ident #ty_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_struct()?;
+                #name_check
                 v.check_members(&[#field_name_strs])?;
                 Ok(Self {
                     #field_defs
@@ -163,6 +214,7 @@ fn gen_unnamed_struct(
     ident: &syn::Ident,
     generics: &syn::Generics,
     fields: &syn::FieldsUnnamed,
+    name_check: Option<proc_macro2::TokenStream>,
 ) -> proc_macro2::TokenStream {
     let len = fields.unnamed.len();
     let field_lets = fields.unnamed.iter().enumerate().map(|(i, fld)| {
@@ -185,6 +237,7 @@ fn gen_unnamed_struct(
         impl #impl_generics humility::reflect::Load for #ident #ty_generics {
             fn from_value(v: &humility::reflect::Value) -> anyhow::Result<Self> {
                 let v = v.as_tuple()?;
+                #name_check
                 if v.len() != #len {
                     anyhow::bail!("wrong tuple size for {}: {:?}",
                         stringify!(#ident), v);


### PR DESCRIPTION
(staged on #662)

This PR makes cell types in `doppel` generic, then uses that new functionality where relevant.

It requires editing the proc macro to support generic parameters, but then can remove the explicit `impl Load for MaybeUninit<T>` implementation.