### PR TITLE
Automatically `Load` the `hiffy_call` result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,7 +2738,6 @@ dependencies = [
  "humility-idol",
  "idol",
  "log",
- "parse_int",
  "postcard",
  "thiserror 2.0.18",
  "zerocopy",

--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -10,7 +10,7 @@ use std::os::unix::io::AsRawFd;
 use std::time::Duration;
 use std::{io, thread};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result};
 use clap::Parser;
 use crossbeam_channel::{Sender, select};
 use picocom_map::RemapRules;
@@ -48,7 +48,7 @@ impl<'a> UartConsoleHandler<'a> {
     fn uart_read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let op = self.hubris.get_idol_command("ControlPlaneAgent.uart_read")?;
 
-        let value = humility_hiffy::hiffy_call(
+        let v = humility_hiffy::hiffy_call::<u32>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -57,14 +57,6 @@ impl<'a> UartConsoleHandler<'a> {
             None,
             Some(buf),
         )?;
-
-        let v = match value {
-            Ok(v) => v,
-            Err(e) => bail!("Got Hiffy error: {e}"),
-        };
-
-        let v =
-            v.as_base()?.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))?;
 
         Ok(v as usize)
     }
@@ -75,7 +67,7 @@ impl<'a> UartConsoleHandler<'a> {
 
         let buf = &buf[..usize::min(buf.len(), HIFFY_BUF_SIZE)];
 
-        let value = humility_hiffy::hiffy_call(
+        let v = humility_hiffy::hiffy_call::<u32>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -84,14 +76,6 @@ impl<'a> UartConsoleHandler<'a> {
             Some(buf),
             None,
         )?;
-
-        let v = match value {
-            Ok(v) => v,
-            Err(e) => bail!("Got Hiffy error: {e}"),
-        };
-
-        let v =
-            v.as_base()?.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))?;
 
         Ok(v as usize)
     }
