### PR TITLE
Switch to using `Duration` with `HiffyContext`

### DIFF
--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -23,9 +23,9 @@ struct AuxFlashArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: AuxFlashCommand,
@@ -101,7 +101,8 @@ fn auxflash(context: &mut ExecutionContext) -> Result<()> {
     let subargs = AuxFlashArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut worker = AuxFlashHandler::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut worker = AuxFlashHandler::new(hubris, core, timeout)?;
 
     match subargs.cmd {
         AuxFlashCommand::Status { verbose } => {

--- a/cmd/console-proxy/src/lib.rs
+++ b/cmd/console-proxy/src/lib.rs
@@ -34,7 +34,7 @@ struct UartConsoleArgs {
         default_value_t = 5000,
         value_name = "hiffy_timeout_ms"
     )]
-    hiffy_timeout: u32,
+    hiffy_timeout: u64,
 
     #[clap(
         long,
@@ -43,7 +43,7 @@ struct UartConsoleArgs {
         help = "frequency of polling the SP for new data",
         value_name = "poll_interval_ms"
     )]
-    poll_interval: u32,
+    poll_interval: u64,
 
     #[clap(subcommand)]
     cmd: UartConsoleCommand,

--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -38,16 +38,11 @@ impl<'a> UartConsoleHandler<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        hiffy_timeout: u32,
-        poll_interval: u32,
+        hiffy_timeout: Duration,
+        poll_interval: Duration,
     ) -> Result<Self> {
         let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self {
-            hubris,
-            core,
-            context,
-            poll_interval: Duration::from_millis(u64::from(poll_interval)),
-        })
+        Ok(Self { hubris, core, context, poll_interval })
     }
 
     fn uart_read(&mut self, buf: &mut [u8]) -> Result<usize> {
@@ -317,12 +312,10 @@ pub(super) fn console_proxy(context: &mut ExecutionContext) -> Result<()> {
     let subargs = UartConsoleArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut worker = UartConsoleHandler::new(
-        hubris,
-        core,
-        subargs.hiffy_timeout,
-        subargs.poll_interval,
-    )?;
+    let hiffy_timeout = Duration::from_millis(subargs.hiffy_timeout);
+    let poll_interval = Duration::from_millis(subargs.poll_interval);
+    let mut worker =
+        UartConsoleHandler::new(hubris, core, hiffy_timeout, poll_interval)?;
 
     match subargs.cmd {
         UartConsoleCommand::Attach { raw, imap, omap, log } => {

--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -57,7 +57,7 @@ struct DashboardArgs {
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
         value_parser = parse_int::parse::<u32>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// CSV output file
     #[clap(long, short)]
@@ -399,7 +399,8 @@ impl<'a> Dashboard<'a> {
         core: &mut dyn Core,
         subargs: &DashboardArgs,
     ) -> Result<Dashboard<'a>> {
-        let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+        let timeout = Duration::from_millis(subargs.timeout);
+        let mut context = HiffyContext::new(hubris, core, timeout)?;
         let mut ops = vec![];
 
         let mut status_ops = vec![];

--- a/cmd/dump/src/lib.rs
+++ b/cmd/dump/src/lib.rs
@@ -93,9 +93,9 @@ struct DumpArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 20000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// show dump agent status
     #[clap(long, conflicts_with_all = &["simulation", "task", "extract_all"])]
@@ -330,7 +330,8 @@ fn get_dump_agent<'a>(
         Ok(Box::new(UdpDumpAgent::new(core, imageid)?))
     } else {
         humility::msg!("using hiffy dump agent");
-        Ok(Box::new(HiffyDumpAgent::new(hubris, core, subargs.timeout)?))
+        let timeout = std::time::Duration::from_millis(subargs.timeout);
+        Ok(Box::new(HiffyDumpAgent::new(hubris, core, timeout)?))
     }
 }
 

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -158,7 +158,11 @@ fn get_image_state(
 
         // Note that we only run this check if we pass the image ID check;
         // otherwise, the Idol / hiffy memory maps are unknown.
-        let mut worker = match AuxFlashHandler::new(hubris, core, 15_000) {
+        let mut worker = match AuxFlashHandler::new(
+            hubris,
+            core,
+            std::time::Duration::from_millis(15_000),
+        ) {
             Ok(w) => w,
             Err(e) => {
                 // Halt the core before returning!
@@ -288,7 +292,11 @@ fn program_auxflash(
     core: &mut dyn Core,
     data: &[u8],
 ) -> Result<()> {
-    let mut worker = AuxFlashHandler::new(hubris, core, 15_000)?;
+    let mut worker = AuxFlashHandler::new(
+        hubris,
+        core,
+        std::time::Duration::from_millis(15_000),
+    )?;
 
     // At this point, we've already rebooted into the new image.
     //

--- a/cmd/gpio/src/lib.rs
+++ b/cmd/gpio/src/lib.rs
@@ -109,9 +109,9 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// shows the state of an input pin (or all pins if pin is unspecified)
     #[clap(
@@ -153,7 +153,8 @@ fn gpio(context: &mut ExecutionContext) -> Result<()> {
     let subargs = GpioArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let gpio_toggle = context.get_function("GpioToggle", 2)?;
     let gpio_set = context.get_function("GpioSet", 2)?;

--- a/cmd/hash/src/lib.rs
+++ b/cmd/hash/src/lib.rs
@@ -83,9 +83,9 @@ struct HashArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// enable long test
     #[clap(long, short)]
@@ -97,7 +97,8 @@ fn hash(context: &mut ExecutionContext) -> Result<()> {
     let archive = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(archive)?;
 
-    let mut context = HiffyContext::new(archive, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(archive, core, timeout)?;
     let scratch_size = context.scratch_size();
     let mut ops = vec![];
 

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -63,9 +63,9 @@ struct HiffyArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// list HIF functions
     #[clap(long = "list-functions", short = 'L')]
@@ -257,7 +257,8 @@ fn hiffy(context: &mut ExecutionContext) -> Result<()> {
     }
 
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     if let Some(call) = subargs.call {
         let func: Vec<&str> = call.split('.').collect();

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -351,7 +351,11 @@ fn host_post_codes(
     check_post_code_target(hubris);
     use hif::*;
 
-    let mut context = HiffyContext::new(hubris, core, 5000)?;
+    let mut context = HiffyContext::new(
+        hubris,
+        core,
+        std::time::Duration::from_millis(5000),
+    )?;
     let op = hubris.get_idol_command("Sequencer.post_code_buffer_len")?;
     let value = humility_hiffy::hiffy_call(
         hubris,
@@ -438,7 +442,11 @@ fn host_last_post_code(
 ) -> Result<()> {
     check_post_code_target(hubris);
 
-    let mut context = HiffyContext::new(hubris, core, 5000)?;
+    let mut context = HiffyContext::new(
+        hubris,
+        core,
+        std::time::Duration::from_millis(5000),
+    )?;
     let op = hubris.get_idol_command("Sequencer.last_post_code")?;
     let value = humility_hiffy::hiffy_call(
         hubris,

--- a/cmd/i2c/src/lib.rs
+++ b/cmd/i2c/src/lib.rs
@@ -113,9 +113,9 @@ pub struct I2cArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// scan a controller for devices (by performing a raw read) or a device
     /// for registers (by doing a write followed by a read)
@@ -440,7 +440,8 @@ fn i2c(context: &mut ExecutionContext) -> Result<()> {
     }
 
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let (fname, args) = if subargs.flash.is_some() {
         ("I2cBulkWrite", 8)

--- a/cmd/ibc/src/lib.rs
+++ b/cmd/ibc/src/lib.rs
@@ -123,9 +123,9 @@ struct IbcArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: IbcSubcommand,
@@ -150,8 +150,9 @@ impl<'a> IbcHandler<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        hiffy_timeout: u32,
+        hiffy_timeout: u64,
     ) -> Result<Self> {
+        let hiffy_timeout = std::time::Duration::from_millis(hiffy_timeout);
         let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
         Ok(Self { hubris, core, context })
     }

--- a/cmd/lpc55gpio/src/lib.rs
+++ b/cmd/lpc55gpio/src/lib.rs
@@ -119,9 +119,9 @@ struct GpioArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// toggle specified pins
     #[clap(
@@ -167,7 +167,8 @@ fn gpio(context: &mut ExecutionContext) -> Result<()> {
     let subargs = GpioArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let gpio_toggle = context.get_function("GpioToggle", 1)?;
     let gpio_set = context.get_function("GpioSet", 1)?;

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -188,9 +188,9 @@ struct MonorailArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: Command,
@@ -1088,7 +1088,8 @@ fn monorail(context: &mut ExecutionContext) -> Result<()> {
 
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     match subargs.cmd {
         Command::Info { .. } => panic!("Called monorail with info subcommand"),
         Command::Status { ports } => {

--- a/cmd/mwocp/src/lib.rs
+++ b/cmd/mwocp/src/lib.rs
@@ -57,9 +57,9 @@ struct MwocpArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(flatten)]
     dev: DeviceIdentity,
@@ -121,7 +121,8 @@ fn mwocp(context: &mut ExecutionContext) -> Result<()> {
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let i2c_read = context.get_function("I2cRead", 7)?;
     let i2c_write = context.get_function("I2cWrite", 8)?;

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -81,9 +81,9 @@ struct NetArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: NetCommand,
@@ -566,7 +566,8 @@ fn net(context: &mut ExecutionContext) -> Result<()> {
 
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let hiffy_context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let hiffy_context = HiffyContext::new(hubris, core, timeout)?;
 
     match subargs.cmd {
         NetCommand::Mac => net_mac_table(hubris, core, hiffy_context)?,

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -211,9 +211,9 @@ struct PmbusArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// list PMBus components
     #[clap(
@@ -1458,8 +1458,9 @@ impl<'a> I2cWorker<'a> {
     fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        timeout: u32,
+        timeout: u64,
     ) -> Result<Self> {
+        let timeout = std::time::Duration::from_millis(timeout);
         let context = HiffyContext::new(hubris, core, timeout)?;
         let read_func = context.get_function("I2cRead", 7)?;
         let write_func = context.get_function("I2cWrite", 8)?;
@@ -1639,8 +1640,9 @@ impl<'a> IdolWorker<'a> {
     fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        timeout: u32,
+        timeout: u64,
     ) -> Result<Self> {
+        let timeout = std::time::Duration::from_millis(timeout);
         let context = HiffyContext::new(hubris, core, timeout)?;
         let write_set = hubris.get_idol_command("Power.raw_pmbus_set")?;
         let write_byte =

--- a/cmd/power/src/lib.rs
+++ b/cmd/power/src/lib.rs
@@ -32,9 +32,9 @@ struct PowerArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// only show values associated with the specified rail(s)
     #[clap(short, long, use_value_delimiter = true)]
@@ -120,7 +120,8 @@ fn power(context: &mut ExecutionContext) -> Result<()> {
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let mut ops = vec![];
     let op = hubris.get_idol_command("Sensor.get")?;
 

--- a/cmd/powershelf/src/lib.rs
+++ b/cmd/powershelf/src/lib.rs
@@ -29,9 +29,9 @@ struct PowershelfArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// index of the power shelf to inspect
     #[clap(long, default_value_t = 0)]
@@ -136,7 +136,8 @@ fn powershelf_run(context: &mut ExecutionContext) -> Result<()> {
 
     let operation = lookup_operation_enum(hubris)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let mut ops = vec![];
 
     let idol_cmd = hubris

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -111,9 +111,9 @@ struct QspiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 30000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// pull status string
     #[clap(long, short, group = "command")]
@@ -486,7 +486,8 @@ fn qspi(context: &mut ExecutionContext) -> Result<()> {
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     match subargs.slot {
         None => humility::msg!("Using existing slot settings"),

--- a/cmd/rencm/src/lib.rs
+++ b/cmd/rencm/src/lib.rs
@@ -34,9 +34,9 @@ struct RencmArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// verbose output
     #[clap(long, short)]
@@ -100,7 +100,8 @@ fn rencm_attached(
     subargs: &RencmArgs,
     modules: &[Module],
 ) -> Result<()> {
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let read_func = context.get_function("I2cRead", 7)?;
     let write_func = context.get_function("I2cWrite", 8)?;
 

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -180,9 +180,9 @@ struct RendmpArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(flatten)]
     dev: DeviceIdentity,
@@ -2326,7 +2326,8 @@ fn rendmp(context: &mut ExecutionContext) -> Result<()> {
         return rendmp_ingest(&subargs);
     }
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     if subargs.blackbox {
         return rendmp_blackbox(subargs, hubris, core, &mut context);
     } else if subargs.open_pin {

--- a/cmd/sbrmi/src/lib.rs
+++ b/cmd/sbrmi/src/lib.rs
@@ -114,9 +114,9 @@ struct SbrmiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// thread to operate upon
     #[clap(
@@ -521,7 +521,8 @@ fn sbrmi(context: &mut ExecutionContext) -> Result<()> {
     let subargs = SbrmiArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     if subargs.cpuid {
         return cpuid(hubris, core, &mut context, subargs.thread);

--- a/cmd/sensors/src/lib.rs
+++ b/cmd/sensors/src/lib.rs
@@ -46,9 +46,9 @@ struct SensorsArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// list all sensors
     #[clap(long, short)]
@@ -622,13 +622,14 @@ fn sensors(context: &mut ExecutionContext) -> Result<()> {
         sensors.push((i, s.clone()));
     }
 
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
     let core = &mut *context.cli.attach_live_or_dump_booted(hubris)?;
     let mut reader: Box<dyn SensorReader> = match subargs.backend {
         Some(Backend::Hiffy) => {
             if core.is_dump() {
                 bail!("cannot use hiffy backend on dump");
             }
-            let context = HiffyContext::new(hubris, core, subargs.timeout)?;
+            let context = HiffyContext::new(hubris, core, timeout)?;
             Box::new(HiffySensorReader::new(hubris, &sensors, context)?)
         }
         Some(Backend::Readmem) => {
@@ -637,7 +638,7 @@ fn sensors(context: &mut ExecutionContext) -> Result<()> {
         None if core.is_dump() => {
             Box::new(RamSensorReader::new(hubris, &sensors)?)
         }
-        None => match HiffyContext::new(hubris, core, subargs.timeout) {
+        None => match HiffyContext::new(hubris, core, timeout) {
             Ok(ctx) => Box::new(HiffySensorReader::new(hubris, &sensors, ctx)?),
             Err(_) => Box::new(RamSensorReader::new(hubris, &sensors)?),
         },

--- a/cmd/spctrl/src/lib.rs
+++ b/cmd/spctrl/src/lib.rs
@@ -76,9 +76,9 @@ struct SpCtrlArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: SpCtrlCmd,
@@ -92,7 +92,8 @@ fn spctrl(context: &mut ExecutionContext) -> Result<()> {
     let subargs = SpCtrlArgs::try_parse_from(&context.cli.cmd)?;
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let mut ops = vec![];
 
     match subargs.cmd {

--- a/cmd/spd/src/lib.rs
+++ b/cmd/spd/src/lib.rs
@@ -127,9 +127,9 @@ struct SpdArgs {
     /// sets timeout
     #[clap(
         long, short, default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// verbose output (including raw SPD data)
     #[clap(long, short)]
@@ -379,7 +379,8 @@ fn dump_ddr4_over_i2c(
         );
     };
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let i2c_read = context.get_function("I2cRead", 7)?;
     let i2c_write = context.get_function("I2cWrite", 8)?;

--- a/cmd/spi/src/lib.rs
+++ b/cmd/spi/src/lib.rs
@@ -50,9 +50,9 @@ struct SpiArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// SPI peripheral on which to operate
     #[clap(long, short, value_name = "peripheral")]
@@ -175,7 +175,8 @@ fn spi(context: &mut ExecutionContext) -> Result<()> {
     let hubris = &context.cli.archive()?;
     let core = &mut *context.cli.attach_live_booted(hubris)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let spi_read = context.get_function("SpiRead", 4)?;
     let spi_write = context.get_function("SpiWrite", 3)?;

--- a/cmd/test/src/lib.rs
+++ b/cmd/test/src/lib.rs
@@ -108,9 +108,9 @@ struct TestArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 3000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// dump full report even on success
     #[clap(long, short)]
@@ -201,7 +201,8 @@ fn test(context: &mut ExecutionContext) -> Result<()> {
     writeln!(out, "==== Test archive details")?;
     writeln!(out, "{:#?}", hubris.manifest)?;
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let run_test = context.get_function("RunTest", 1)?;
 

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -29,9 +29,9 @@ struct EepromArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 15000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     #[clap(subcommand)]
     cmd: EepromCommand,
@@ -65,8 +65,9 @@ impl<'a> EepromHandler<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        hiffy_timeout: u32,
+        hiffy_timeout: u64,
     ) -> Result<Self> {
+        let hiffy_timeout = std::time::Duration::from_millis(hiffy_timeout);
         let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
         Ok(Self { hubris, core, context })
     }

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -59,9 +59,9 @@ struct ValidateArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>,
+        value_parser = parse_int::parse::<u64>,
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// list all devices to be validated
     #[clap(long, short)]
@@ -154,7 +154,8 @@ fn validate(context: &mut ExecutionContext) -> Result<()> {
         return Ok(());
     }
 
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let op = hubris.get_idol_command("Validate.validate_i2c")?;
     let mut ops = vec![];
 

--- a/cmd/vpd/src/lib.rs
+++ b/cmd/vpd/src/lib.rs
@@ -125,9 +125,9 @@ struct VpdArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
-    timeout: u32,
+    timeout: u64,
 
     /// list all devices that have VPD (can be combined with --read)
     #[clap(long, short, conflicts_with_all = &[
@@ -205,7 +205,8 @@ fn list(
     subargs: &VpdArgs,
 ) -> Result<()> {
     let devices = vpd_devices(hubris).collect::<Vec<_>>();
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let read_op = hubris.get_idol_command("Vpd.read")?;
 
     let locked_op = hubris.get_idol_command("Vpd.is_locked").ok();
@@ -356,7 +357,8 @@ fn vpd_write(
     core: &mut dyn Core,
     subargs: &VpdArgs,
 ) -> Result<()> {
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let op = hubris.get_idol_command("Vpd.write")?;
     let target = target(hubris, subargs)?;
 
@@ -540,7 +542,8 @@ fn vpd_read(
     core: &mut dyn Core,
     subargs: &VpdArgs,
 ) -> Result<()> {
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let op = hubris.get_idol_command("Vpd.read")?;
     let mut target = target(hubris, subargs)?;
 
@@ -582,7 +585,8 @@ fn vpd_lock(
     core: &mut dyn Core,
     subargs: &VpdArgs,
 ) -> Result<()> {
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
 
     let op = hubris.get_idol_command("Vpd.permanently_lock")?;
     let index = match target(hubris, subargs)? {
@@ -620,7 +624,8 @@ fn vpd_lock_all(
     core: &mut dyn Core,
     subargs: &VpdArgs,
 ) -> Result<()> {
-    let mut context = HiffyContext::new(hubris, core, subargs.timeout)?;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
+    let mut context = HiffyContext::new(hubris, core, timeout)?;
     let op = hubris.get_idol_command("Vpd.is_locked")?;
     let read_op = hubris.get_idol_command("Vpd.read")?;
     let lock_op = hubris.get_idol_command("Vpd.permanently_lock")?;

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -8,6 +8,7 @@ use humility::core::Core;
 use humility::hubris::*;
 use humility_hiffy::HiffyContext;
 use humility_idol::{HubrisIdol, IdolArgument};
+use std::time::Duration;
 
 const DEFAULT_SLOT_SIZE_BYTES: usize = 2 * 1024 * 1024;
 const READ_CHUNK_SIZE: usize = 256; // limited by HIFFY_SCRATCH_SIZE
@@ -24,7 +25,7 @@ impl<'a> AuxFlashHandler<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        hiffy_timeout: u32,
+        hiffy_timeout: Duration,
     ) -> Result<Self> {
         let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
         Ok(Self { hubris, core, context })

--- a/humility-dump-agent/src/hiffy.rs
+++ b/humility-dump-agent/src/hiffy.rs
@@ -9,6 +9,7 @@ use humility::{core::Core, hubris::HubrisArchive};
 use humility_hiffy::{HiffyContext, IpcError};
 use humility_idol::{self as idol, HubrisIdol};
 use humpty::{DumpAreaHeader, DumpSegment, DumpSegmentHeader};
+use std::time::Duration;
 
 /// Represents a dump agent that communicates through the `hiffy` task
 ///
@@ -25,7 +26,7 @@ impl<'a> HiffyDumpAgent<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        timeout: u32,
+        timeout: Duration,
     ) -> Result<Self> {
         let context = HiffyContext::new(hubris, core, timeout)?;
 

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -35,7 +35,7 @@ enum State {
 pub struct HiffyContext<'a> {
     hubris: &'a HubrisArchive,
     scratch_size: usize,
-    timeout: u32,
+    timeout: Duration,
     state: State,
     functions: HiffyFunctions,
     hiffy: HiffyImpl<'a>,
@@ -252,10 +252,10 @@ impl<'a> HiffyContext<'a> {
     pub fn new(
         hubris: &'a HubrisArchive,
         core: &mut dyn Core,
-        timeout: u32,
+        timeout: Duration,
     ) -> Result<HiffyContext<'a>> {
         let hiffy = if core.is_net() {
-            core.set_timeout(Duration::from_millis(timeout.into()))?;
+            core.set_timeout(timeout)?;
             if hubris
                 .manifest
                 .task_features
@@ -1143,8 +1143,7 @@ impl<'a> HiffyContext<'a> {
 
         let start = std::time::Instant::now();
         let mut ready = false;
-        let timeout = Duration::from_millis(self.timeout.into());
-        while start.elapsed() < timeout {
+        while start.elapsed() < self.timeout {
             if !syscall_observed {
                 if has_task_started(self.hubris, core, hiffy_task.unwrap())? {
                     syscall_observed = true;
@@ -1261,7 +1260,7 @@ impl<'a> HiffyContext<'a> {
 
         core.op_done()?;
 
-        if kick_time.elapsed().as_millis() > self.timeout.into() {
+        if kick_time.elapsed() > self.timeout {
             bail!("operation timed out");
         }
 


### PR DESCRIPTION
This makes it much clearer for eventually doing humility as a library. There's not a nice way to have clap automatically parse a duration but we can at least change all the arguments to be a `u64` to easily pass to Duration.