### PR TITLE
Remove unused `get_probe_serial`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,7 +1629,6 @@ dependencies = [
  "humility-probes-core",
  "indexmap 2.14.0",
  "parse_int",
- "regex",
  "serde",
  "serde_json",
 ]

--- a/humility-cli/Cargo.toml
+++ b/humility-cli/Cargo.toml
@@ -10,7 +10,6 @@ anyhow.workspace = true
 clap.workspace = true
 indexmap.workspace = true
 parse_int.workspace = true
-regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -121,53 +121,6 @@ pub struct Cli {
 }
 
 impl Cli {
-    /// Extracts and returns the probe serial name
-    ///
-    /// We can get the serial name from two different places:
-    /// - If the global `--probe` argument is of the form `vid:pid:serial`, then we
-    ///   can extract the serial name.  This is also the case if we're using an
-    ///   environment file, which populates `args.probe` automatically.
-    /// - If the `--serial` argument is given in this command's subarguments,
-    ///   then we use it directly.
-    ///
-    /// This function checks both sources, returns an error if they conflict, and
-    /// returns the (optional) serial name otherwise.
-    pub fn get_probe_serial(
-        &self,
-        subargs_serial: Option<&str>,
-    ) -> Result<Option<String>> {
-        match &self.probe {
-            Some(probe) => {
-                let re = regex::Regex::new(
-                    r"^([[:xdigit:]]+):([[:xdigit:]]+):([[:xdigit:]]+)$",
-                )
-                .unwrap();
-                if let Some(cap) = re.captures(probe) {
-                    if subargs_serial.is_some() {
-                        if self.target.is_some() {
-                            bail!(
-                                "Cannot specify probe serial number with both \
-                                 environment and `--serial`"
-                            );
-                        } else {
-                            bail!(
-                                "Cannot specify probe serial number with both \
-                                 `--probe` and `--serial`"
-                            );
-                        }
-                    }
-                    Ok(Some(cap.get(3).unwrap().as_str().to_string()))
-                } else {
-                    bail!(
-                        "`--probe` argument must be of the form
-                         `vid:pid:serial`, not {probe}",
-                    );
-                }
-            }
-            None => Ok(subargs_serial.map(|s| s.to_owned())),
-        }
-    }
-
     /// Loads an archive based on CLI arguments
     ///
     /// If `--archive` is specified, then the archive is loaded (and cooked to


### PR DESCRIPTION
With the removal of OpenOCD and GDB, `get_probe_serial` is no longer used.