### PR TITLE
Fix spurious errors on images without auxflash

### DIFF
--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -3622,10 +3622,8 @@ impl HubrisArchive {
     pub fn read_file(&self, name: &str) -> Result<Option<Vec<u8>>> {
         match self.hubris_archive.extract_file(name) {
             Ok(s) => Ok(Some(s)),
-            Err(hubtools::Error::ZipError(
-                zip::result::ZipError::FileNotFound,
-            )) => Ok(None),
-            Err(e) => bail!("Failed to extract {name}: {e}"),
+            Err(hubtools::Error::MissingFile(..)) => Ok(None),
+            Err(e) => bail!("Failed to extract {name}: {e:?}"),
         }
     }
 


### PR DESCRIPTION
On `humility master`, I noticed something odd while flashing an RoT:
```
humility: attaching with chip set to "LPC55S69JBD100"
humility: attached via CMSIS-DAP
humility: Failed to extract img/auxi.tlvc: could not find `img/auxi.tlvc`: specified file not found in archive; reflashing
[flashing happens]
humility flash failed: Failed to extract img/auxi.tlvc: could not find `img/auxi.tlvc`: specified file not found in archive
```

This failed because when we updated `hubtools` with fine-grained error types, we didn't change Humility; it's looking for `ZipError(FileNotFound)` instead of `MissingFile(..)`

As such, the initial `validate(..)` call fails, leading us to reflash the image (with a confusing message).  Then, the post-flash `try_program_auxflash` call fails, causing Humility to exit with an error.  The image has been flashed, but having a non-zero exit code (and confusing logs) is far from ideal!