### PR TITLE
Fix parsing of dashboard timeout arg

### DIFF
--- a/cmd/dashboard/src/lib.rs
+++ b/cmd/dashboard/src/lib.rs
@@ -55,7 +55,7 @@ struct DashboardArgs {
     /// sets timeout
     #[clap(
         long, short = 'T', default_value_t = 5000, value_name = "timeout_ms",
-        value_parser = parse_int::parse::<u32>
+        value_parser = parse_int::parse::<u64>
     )]
     timeout: u64,
 


### PR DESCRIPTION
This was causing `humility dashboard` to panic with "Mismatch between definition and access of `timeout`. Could not downcast to u64, need to downcast to u32"