### PR TITLE
Clean up errors in `humility-arch-arm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,6 @@ dependencies = [
  "capstone",
  "num-derive 0.4.2",
  "num-traits",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,10 +1607,10 @@ dependencies = [
 name = "humility-arch-arm"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "capstone",
  "num-derive 0.4.2",
  "num-traits",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/humility-arch-arm/Cargo.toml
+++ b/humility-arch-arm/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 capstone.workspace = true
-num-traits.workspace = true
 num-derive.workspace = true
+num-traits.workspace = true
+thiserror.workspace = true

--- a/humility-arch-arm/Cargo.toml
+++ b/humility-arch-arm/Cargo.toml
@@ -7,4 +7,3 @@ edition.workspace = true
 capstone.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
-thiserror.workspace = true

--- a/humility-arch-arm/src/lib.rs
+++ b/humility-arch-arm/src/lib.rs
@@ -210,40 +210,6 @@ fn instr_operands(cs: &Capstone, instr: &capstone::Insn) -> Vec<ARMRegister> {
     rval
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum InstructionError {
-    #[error("multiple source registers")]
-    MultipleSourceRegisters,
-    #[error("multiple target registers")]
-    MultipleTargetRegisters,
-}
-
-fn instr_source_target(
-    cs: &Capstone,
-    instr: &capstone::Insn,
-) -> Result<(Option<ARMRegister>, Option<ARMRegister>), InstructionError> {
-    let detail = cs.insn_detail(instr).unwrap();
-
-    let mut source: Option<ARMRegister> = None;
-    let mut target: Option<ARMRegister> = None;
-
-    for op in detail.regs_read() {
-        if source.is_some() {
-            return Err(InstructionError::MultipleSourceRegisters);
-        }
-        source = Some((*op).into());
-    }
-
-    for op in detail.regs_write() {
-        if target.is_some() {
-            return Err(InstructionError::MultipleTargetRegisters);
-        }
-        target = Some((*op).into());
-    }
-
-    Ok((source, target))
-}
-
 //
 // On ARM, our stub frames (that is, those frames that contain system call
 // instructions) have no DWARF information that describes how to unwind
@@ -259,7 +225,7 @@ fn instr_source_target(
 pub fn presyscall_pushes(
     cs: &Capstone,
     instrs: &[capstone::Insn],
-) -> Result<Vec<ARMRegister>, InstructionError> {
+) -> Vec<ARMRegister> {
     const ARM_INSN_PUSH: u32 = arch::arm::ArmInsn::ARM_INS_PUSH as u32;
     const ARM_INSN_MOV: u32 = arch::arm::ArmInsn::ARM_INS_MOV as u32;
     const ARM_INSN_POP: u32 = arch::arm::ArmInsn::ARM_INS_POP as u32;
@@ -270,10 +236,20 @@ pub fn presyscall_pushes(
     for instr in instrs {
         match instr.id() {
             InsnId(ARM_INSN_MOV) => {
-                let (source, target) = instr_source_target(cs, instr)?;
+                // Get source and target registers.  The source may be absent
+                // if this is an instruction of the form `mov Rd, #imm`; the
+                // target must always be present.
+                let detail = cs.insn_detail(instr).unwrap();
 
-                if let (Some(source), Some(target)) = (source, target) {
-                    map.insert(target, source);
+                let read = detail.regs_read();
+                assert!(read.len() <= 1, "multiple source registers in MOV");
+
+                let write = detail.regs_write();
+                assert_eq!(write.len(), 1, "MOV must have a single target reg");
+                let target = ARMRegister::from(write[0]);
+
+                if let Some(source) = read.first() {
+                    map.insert(target, ARMRegister::from(*source));
                 }
             }
 
@@ -304,7 +280,7 @@ pub fn presyscall_pushes(
     //
     rval.reverse();
 
-    Ok(rval)
+    rval
 }
 
 //

--- a/humility-arch-arm/src/lib.rs
+++ b/humility-arch-arm/src/lib.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use anyhow::{Result, bail};
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::ToPrimitive;
 use std::collections::{BTreeMap, HashMap};
@@ -211,10 +210,18 @@ fn instr_operands(cs: &Capstone, instr: &capstone::Insn) -> Vec<ARMRegister> {
     rval
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum InstructionError {
+    #[error("multiple source registers")]
+    MultipleSourceRegisters,
+    #[error("multiple target registers")]
+    MultipleTargetRegisters,
+}
+
 fn instr_source_target(
     cs: &Capstone,
     instr: &capstone::Insn,
-) -> Result<(Option<ARMRegister>, Option<ARMRegister>)> {
+) -> Result<(Option<ARMRegister>, Option<ARMRegister>), InstructionError> {
     let detail = cs.insn_detail(instr).unwrap();
 
     let mut source: Option<ARMRegister> = None;
@@ -222,14 +229,14 @@ fn instr_source_target(
 
     for op in detail.regs_read() {
         if source.is_some() {
-            bail!("multiple source registers");
+            return Err(InstructionError::MultipleSourceRegisters);
         }
         source = Some((*op).into());
     }
 
     for op in detail.regs_write() {
         if target.is_some() {
-            bail!("multiple target registers");
+            return Err(InstructionError::MultipleTargetRegisters);
         }
         target = Some((*op).into());
     }
@@ -252,7 +259,7 @@ fn instr_source_target(
 pub fn presyscall_pushes(
     cs: &Capstone,
     instrs: &[capstone::Insn],
-) -> Result<Vec<ARMRegister>> {
+) -> Result<Vec<ARMRegister>, InstructionError> {
     const ARM_INSN_PUSH: u32 = arch::arm::ArmInsn::ARM_INS_PUSH as u32;
     const ARM_INSN_MOV: u32 = arch::arm::ArmInsn::ARM_INS_MOV as u32;
     const ARM_INSN_POP: u32 = arch::arm::ArmInsn::ARM_INS_POP as u32;

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -4162,7 +4162,7 @@ impl HubrisObjectLoader {
             {
                 self.syscall_pushes.insert(
                     addr + b.len() as u32,
-                    Some(presyscall_pushes(cs, &instrs[0..ndx])?),
+                    Some(presyscall_pushes(cs, &instrs[0..ndx])),
                 );
             }
         }


### PR DESCRIPTION
This is a tiny PR which gives `humility-arch-arm` fine-grained error types.