@@ -175,7 +159,7 @@ impl<'a> UartConsoleHandler<'a> {
             .hubris
             .get_idol_command("ControlPlaneAgent.set_humility_uart_client")?;
 
-        let value = humility_hiffy::hiffy_call(
+        humility_hiffy::hiffy_call::<()>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -184,11 +168,7 @@ impl<'a> UartConsoleHandler<'a> {
             None,
             None,
         )?;
-
-        match value {
-            Ok(_) => Ok(()),
-            Err(e) => bail!("Got Hiffy error: {e}"),
-        }
+        Ok(())
     }
 
     fn current_client(&mut self) -> Result<()> {
@@ -196,7 +176,7 @@ impl<'a> UartConsoleHandler<'a> {
             .hubris
             .get_idol_command("ControlPlaneAgent.get_uart_client")?;
 
-        let value = humility_hiffy::hiffy_call(
+        let value = humility_hiffy::hiffy_call::<humility::reflect::Enum>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -205,15 +185,6 @@ impl<'a> UartConsoleHandler<'a> {
             None,
             None,
         )?;
-
-        let value = match value {
-            Ok(v) => v,
-            Err(e) => bail!("Got Hiffy error: {e}"),
-        };
-
-        let value = value
-            .as_enum()
-            .context("get_uart_client did not return an enum")?;
 
         println!("Current console client: {}", value.disc());
         Ok(())

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -312,7 +312,7 @@ fn hiffy(context: &mut ExecutionContext) -> Result<()> {
             };
 
             (
-                hiffy_call(
+                match hiffy_call(
                     hubris,
                     core,
                     &mut context,
@@ -320,7 +320,11 @@ fn hiffy(context: &mut ExecutionContext) -> Result<()> {
                     &args,
                     input.as_deref(),
                     output.as_deref_mut(),
-                )?,
+                ) {
+                    Ok(s) => Ok(s),
+                    Err(HiffyCallError::Hiffy(s)) => Err(s),
+                    Err(HiffyCallError::Other(e)) => return Err(e),
+                },
                 output,
             )
         };

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -357,7 +357,7 @@ fn host_post_codes(
         std::time::Duration::from_millis(5000),
     )?;
     let op = hubris.get_idol_command("Sequencer.post_code_buffer_len")?;
-    let value = humility_hiffy::hiffy_call(
+    let count = humility_hiffy::hiffy_call::<u32>(
         hubris,
         core,
         &mut context,
@@ -366,12 +366,6 @@ fn host_post_codes(
         None,
         None,
     )?;
-    let Ok(reflect::Value::Base(reflect::Base::U32(count))) = value else {
-        bail!(
-            "Got bad value from post_code_buffer_len: \
-             expected U32, got {value:?}"
-        );
-    };
 
     let op = hubris.get_idol_command("Sequencer.get_post_code")?;
     let handle_value = |v| {
@@ -448,7 +442,7 @@ fn host_last_post_code(
         std::time::Duration::from_millis(5000),
     )?;
     let op = hubris.get_idol_command("Sequencer.last_post_code")?;
-    let value = humility_hiffy::hiffy_call(
+    let v = humility_hiffy::hiffy_call::<u32>(
         hubris,
         core,
         &mut context,
@@ -457,9 +451,6 @@ fn host_last_post_code(
         None,
         None,
     )?;
-    let Ok(reflect::Value::Base(reflect::Base::U32(v))) = value else {
-        bail!("Got bad value from last_post_code: expected U32, got {value:?}");
-    };
     if raw {
         println!("{v:08x}");
     } else {

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -309,7 +309,7 @@ fn monorail_read(
     humility::msg!("Reading {reg} from {addr:#x}");
 
     let op = hubris.get_idol_command("Monorail.read_vsc7448_reg")?;
-    let value = humility_hiffy::hiffy_call(
+    let value = humility_hiffy::hiffy_call::<u32>(
         hubris,
         core,
         context,
@@ -318,30 +318,16 @@ fn monorail_read(
         None,
         None,
     )?;
-    match value {
-        Ok(v) => {
-            let value = if let Value::Base(Base::U32(v)) = v {
-                v
-            } else {
-                bail!("Got bad reflected value: expected U32, got {v:?}");
-            };
-            println!("{reg} => {value:#x}");
+    println!("{reg} => {value:#x}");
 
-            // The VSC7448 is configured to return 0x88888888 if a register is
-            // read too fast.  This should never happen, because the `monorail`
-            // task configures appropriate padding bytes between setting the
-            // target register and reading it back.
-            if value == 0x88888888 {
-                log::warn!(
-                    "0x88888888 typically indicates a communication issue!"
-                );
-            }
-            pretty_print_fields(value, reg.fields(), 0);
-        }
-        Err(e) => {
-            println!("Got error: {e}");
-        }
+    // The VSC7448 is configured to return 0x88888888 if a register is
+    // read too fast.  This should never happen, because the `monorail`
+    // task configures appropriate padding bytes between setting the
+    // target register and reading it back.
+    if value == 0x88888888 {
+        log::warn!("0x88888888 typically indicates a communication issue!");
     }
+    pretty_print_fields(value, reg.fields(), 0);
     Ok(())
 }
 
@@ -358,7 +344,7 @@ fn monorail_write(
     pretty_print_fields(value, reg.fields(), 0);
 
     let op = hubris.get_idol_command("Monorail.write_vsc7448_reg")?;
-    let value = humility_hiffy::hiffy_call(
+    humility_hiffy::hiffy_call::<()>(
         hubris,
         core,
         context,
@@ -370,16 +356,6 @@ fn monorail_write(
         None,
         None,
     )?;
-    match value {
-        Ok(v) => {
-            if !matches!(v, Value::Base(Base::U0)) {
-                bail!("Got unexpected value: expected (), got {v:?}")
-            }
-        }
-        Err(e) => {
-            println!("Got error: {e}");
-        }
-    }
     Ok(())
 }
 
@@ -446,7 +422,7 @@ fn monorail_phy_read(
     let reg = parse_phy_register(&reg)?;
     println!("Reading from port {} PHY, register {}", port, reg.name);
     let op = hubris.get_idol_command("Monorail.read_phy_reg")?;
-    let value = humility_hiffy::hiffy_call(
+    let value = humility_hiffy::hiffy_call::<u16>(
         hubris,
         core,
         context,
@@ -459,19 +435,8 @@ fn monorail_phy_read(
         None,
         None,
     )?;
-    match value {
-        Ok(v) => {
-            let value = v
-                .as_base()?
-                .as_u16()
-                .ok_or_else(|| anyhow!("Could not get U16 from {:?}", v))?;
-            println!("Got result {:#x}", value);
-            pretty_print_fields(value as u32, &reg.fields, 0);
-        }
-        Err(e) => {
-            println!("Got error: {}", e);
-        }
-    }
+    println!("Got result {:#x}", value);
+    pretty_print_fields(value as u32, &reg.fields, 0);
     Ok(())
 }
 
@@ -490,7 +455,7 @@ fn monorail_phy_write(
     );
     pretty_print_fields(value as u32, &reg.fields, 0);
     let op = hubris.get_idol_command("Monorail.write_phy_reg")?;
-    let value = humility_hiffy::hiffy_call(
+    humility_hiffy::hiffy_call::<()>(
         hubris,
         core,
         context,
@@ -504,16 +469,6 @@ fn monorail_phy_write(
         None,
         None,
     )?;
-    match value {
-        Ok(v) => {
-            if !matches!(v, Value::Base(Base::U0)) {
-                bail!("Got unexpected value: expected (), got {v:?}")
-            }
-        }
-        Err(e) => {
-            println!("Got error: {e}");
-        }
-    }
     Ok(())
 }
 
@@ -724,11 +679,19 @@ fn monorail_status(
 
         let port_results = port_results
             .into_iter()
-            .map(move |r| humility_hiffy::hiffy_decode(hubris, &op_port, r))
+            .map(move |r| {
+                humility_hiffy::hiffy_decode::<humility::reflect::Struct>(
+                    hubris, &op_port, r,
+                )
+            })
             .collect::<Result<Vec<Result<_, _>>>>()?;
         let phy_results = phy_results
             .into_iter()
-            .map(move |r| humility_hiffy::hiffy_decode(hubris, &op_phy, r))
+            .map(move |r| {
+                humility_hiffy::hiffy_decode::<humility::reflect::Struct>(
+                    hubris, &op_phy, r,
+                )
+            })
             .collect::<Result<Vec<Result<_, _>>>>()?;
 
         // Decode the port and phy status values into reflect::Value
@@ -794,8 +757,7 @@ fn monorail_status(
         }
         print!(" {:<3} | ", port);
         match port_value {
-            Ok(v) => {
-                let s = v.as_struct()?;
+            Ok(s) => {
                 assert_eq!(s.name(), "PortStatus");
                 let (dev, serdes, mode, speed) = match &s["cfg"] {
                     Value::Struct(cfg) => {
@@ -841,8 +803,7 @@ fn monorail_status(
         }
         print!(" | ");
         match phy_value {
-            Ok(v) => {
-                let s = v.as_struct()?;
+            Ok(s) => {
                 assert_eq!(s.name(), "PhyStatus");
                 let phy_ty = match &s["ty"] {
                     Value::Enum(e) => e.disc().to_uppercase(),
@@ -878,7 +839,7 @@ fn monorail_mac_table(
     // We need to make two HIF calls:
     // - Read the number of entries in the MAC table
     // - Loop over the table that many times, reading entries
-    let value = humility_hiffy::hiffy_call(
+    let mac_count = humility_hiffy::hiffy_call::<u32>(
         hubris,
         core,
         context,
@@ -887,18 +848,6 @@ fn monorail_mac_table(
         None,
         None,
     )?;
-    let mac_count = match value {
-        Ok(v) => {
-            if let Value::Base(Base::U32(v)) = v {
-                v
-            } else {
-                bail!("Got bad reflected value: expected U32, got {:?}", v);
-            }
-        }
-        Err(e) => {
-            bail!("Got error: {e}");
-        }
-    };
 
     println!("Reading {mac_count} MAC addresses...");
 
@@ -931,13 +880,16 @@ fn monorail_mac_table(
     let results = context.run(core, ops.as_slice(), None)?;
     let results = results
         .into_iter()
-        .map(move |r| humility_hiffy::hiffy_decode(hubris, &op, r))
+        .map(move |r| {
+            humility_hiffy::hiffy_decode::<humility::reflect::Struct>(
+                hubris, &op, r,
+            )
+        })
         .collect::<Result<Vec<Result<_, _>>>>()?;
 
     let mut mac_table: BTreeMap<u16, Vec<[u8; 6]>> = BTreeMap::new();
     for r in results {
-        if let Ok(r) = r {
-            let s = r.as_struct()?;
+        if let Ok(s) = r {
             assert_eq!(s.name(), "MacTableEntry");
             let port = s.field::<u16>("port").unwrap();
             let mac = s.field::<[u8; 6]>("mac").unwrap();
@@ -980,7 +932,7 @@ fn monorail_reset_counters(
     port: u8,
 ) -> Result<()> {
     let op = hubris.get_idol_command("Monorail.reset_port_counters")?;
-    let value = humility_hiffy::hiffy_call(
+    humility_hiffy::hiffy_call::<()>(
         hubris,
         core,
         context,
@@ -989,7 +941,7 @@ fn monorail_reset_counters(
         None,
         None,
     )?;
-    value.map(|_| ()).map_err(|err| anyhow!("Got error {err}"))
+    Ok(())
 }
 
 fn monorail_counters(
@@ -999,7 +951,7 @@ fn monorail_counters(
     port: u8,
 ) -> Result<()> {
     let op = hubris.get_idol_command("Monorail.get_port_counters")?;
-    let value = humility_hiffy::hiffy_call(
+    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
         hubris,
         core,
         context,
@@ -1008,44 +960,24 @@ fn monorail_counters(
         None,
         None,
     )?;
-    let decode_count = |s: &Value| match s {
-        Value::Struct(s) => {
-            let mc = match &s["multicast"] {
-                Value::Base(Base::U32(v)) => *v,
-                v => panic!("Expected U32, got {:?}", v),
-            };
-            let uc = match &s["unicast"] {
-                Value::Base(Base::U32(v)) => *v,
-                v => panic!("Expected U32, got {:?}", v),
-            };
-            let bc = match &s["broadcast"] {
-                Value::Base(Base::U32(v)) => *v,
-                v => panic!("Expected U32, got {:?}", v),
-            };
-            (mc, uc, bc)
-        }
-        s => panic!("Expected Struct, got {:?}", s),
+    let decode_count = |s: &humility::reflect::Value| -> (u32, u32, u32) {
+        let mc = s.field("multicast").unwrap();
+        let uc = s.field("unicast").unwrap();
+        let bc = s.field("broadcast").unwrap();
+        (mc, uc, bc)
     };
 
-    match value {
-        Ok(v) => {
-            let s = v.as_struct()?;
-            let (rx_mc, rx_uc, rx_bc) = decode_count(&s["rx"]);
-            let (tx_mc, tx_uc, tx_bc) = decode_count(&s["tx"]);
-            println!("{} (port {port})", "Packet counters:".bold());
-            println!("  Receive:");
-            println!("    Unicast:   {rx_uc}");
-            println!("    Multicast: {rx_mc}");
-            println!("    Broadcast:  {rx_bc}");
-            println!("  Transmit:");
-            println!("    Unicast:   {tx_uc}");
-            println!("    Multicast: {tx_mc}");
-            println!("    Broadcast:  {tx_bc}");
-        }
-        Err(e) => {
-            println!("Got error: {e}");
-        }
-    }
+    let (rx_mc, rx_uc, rx_bc) = decode_count(&s["rx"]);
+    let (tx_mc, tx_uc, tx_bc) = decode_count(&s["tx"]);
+    println!("{} (port {port})", "Packet counters:".bold());
+    println!("  Receive:");
+    println!("    Unicast:   {rx_uc}");
+    println!("    Multicast: {rx_mc}");
+    println!("    Broadcast:  {rx_bc}");
+    println!("  Transmit:");
+    println!("    Unicast:   {tx_uc}");
+    println!("    Multicast: {tx_mc}");
+    println!("    Broadcast:  {tx_bc}");
     Ok(())
 }
 

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -39,7 +39,7 @@
 //! VSC8552; this is indicated with `--` in the relevant table positions.
 use std::collections::BTreeMap;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use colored::Colorize;
 
@@ -96,7 +96,7 @@ fn net_ip(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.get_mac_address")?;
 
-    let value = humility_hiffy::hiffy_call(
+    let v = humility_hiffy::hiffy_call::<humility::reflect::Tuple>(
         hubris,
         core,
         &mut hiffy_context,
@@ -105,11 +105,6 @@ fn net_ip(
         None,
         None,
     )?;
-    let v = match value {
-        Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {e}"),
-    };
-    let v = v.as_tuple()?;
     assert_eq!(v.name(), "MacAddress");
     let mac = v.field::<[u8; 6]>(0)?;
     print!("{}:  ", "MAC address".bold());
@@ -152,7 +147,7 @@ fn net_mac_table(
     // We need to make two HIF calls:
     // - Read the number of entries in the MAC table
     // - Loop over the table that many times, reading entries
-    let value = humility_hiffy::hiffy_call(
+    let mac_count = humility_hiffy::hiffy_call::<u32>(
         hubris,
         core,
         &mut hiffy_context,
@@ -161,18 +156,6 @@ fn net_mac_table(
         None,
         None,
     )?;
-    let mac_count = match value {
-        Ok(v) => {
-            if let Value::Base(Base::U32(v)) = v {
-                v
-            } else {
-                bail!("Got bad reflected value: expected U32, got {v:?}");
-            }
-        }
-        Err(e) => {
-            bail!("Got error: {e}");
-        }
-    };
 
     // Due to HIF limitations (lack of Expand16 / Collect16), we're going to
     // limit ourselves to 255 MAC table entries.
@@ -216,13 +199,16 @@ fn net_mac_table(
     let results = hiffy_context.run(core, ops.as_slice(), None)?;
     let results = results
         .into_iter()
-        .map(move |r| humility_hiffy::hiffy_decode(hubris, &op, r))
+        .map(move |r| {
+            humility_hiffy::hiffy_decode::<humility::reflect::Struct>(
+                hubris, &op, r,
+            )
+        })
         .collect::<Result<Vec<Result<_, _>>>>()?;
 
     let mut mac_table: BTreeMap<u16, Vec<[u8; 6]>> = BTreeMap::new();
     for r in results {
-        if let Ok(r) = r {
-            let s = r.as_struct()?;
+        if let Ok(s) = r {
             assert_eq!(s.name(), "KszMacTableEntry");
             let port = s.field::<u16>("port")?;
             let mac = s.field::<[u8; 6]>("mac")?;
@@ -268,7 +254,7 @@ fn net_status(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.management_link_status")?;
 
-    let value = humility_hiffy::hiffy_call(
+    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
         hubris,
         core,
         &mut hiffy_context,
@@ -277,11 +263,6 @@ fn net_status(
         None,
         None,
     )?;
-    let v = match value {
-        Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {e}"),
-    };
-    let s = v.as_struct()?;
     assert_eq!(s.name(), "ManagementLinkStatus");
 
     let ksz_100base_fx: Vec<bool> = s.field("ksz8463_100base_fx_link_up")?;
@@ -337,7 +318,7 @@ fn net_counters(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.management_counters")?;
 
-    let value = humility_hiffy::hiffy_call(
+    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
         hubris,
         core,
         &mut hiffy_context,
@@ -346,23 +327,18 @@ fn net_counters(
         None,
         None,
     )?;
-    let v = match value {
-        Ok(v) => v,
-        Err(e) => bail!("Got Hiffy error: {e}"),
-    };
-    let s = v.as_struct()?;
     assert_eq!(s.name(), "ManagementCounters");
 
     if !table && !diagram {
-        net_counters_table(s)?;
+        net_counters_table(&s)?;
         println!();
-        net_counters_diagram(s)?;
+        net_counters_diagram(&s)?;
     } else {
         if table {
-            net_counters_table(s)?;
+            net_counters_table(&s)?;
         }
         if diagram {
-            net_counters_diagram(s)?;
+            net_counters_diagram(&s)?;
         }
     }
     Ok(())

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -494,7 +494,7 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
         s @ (Some(0) | Some(1)) => {
             let s = s.unwrap();
             humility::msg!("Setting slot to {s}");
-            let out = hiffy_call(
+            hiffy_call::<()>(
                 hubris,
                 core,
                 &mut context,
@@ -503,9 +503,6 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
                 None,
                 None,
             )?;
-            if let Err(e) = out {
-                bail!("set_dev failed: {e}");
-            }
         }
         _ => bail!("Bad slot setting"),
     }
@@ -1028,7 +1025,7 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
             1 => "Flash1",
             _ => bail!("dev_select must be 0 or 1"),
         };
-        let out = hiffy_call(
+        hiffy_call::<()>(
             hubris,
             core,
             &mut context,
@@ -1037,11 +1034,7 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
             None,
             None,
         )?;
-        if let Err(e) = out {
-            bail!("write_persistent_data failed: {e}");
-        } else {
-            humility::msg!("write_persistent_data succeeded");
-        }
+        humility::msg!("write_persistent_data succeeded");
         return Ok(());
     } else {
         bail!("expected an operation");

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1126,7 +1126,7 @@ fn rendmp_blackbox(
 ) -> Result<()> {
     let (addr, _dev) = check_addr(&subargs, hubris)?;
     let op = hubris.get_idol_command("Power.rendmp_blackbox_dump")?;
-    let value = hiffy_call(
+    let e = hiffy_call::<humility::reflect::Enum>(
         hubris,
         core,
         context,
@@ -1135,47 +1135,39 @@ fn rendmp_blackbox(
         None,
         None,
     )?;
-    match value {
-        Ok(Value::Enum(e)) => {
-            let contents = e
-                .contents()
-                .ok_or_else(|| anyhow!("missing contents in blackbox enum"))?;
-            let Value::Tuple(c) = contents else {
-                bail!("missing tuple in blackbox enum");
-            };
-            let Value::Array(a) = &c[0] else {
-                bail!("missing array in blackbox enum");
-            };
-            let mut data = vec![];
-            for word in a.iter() {
-                let Value::Base(Base::U32(b)) = word else {
-                    bail!("unexpected type in array: {word:?}");
-                };
-                data.extend(b.as_bytes());
-            }
-            match e.disc() {
-                "Gen2p5" => println!(
-                    "{}",
-                    blackbox::BlackboxRamGen2p5::read_from_bytes(
-                        data.as_slice()
-                    )
-                    .map_err(|e| anyhow!(
-                        "could not load blackbox from bytes: {e}"
-                    ))?,
-                ),
-                "Gen2" => println!(
-                    "{}",
-                    blackbox::BlackboxRamGen2::read_from_bytes(data.as_slice())
-                        .map_err(|e| anyhow!(
-                            "could not load blackbox from bytes: {e}"
-                        ))?,
-                ),
-                v => bail!("unknown blackbox gen: {v:?}"),
-            };
-        }
-        Ok(other) => bail!("unexpected value: {other:?}"),
-        Err(e) => bail!("got error: {e:?}"),
+    let contents = e
+        .contents()
+        .ok_or_else(|| anyhow!("missing contents in blackbox enum"))?;
+    let Value::Tuple(c) = contents else {
+        bail!("missing tuple in blackbox enum");
+    };
+    let Value::Array(a) = &c[0] else {
+        bail!("missing array in blackbox enum");
+    };
+    let mut data = vec![];
+    for word in a.iter() {
+        let Value::Base(Base::U32(b)) = word else {
+            bail!("unexpected type in array: {word:?}");
+        };
+        data.extend(b.as_bytes());
     }
+    match e.disc() {
+        "Gen2p5" => println!(
+            "{}",
+            blackbox::BlackboxRamGen2p5::read_from_bytes(data.as_slice())
+                .map_err(|e| anyhow!(
+                    "could not load blackbox from bytes: {e}"
+                ))?,
+        ),
+        "Gen2" => println!(
+            "{}",
+            blackbox::BlackboxRamGen2::read_from_bytes(data.as_slice())
+                .map_err(|e| anyhow!(
+                    "could not load blackbox from bytes: {e}"
+                ))?,
+        ),
+        v => bail!("unknown blackbox gen: {v:?}"),
+    };
 
     Ok(())
 }
@@ -1625,41 +1617,36 @@ impl<'a, 'b> HifWorker<'a, 'b> {
                 Call::WriteByte => &self.write_byte,
                 Call::WriteWord32 => &self.write_word32,
             };
-            let v = hiffy_decode(self.hubris, op, value)
+            let v = hiffy_decode::<Base>(self.hubris, op, value)
                 .with_context(|| format!("failed to decode {call:?} result"))?;
             match v {
-                Ok(v) => {
-                    let v = v.as_base().context("expected Base, got {v:?}")?;
-                    match (v, call) {
-                        (Base::U32(v), Call::ReadDma(..)) => {
-                            out.push(Ok(Call::ReadDma(*v)))
-                        }
-                        (Base::U8(v), Call::ReadByte(..)) => {
-                            out.push(Ok(Call::ReadByte(*v)))
-                        }
-                        (Base::U16(v), Call::ReadWord(..)) => {
-                            out.push(Ok(Call::ReadWord(*v)))
-                        }
-                        (Base::U32(v), Call::ReadWord32(..)) => {
-                            out.push(Ok(Call::ReadWord32(*v)))
-                        }
-                        (Base::U0, Call::WriteDma) => {
-                            out.push(Ok(Call::WriteDma))
-                        }
-                        (Base::U0, Call::WriteWord) => {
-                            out.push(Ok(Call::WriteWord))
-                        }
-                        (Base::U0, Call::WriteByte) => {
-                            out.push(Ok(Call::WriteByte))
-                        }
-                        (Base::U0, Call::WriteWord32) => {
-                            out.push(Ok(Call::WriteWord32))
-                        }
-                        (base, op) => {
-                            bail!("got unexpected result {base} for {op:?}")
-                        }
+                Ok(v) => match (v, call) {
+                    (Base::U32(v), Call::ReadDma(..)) => {
+                        out.push(Ok(Call::ReadDma(v)))
                     }
-                }
+                    (Base::U8(v), Call::ReadByte(..)) => {
+                        out.push(Ok(Call::ReadByte(v)))
+                    }
+                    (Base::U16(v), Call::ReadWord(..)) => {
+                        out.push(Ok(Call::ReadWord(v)))
+                    }
+                    (Base::U32(v), Call::ReadWord32(..)) => {
+                        out.push(Ok(Call::ReadWord32(v)))
+                    }
+                    (Base::U0, Call::WriteDma) => out.push(Ok(Call::WriteDma)),
+                    (Base::U0, Call::WriteWord) => {
+                        out.push(Ok(Call::WriteWord))
+                    }
+                    (Base::U0, Call::WriteByte) => {
+                        out.push(Ok(Call::WriteByte))
+                    }
+                    (Base::U0, Call::WriteWord32) => {
+                        out.push(Ok(Call::WriteWord32))
+                    }
+                    (base, op) => {
+                        bail!("got unexpected result {base} for {op:?}")
+                    }
+                },
                 Err(e) => out.push(Err(e)),
             }
         }
@@ -1679,12 +1666,15 @@ fn rendmp_phase_check<'a>(
         .get_idol_command("Sequencer.tofino_seq_state")
         .or_else(|_| hubris.get_idol_command("Sequencer.get_state"))
         .context("could not get power state HIF operation")?;
-    let r =
-        hiffy_call(hubris, core, context, &power_state_op, &[], None, None)?;
-    if let Err(e) = r {
-        bail!("power state check got an error: {e}");
-    }
-    if hiffy_format_result(hubris, r) != "A2" {
+    let r = hiffy_call(hubris, core, context, &power_state_op, &[], None, None);
+    let v = match r {
+        Ok(r) => Ok(r),
+        Err(HiffyCallError::Hiffy(s)) => Err(s),
+        Err(HiffyCallError::Other(e)) => {
+            return Err(e.context("power state check"));
+        }
+    };
+    if hiffy_format_result(hubris, v) != "A2" {
         bail!("must be in A2 when checking phases");
     }
 

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -86,7 +86,7 @@ impl<'a> EepromHandler<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            let value = humility_hiffy::hiffy_call(
+            humility_hiffy::hiffy_call::<()>(
                 self.hubris,
                 self.core,
                 &mut self.context,
@@ -95,9 +95,6 @@ impl<'a> EepromHandler<'a> {
                 None,
                 Some(chunk),
             )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
             bar.set_position(offset as u64);
         }
         bar.finish_and_clear();
@@ -124,7 +121,7 @@ impl<'a> EepromHandler<'a> {
         bar.set_length(data.len() as u64);
         for (i, chunk) in data.chunks(WRITE_CHUNK_SIZE).enumerate() {
             let offset = i * WRITE_CHUNK_SIZE;
-            let value = humility_hiffy::hiffy_call(
+            humility_hiffy::hiffy_call::<()>(
                 self.hubris,
                 self.core,
                 &mut self.context,
@@ -133,9 +130,6 @@ impl<'a> EepromHandler<'a> {
                 Some(chunk),
                 None,
             )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
             bar.set_position(offset as u64);
         }
         bar.set_position(data.len() as u64);

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -6,7 +6,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 
 use humility::core::Core;
 use humility::hubris::*;
-use humility_hiffy::HiffyContext;
+use humility_hiffy::{HiffyCallError, HiffyContext};
 use humility_idol::{HubrisIdol, IdolArgument};
 use std::time::Duration;
 
@@ -44,7 +44,7 @@ impl<'a> AuxFlashHandler<'a> {
     /// Returns the number of auxflash slots
     pub fn slot_count(&mut self) -> Result<u32> {
         let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
-        let value = humility_hiffy::hiffy_call(
+        let value = humility_hiffy::hiffy_call::<u32>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -53,12 +53,7 @@ impl<'a> AuxFlashHandler<'a> {
             None,
             None,
         )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        };
-        let v = v.as_base()?;
-        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32"))
+        Ok(value)
     }
 
     /// Returns the active slot, or `None` if there is no active slot
@@ -66,7 +61,7 @@ impl<'a> AuxFlashHandler<'a> {
         let op = self
             .hubris
             .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-        let value = humility_hiffy::hiffy_call(
+        let value = humility_hiffy::hiffy_call::<u32>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -74,22 +69,18 @@ impl<'a> AuxFlashHandler<'a> {
             &[],
             None,
             None,
-        )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) if e == "NoActiveSlot" => {
-                return Ok(None);
-            }
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        };
-        let v = v.as_base()?;
-        v.as_u32().ok_or_else(|| anyhow!("Couldn't get U32")).map(Some)
+        );
+        match value {
+            Ok(v) => Ok(Some(v)),
+            Err(HiffyCallError::Hiffy(s)) if s == "NoActiveSlot" => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Erases a single auxflash slot
     pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
         let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
-        let value = humility_hiffy::hiffy_call(
+        humility_hiffy::hiffy_call::<()>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -98,10 +89,7 @@ impl<'a> AuxFlashHandler<'a> {
             None,
             None,
         )?;
-        match value {
-            Ok(..) => Ok(()),
-            Err(e) => bail!("Got Hiffy error: {}", e),
-        }
+        Ok(())
     }
 
     /// Returns the checksum of an auxflash slot
@@ -110,7 +98,7 @@ impl<'a> AuxFlashHandler<'a> {
     /// erased).
     pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
         let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-        let value = humility_hiffy::hiffy_call(
+        let value = humility_hiffy::hiffy_call::<([u8; 32],)>(
             self.hubris,
             self.core,
             &mut self.context,
@@ -118,23 +106,12 @@ impl<'a> AuxFlashHandler<'a> {
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
             None,
-        )?;
-        let v = match value {
-            Ok(v) => v,
-            Err(e) if e == "MissingChck" => return Ok(None),
-            Err(e) => bail!("{}", e),
-        };
-        let array = v.as_1tuple().unwrap().as_array().unwrap();
-        assert_eq!(array.len(), 32);
-        let mut out = [0u8; 32];
-        for (o, v) in out
-            .iter_mut()
-            .zip(array.iter().map(|i| i.as_base().unwrap().as_u8().unwrap()))
-        {
-            *o = v;
+        );
+        match value {
+            Ok(v) => Ok(Some(v.0)),
+            Err(HiffyCallError::Hiffy(e)) if e == "MissingChck" => Ok(None),
+            Err(e) => Err(e.into()),
         }
-
-        Ok(Some(out))
     }
 
     /// Reads some number of bytes from a particular slot
@@ -159,7 +136,7 @@ impl<'a> AuxFlashHandler<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            let value = humility_hiffy::hiffy_call(
+            humility_hiffy::hiffy_call::<()>(
                 self.hubris,
                 self.core,
                 &mut self.context,
@@ -171,9 +148,6 @@ impl<'a> AuxFlashHandler<'a> {
                 None,
                 Some(chunk),
             )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
             bar.set_position(offset as u64);
         }
         bar.set_position(out.len() as u64);
@@ -261,7 +235,7 @@ impl<'a> AuxFlashHandler<'a> {
         bar.set_length(data.len() as u64);
         for (i, chunk) in data.chunks(data_size).enumerate() {
             let offset = i * data_size;
-            let value = humility_hiffy::hiffy_call(
+            humility_hiffy::hiffy_call::<()>(
                 self.hubris,
                 self.core,
                 &mut self.context,
@@ -273,9 +247,6 @@ impl<'a> AuxFlashHandler<'a> {
                 Some(chunk),
                 None,
             )?;
-            if let Err(e) = value {
-                bail!("Got Hubris error: {:?}", e);
-            }
             bar.set_position(offset as u64);
         }
         bar.set_position(data.len() as u64);

--- a/humility-core/src/reflect.rs
+++ b/humility-core/src/reflect.rs
@@ -1077,6 +1077,16 @@ impl Load for Tuple {
     }
 }
 
+impl Load for Array {
+    fn from_value(v: &Value) -> Result<Self> {
+        if let Value::Array(v) = v {
+            Ok(v.clone())
+        } else {
+            bail!("expected array, got {v:?}");
+        }
+    }
+}
+
 impl Load for Base {
     fn from_value(v: &Value) -> Result<Self> {
         if let Value::Base(v) = v {
@@ -1128,16 +1138,6 @@ impl Load for () {
         match v.as_base()? {
             Base::U0 => Ok(()),
             b => bail!("expected U0, got base {b:?}"),
-        }
-    }
-}
-
-impl Load for Array {
-    fn from_value(v: &Value) -> Result<Self> {
-        if let Value::Array(v) = v {
-            Ok(v.clone())
-        } else {
-            bail!("expected array, got {v:?}");
         }
     }
 }

--- a/humility-hiffy/Cargo.toml
+++ b/humility-hiffy/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 anyhow.workspace = true
 hif.workspace = true
 idol.workspace = true
-parse_int.workspace = true
 postcard.workspace = true
 thiserror.workspace = true
 zerocopy.workspace = true

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1437,11 +1437,19 @@ fn has_task_started(
     }
 }
 
-/// Executes a Hiffy call, printing the output to the terminal
-///
-/// Returns an outer error if Hiffy communication fails, or an inner error
-/// if the Hiffy call returns an error code (formatted as a String).
-pub fn hiffy_call(
+/// Error returned from [`hiffy_call`]
+#[derive(thiserror::Error, Debug)]
+pub enum HiffyCallError {
+    /// A function called in the HIF program returned an error
+    #[error("hiffy error: {0}")]
+    Hiffy(String),
+    /// There was an error invoking the HIF program
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+/// Executes a Hiffy call, returning the output value (or an error)
+pub fn hiffy_call<T: humility::reflect::Load>(
     hubris: &HubrisArchive,
     core: &mut dyn Core,
     context: &mut HiffyContext,
@@ -1449,7 +1457,7 @@ pub fn hiffy_call(
     args: &[(&str, idol::IdolArgument)],
     lease_write: Option<&[u8]>,
     lease_read: Option<&mut [u8]>,
-) -> Result<std::result::Result<humility::reflect::Value, String>> {
+) -> Result<T, HiffyCallError> {
     check_op(op)?;
     check_leases(op, lease_write, lease_read.as_deref())?;
 
@@ -1487,7 +1495,10 @@ pub fn hiffy_call(
     let mut results = context.run(core, ops.as_slice(), lease_write)?;
 
     if results.len() != 1 {
-        bail!("unexpected results length: {:?}", results);
+        return Err(HiffyCallError::Other(anyhow!(
+            "unexpected results length: {:?}",
+            results
+        )));
     }
 
     let mut v: Result<Vec<u8>, IpcError> = results.pop().unwrap();
@@ -1506,22 +1517,22 @@ pub fn hiffy_call(
         }
         _ => hiffy_decode(hubris, op, v)?,
     };
-    Ok(out)
+    out.map_err(HiffyCallError::Hiffy)
 }
 
 /// Decodes a value returned from [hiffy_call] or equivalent.
 ///
 /// Returns an outer error if decoding fails, or an inner error if the Hiffy
 /// call returns an error code (formatted as a String).
-pub fn hiffy_decode(
+pub fn hiffy_decode<T: humility::reflect::Load>(
     hubris: &HubrisArchive,
     op: &idol::IdolOperation,
     val: Result<Vec<u8>, impl Into<IpcError>>,
-) -> Result<std::result::Result<humility::reflect::Value, String>> {
+) -> Result<std::result::Result<T, String>> {
     let r = match val.map_err(Into::into) {
         Ok(val) => {
             let ty = hubris.lookup_type(op.ok).unwrap();
-            Ok(match op.operation.encoding {
+            let value = match op.operation.encoding {
                 ::idol::syntax::Encoding::Zerocopy => {
                     humility::reflect::load_value(hubris, &val, ty, 0)?
                 }
@@ -1529,7 +1540,8 @@ pub fn hiffy_decode(
                 | ::idol::syntax::Encoding::Hubpack => {
                     humility::reflect::deserialize_value(hubris, &val, ty)?.0
                 }
-            })
+            };
+            Ok(T::from_value(&value)?)
         }
         Err(IpcError::Error(e)) => match op.error {
             idol::IdolError::CLike(error) => {


### PR DESCRIPTION
(staged on #663)

This PR changes the return type from `hiffy_call` from `Result<Result<Value, String>>` to a `Result<T: Load, HiffyCallError>`.  There are two changes here:

- We automatically unpack into a `T: Load` (instead of returning a `Value`)
- We collapse the nested outer / inner error types into an `enum HiffyCallError`, which represents both cases

This ends up being a bunch of churn, but is a significant cleanup overall.