### PR TITLE
Move `hiffy_call` into a method on `HiffyContext`

### DIFF
--- a/cmd/console-proxy/src/posix.rs
+++ b/cmd/console-proxy/src/posix.rs
@@ -47,14 +47,8 @@ impl<'a> UartConsoleHandler<'a> {
     fn uart_read(&mut self, buf: &mut [u8]) -> Result<usize> {
         let op = self.hubris.get_idol_command("ControlPlaneAgent.uart_read")?;
 
-        let v = humility_hiffy::hiffy_call::<u32>(
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            None,
-            Some(buf),
-        )?;
+        let v =
+            self.context.call::<u32>(self.core, &op, &[], None, Some(buf))?;
 
         Ok(v as usize)
     }
@@ -65,14 +59,8 @@ impl<'a> UartConsoleHandler<'a> {
 
         let buf = &buf[..usize::min(buf.len(), HIFFY_BUF_SIZE)];
 
-        let v = humility_hiffy::hiffy_call::<u32>(
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            Some(buf),
-            None,
-        )?;
+        let v =
+            self.context.call::<u32>(self.core, &op, &[], Some(buf), None)?;
 
         Ok(v as usize)
     }
@@ -156,9 +144,8 @@ impl<'a> UartConsoleHandler<'a> {
             .hubris
             .get_idol_command("ControlPlaneAgent.set_humility_uart_client")?;
 
-        humility_hiffy::hiffy_call::<()>(
+        self.context.call::<()>(
             self.core,
-            &mut self.context,
             &op,
             &[("attach", IdolArgument::String("false"))],
             None,
@@ -172,9 +159,8 @@ impl<'a> UartConsoleHandler<'a> {
             .hubris
             .get_idol_command("ControlPlaneAgent.get_uart_client")?;
 
-        let value = humility_hiffy::hiffy_call::<humility::reflect::Enum>(
+        let value = self.context.call::<humility::reflect::Enum>(
             self.core,
-            &mut self.context,
             &op,
             &[],
             None,

--- a/cmd/hiffy/src/lib.rs
+++ b/cmd/hiffy/src/lib.rs
@@ -311,9 +311,8 @@ fn hiffy(subargs: HiffyArgs, context: &mut ExecutionContext) -> Result<()> {
             };
 
             (
-                match hiffy_call(
+                match context.call(
                     core,
-                    &mut context,
                     &op,
                     &args,
                     input.as_deref(),

--- a/cmd/host/src/lib.rs
+++ b/cmd/host/src/lib.rs
@@ -356,14 +356,7 @@ fn host_post_codes(
         std::time::Duration::from_millis(5000),
     )?;
     let op = hubris.get_idol_command("Sequencer.post_code_buffer_len")?;
-    let count = humility_hiffy::hiffy_call::<u32>(
-        core,
-        &mut context,
-        &op,
-        &[],
-        None,
-        None,
-    )?;
+    let count = context.call::<u32>(core, &op, &[], None, None)?;
 
     let op = hubris.get_idol_command("Sequencer.get_post_code")?;
     let handle_value = |v| {
@@ -436,14 +429,7 @@ fn host_last_post_code(
         std::time::Duration::from_millis(5000),
     )?;
     let op = hubris.get_idol_command("Sequencer.last_post_code")?;
-    let v = humility_hiffy::hiffy_call::<u32>(
-        core,
-        &mut context,
-        &op,
-        &[],
-        None,
-        None,
-    )?;
+    let v = context.call::<u32>(core, &op, &[], None, None)?;
     if raw {
         println!("{v:08x}");
     } else {

--- a/cmd/monorail/src/lib.rs
+++ b/cmd/monorail/src/lib.rs
@@ -309,9 +309,8 @@ fn monorail_read(
     humility::msg!("Reading {reg} from {addr:#x}");
 
     let op = hubris.get_idol_command("Monorail.read_vsc7448_reg")?;
-    let value = humility_hiffy::hiffy_call::<u32>(
+    let value = context.call::<u32>(
         core,
-        context,
         &op,
         &[("addr", IdolArgument::Scalar(u64::from(addr)))],
         None,
@@ -343,9 +342,8 @@ fn monorail_write(
     pretty_print_fields(value, reg.fields(), 0);
 
     let op = hubris.get_idol_command("Monorail.write_vsc7448_reg")?;
-    humility_hiffy::hiffy_call::<()>(
+    context.call::<()>(
         core,
-        context,
         &op,
         &[
             ("addr", IdolArgument::Scalar(u64::from(addr))),
@@ -420,9 +418,8 @@ fn monorail_phy_read(
     let reg = parse_phy_register(&reg)?;
     println!("Reading from port {} PHY, register {}", port, reg.name);
     let op = hubris.get_idol_command("Monorail.read_phy_reg")?;
-    let value = humility_hiffy::hiffy_call::<u16>(
+    let value = context.call::<u16>(
         core,
-        context,
         &op,
         &[
             ("port", IdolArgument::Scalar(u64::from(port))),
@@ -452,9 +449,8 @@ fn monorail_phy_write(
     );
     pretty_print_fields(value as u32, &reg.fields, 0);
     let op = hubris.get_idol_command("Monorail.write_phy_reg")?;
-    humility_hiffy::hiffy_call::<()>(
+    context.call::<()>(
         core,
-        context,
         &op,
         &[
             ("port", IdolArgument::Scalar(u64::from(port))),
@@ -811,14 +807,8 @@ fn monorail_mac_table(
     // We need to make two HIF calls:
     // - Read the number of entries in the MAC table
     // - Loop over the table that many times, reading entries
-    let mac_count = humility_hiffy::hiffy_call::<u32>(
-        core,
-        context,
-        &op_mac_count,
-        &[],
-        None,
-        None,
-    )?;
+    let mac_count =
+        context.call::<u32>(core, &op_mac_count, &[], None, None)?;
 
     println!("Reading {mac_count} MAC addresses...");
 
@@ -899,9 +889,8 @@ fn monorail_reset_counters(
     port: u8,
 ) -> Result<()> {
     let op = hubris.get_idol_command("Monorail.reset_port_counters")?;
-    humility_hiffy::hiffy_call::<()>(
+    context.call::<()>(
         core,
-        context,
         &op,
         &[("port", IdolArgument::Scalar(u64::from(port)))],
         None,
@@ -917,9 +906,8 @@ fn monorail_counters(
     port: u8,
 ) -> Result<()> {
     let op = hubris.get_idol_command("Monorail.get_port_counters")?;
-    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
+    let s = context.call::<humility::reflect::Struct>(
         core,
-        context,
         &op,
         &[("port", IdolArgument::Scalar(u64::from(port)))],
         None,

--- a/cmd/net/src/lib.rs
+++ b/cmd/net/src/lib.rs
@@ -95,9 +95,8 @@ fn net_ip(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.get_mac_address")?;
 
-    let v = humility_hiffy::hiffy_call::<humility::reflect::Tuple>(
+    let v = hiffy_context.call::<humility::reflect::Tuple>(
         core,
-        &mut hiffy_context,
         &op,
         &[],
         None,
@@ -145,14 +144,8 @@ fn net_mac_table(
     // We need to make two HIF calls:
     // - Read the number of entries in the MAC table
     // - Loop over the table that many times, reading entries
-    let mac_count = humility_hiffy::hiffy_call::<u32>(
-        core,
-        &mut hiffy_context,
-        &op_mac_count,
-        &[],
-        None,
-        None,
-    )?;
+    let mac_count =
+        hiffy_context.call::<u32>(core, &op_mac_count, &[], None, None)?;
 
     // Due to HIF limitations (lack of Expand16 / Collect16), we're going to
     // limit ourselves to 255 MAC table entries.
@@ -247,9 +240,8 @@ fn net_status(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.management_link_status")?;
 
-    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
+    let s = hiffy_context.call::<humility::reflect::Struct>(
         core,
-        &mut hiffy_context,
         &op,
         &[],
         None,
@@ -310,9 +302,8 @@ fn net_counters(
 ) -> Result<()> {
     let op = hubris.get_idol_command("Net.management_counters")?;
 
-    let s = humility_hiffy::hiffy_call::<humility::reflect::Struct>(
+    let s = hiffy_context.call::<humility::reflect::Struct>(
         core,
-        &mut hiffy_context,
         &op,
         &[],
         None,

--- a/cmd/qspi/src/lib.rs
+++ b/cmd/qspi/src/lib.rs
@@ -493,9 +493,8 @@ fn qspi(subargs: QspiArgs, context: &mut ExecutionContext) -> Result<()> {
         s @ (Some(0) | Some(1)) => {
             let s = s.unwrap();
             humility::msg!("Setting slot to {s}");
-            hiffy_call::<()>(
+            context.call::<()>(
                 core,
-                &mut context,
                 &hubris.get_idol_command("HostFlash.set_dev")?,
                 &[("dev", IdolArgument::String(&format!("Flash{s}")))],
                 None,
@@ -1023,9 +1022,8 @@ fn qspi(subargs: QspiArgs, context: &mut ExecutionContext) -> Result<()> {
             1 => "Flash1",
             _ => bail!("dev_select must be 0 or 1"),
         };
-        hiffy_call::<()>(
+        context.call::<()>(
             core,
-            &mut context,
             &hubris.get_idol_command("HostFlash.write_persistent_data")?,
             &[("dev_select", IdolArgument::String(dev_select))],
             None,

--- a/cmd/rendmp/src/lib.rs
+++ b/cmd/rendmp/src/lib.rs
@@ -1125,9 +1125,8 @@ fn rendmp_blackbox(
 ) -> Result<()> {
     let (addr, _dev) = check_addr(&subargs, hubris)?;
     let op = hubris.get_idol_command("Power.rendmp_blackbox_dump")?;
-    let e = hiffy_call::<humility::reflect::Enum>(
+    let e = context.call::<humility::reflect::Enum>(
         core,
-        context,
         &op,
         &[("addr", addr.into())],
         None,
@@ -1662,7 +1661,7 @@ fn rendmp_phase_check<'a>(
         .get_idol_command("Sequencer.tofino_seq_state")
         .or_else(|_| hubris.get_idol_command("Sequencer.get_state"))
         .context("could not get power state HIF operation")?;
-    let r = hiffy_call(core, context, &power_state_op, &[], None, None);
+    let r = context.call(core, &power_state_op, &[], None, None);
     let v = match r {
         Ok(r) => Ok(r),
         Err(HiffyError::Hiffy(s)) => Err(s),

--- a/cmd/tofino-eeprom/src/lib.rs
+++ b/cmd/tofino-eeprom/src/lib.rs
@@ -85,9 +85,8 @@ impl<'a> EepromHandler<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            humility_hiffy::hiffy_call::<()>(
+            self.context.call::<()>(
                 self.core,
-                &mut self.context,
                 &op,
                 &[("offset", IdolArgument::Scalar(offset as u64))],
                 None,
@@ -119,9 +118,8 @@ impl<'a> EepromHandler<'a> {
         bar.set_length(data.len() as u64);
         for (i, chunk) in data.chunks(WRITE_CHUNK_SIZE).enumerate() {
             let offset = i * WRITE_CHUNK_SIZE;
-            humility_hiffy::hiffy_call::<()>(
+            self.context.call::<()>(
                 self.core,
-                &mut self.context,
                 &op,
                 &[("offset", IdolArgument::Scalar(offset as u64))],
                 Some(chunk),

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -44,14 +44,8 @@ impl<'a> AuxFlashHandler<'a> {
     /// Returns the number of auxflash slots
     pub fn slot_count(&mut self) -> Result<u32> {
         let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
-        let value = humility_hiffy::hiffy_call::<u32>(
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            None,
-            None,
-        )?;
+        let value =
+            self.context.call::<u32>(self.core, &op, &[], None, None)?;
         Ok(value)
     }
 
@@ -60,14 +54,7 @@ impl<'a> AuxFlashHandler<'a> {
         let op = self
             .hubris
             .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-        let value = humility_hiffy::hiffy_call::<u32>(
-            self.core,
-            &mut self.context,
-            &op,
-            &[],
-            None,
-            None,
-        );
+        let value = self.context.call::<u32>(self.core, &op, &[], None, None);
         match value {
             Ok(v) => Ok(Some(v)),
             Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
@@ -82,9 +69,8 @@ impl<'a> AuxFlashHandler<'a> {
     /// Erases a single auxflash slot
     pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
         let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
-        humility_hiffy::hiffy_call::<()>(
+        self.context.call::<()>(
             self.core,
-            &mut self.context,
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
@@ -99,9 +85,8 @@ impl<'a> AuxFlashHandler<'a> {
     /// erased).
     pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
         let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-        let value = humility_hiffy::hiffy_call::<([u8; 32],)>(
+        let value = self.context.call::<([u8; 32],)>(
             self.core,
-            &mut self.context,
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
@@ -140,9 +125,8 @@ impl<'a> AuxFlashHandler<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            humility_hiffy::hiffy_call::<()>(
+            self.context.call::<()>(
                 self.core,
-                &mut self.context,
                 &op,
                 &[
                     ("slot", IdolArgument::Scalar(slot as u64)),
@@ -238,9 +222,8 @@ impl<'a> AuxFlashHandler<'a> {
         bar.set_length(data.len() as u64);
         for (i, chunk) in data.chunks(data_size).enumerate() {
             let offset = i * data_size;
-            humility_hiffy::hiffy_call::<()>(
+            self.context.call::<()>(
                 self.core,
-                &mut self.context,
                 &op,
                 &[
                     ("slot", IdolArgument::Scalar(slot as u64)),

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1368,6 +1368,77 @@ impl<'a> HiffyContext<'a> {
     pub fn scratch_size(&self) -> usize {
         self.scratch_size
     }
+
+    /// Executes a Hiffy call, returning the output value (or an error)
+    pub fn call<T: humility::reflect::Load>(
+        &mut self,
+        core: &mut dyn Core,
+        op: &idol::IdolOperation,
+        args: &[(&str, idol::IdolArgument)],
+        lease_write: Option<&[u8]>,
+        lease_read: Option<&mut [u8]>,
+    ) -> Result<T, HiffyError> {
+        check_op(op)?;
+        check_leases(op, lease_write, lease_read.as_deref())?;
+
+        let mut ops = vec![];
+
+        let payload = op.payload(args)?;
+        // Read/Write is flipped when passing through the Idol operation;
+        // Read/Write is from the perspective of the host, but
+        // idol_call_ops_read/read_write/write is from the perspective of the
+        // called function.
+        match (&lease_write, &lease_read) {
+            (None, None) => self.idol_call_ops(op, &payload, &mut ops)?,
+            (None, Some(n)) => self.idol_call_ops_write(
+                op,
+                &payload,
+                &mut ops,
+                n.len().try_into().unwrap(),
+            )?,
+            (Some(d), None) => self.idol_call_ops_read(
+                op,
+                &payload,
+                &mut ops,
+                d.len().try_into().unwrap(),
+            )?,
+            (Some(d), Some(n)) => self.idol_call_ops_read_write(
+                op,
+                &payload,
+                &mut ops,
+                d.len().try_into().unwrap(),
+                n.len().try_into().unwrap(),
+            )?,
+        }
+        ops.push(Op::Done);
+
+        let mut results = self.run(core, ops.as_slice(), lease_write)?;
+
+        if results.len() != 1 {
+            return Err(HiffyError::Other(anyhow!(
+                "unexpected results length: {:?}",
+                results
+            )));
+        }
+
+        let mut v: Result<Vec<u8>, IpcError> = results.pop().unwrap();
+
+        // If this is a successful Read operation, steal extra data from the
+        // returned stack and copy it into the incoming 'read' argument
+        if let Ok(v) = v.as_mut()
+            && let Some(data) = lease_read
+        {
+            let ok_size = op.reply_size()?;
+            let extra_data = v.drain(ok_size..).collect::<Vec<u8>>();
+            data.copy_from_slice(&extra_data);
+        }
+        op.decode(&v).map_err(|e| match e {
+            idol::IdolDecodeError::DecodeFailed(v) => {
+                HiffyError::Other(v.into())
+            }
+            idol::IdolDecodeError::Idol(v) => HiffyError::Hiffy(v),
+        })
+    }
 }
 
 /// Performs a somewhat probabilistic check for whether a task has _started,_ by
@@ -1421,75 +1492,6 @@ pub enum HiffyError {
     /// There was an error invoking the HIF program
     #[error(transparent)]
     Other(#[from] anyhow::Error),
-}
-
-/// Executes a Hiffy call, returning the output value (or an error)
-pub fn hiffy_call<T: humility::reflect::Load>(
-    core: &mut dyn Core,
-    context: &mut HiffyContext,
-    op: &idol::IdolOperation,
-    args: &[(&str, idol::IdolArgument)],
-    lease_write: Option<&[u8]>,
-    lease_read: Option<&mut [u8]>,
-) -> Result<T, HiffyError> {
-    check_op(op)?;
-    check_leases(op, lease_write, lease_read.as_deref())?;
-
-    let mut ops = vec![];
-
-    let payload = op.payload(args)?;
-    // Read/Write is flipped when passing through the Idol operation;
-    // Read/Write is from the perspective of the host, but
-    // idol_call_ops_read/read_write/write is from the perspective of the
-    // called function.
-    match (&lease_write, &lease_read) {
-        (None, None) => context.idol_call_ops(op, &payload, &mut ops)?,
-        (None, Some(n)) => context.idol_call_ops_write(
-            op,
-            &payload,
-            &mut ops,
-            n.len().try_into().unwrap(),
-        )?,
-        (Some(d), None) => context.idol_call_ops_read(
-            op,
-            &payload,
-            &mut ops,
-            d.len().try_into().unwrap(),
-        )?,
-        (Some(d), Some(n)) => context.idol_call_ops_read_write(
-            op,
-            &payload,
-            &mut ops,
-            d.len().try_into().unwrap(),
-            n.len().try_into().unwrap(),
-        )?,
-    }
-    ops.push(Op::Done);
-
-    let mut results = context.run(core, ops.as_slice(), lease_write)?;
-
-    if results.len() != 1 {
-        return Err(HiffyError::Other(anyhow!(
-            "unexpected results length: {:?}",
-            results
-        )));
-    }
-
-    let mut v: Result<Vec<u8>, IpcError> = results.pop().unwrap();
-
-    // If this is a successful Read operation, steal extra data from the
-    // returned stack and copy it into the incoming 'read' argument
-    if let Ok(v) = v.as_mut()
-        && let Some(data) = lease_read
-    {
-        let ok_size = op.reply_size()?;
-        let extra_data = v.drain(ok_size..).collect::<Vec<u8>>();
-        data.copy_from_slice(&extra_data);
-    }
-    op.decode(&v).map_err(|e| match e {
-        idol::IdolDecodeError::DecodeFailed(v) => HiffyError::Other(v.into()),
-        idol::IdolDecodeError::Idol(v) => HiffyError::Hiffy(v),
-    })
 }
 
 pub fn hiffy_format_result<E: std::fmt::Display>(


### PR DESCRIPTION
(Staged on #681)

This is a small simplification PR to make `hiffy_call` into a method on `HiffyContext`, since that's the type which clearly "owns" the behavior.