### PR TITLE
Make `humility-validate` a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,12 +2525,10 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
- "hif",
  "humility-cli",
  "humility-core",
- "humility-hiffy",
  "humility-i2c",
- "humility-idol",
+ "humility-validate",
  "idol",
  "parse_int",
 ]
@@ -2774,6 +2772,19 @@ dependencies = [
  "humility-arch-arm",
  "humility-core",
  "regex",
+]
+
+[[package]]
+name = "humility-validate"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hif",
+ "humility-core",
+ "humility-hiffy",
+ "humility-idol",
+ "idol",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "humility-probes-core",
     "humility-spd",
     "humility-stack",
+    "humility-validate",
     "cmd/auxflash",
     "cmd/console-proxy",
     "cmd/counters",
@@ -129,6 +130,8 @@ humility-pmbus = { path = "./humility-pmbus" }
 humility-probes-core = { path = "./humility-probes-core" }
 humility-spd = { path = "./humility-spd" }
 humility-stack = { path = "./humility-stack" }
+humility-validate = { path = "./humility-validate" }
+
 cmd-auxflash = { path = "./cmd/auxflash", package = "humility-cmd-auxflash" }
 cmd-console-proxy = { path = "./cmd/console-proxy", package = "humility-cmd-console-proxy" }
 cmd-counters = { path = "./cmd/counters", package = "humility-cmd-counters" }

--- a/cmd/validate/Cargo.toml
+++ b/cmd/validate/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 description = "validate presence and operation of devices"
 
 [dependencies]
-hif.workspace = true
 clap.workspace = true
 colored.workspace = true
 anyhow.workspace = true
@@ -14,6 +13,5 @@ idol.workspace = true
 
 humility.workspace = true
 humility-cli.workspace = true
-humility-hiffy.workspace = true
-humility-idol.workspace = true
 humility-i2c.workspace = true
+humility-validate.workspace = true

--- a/cmd/validate/src/lib.rs
+++ b/cmd/validate/src/lib.rs
@@ -42,15 +42,13 @@
 //! ```
 //!
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
-use hif::*;
 use humility::hubris::*;
 use humility_cli::{ExecutionContext, humility_cmd};
-use humility_hiffy::HiffyContext;
 use humility_i2c::I2cArgs;
-use humility_idol::{self as idol, HubrisIdol, IdolDecodeError, IdolError};
+use humility_validate::{ValidateFailure, ValidateResult, ValidateSuccess};
 
 #[derive(Parser, Debug)]
 #[clap(name = "validate", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -145,7 +143,6 @@ fn validate(
     context: &mut ExecutionContext,
 ) -> Result<()> {
     let hubris = &context.cli.archive()?;
-    let core = &mut *context.cli.attach_live_booted(hubris)?;
     let refdes_len = hubris
         .manifest
         .fmt_meta
@@ -171,13 +168,7 @@ fn validate(
         return Ok(());
     }
 
-    let timeout = std::time::Duration::from_millis(subargs.timeout);
-    let mut context = HiffyContext::new(hubris, core, timeout)?;
-    let op = hubris.get_idol_command("Validate.validate_i2c")?;
-    let mut ops = vec![];
-
     let mut devices = vec![];
-
     for (ndx, device) in hubris.manifest.i2c_devices.iter().enumerate() {
         if let Some(id) = subargs.id
             && ndx != id
@@ -195,51 +186,37 @@ fn validate(
             continue;
         }
 
-        devices.push((ndx, device));
-
-        let payload =
-            op.payload(&[("index", idol::IdolArgument::Scalar(ndx as u64))])?;
-        context.idol_call_ops(&op, &payload, &mut ops)?;
+        devices.push(ndx);
     }
-
-    ops.push(Op::Done);
-
-    let results = context.run(core, ops.as_slice(), None)?;
 
     println!(
         "{:2} {:refdes_len$} {:11} {:>2} {:2} {:3} {:4} {:13} DESCRIPTION",
         "ID", REFDES_HDR, "VALIDATION", "C", "P", "MUX", "ADDR", "DEVICE"
     );
 
-    for (rndx, (ndx, device)) in devices.iter().enumerate() {
-        let result = match op.decode::<humility::reflect::Enum>(&results[rndx])
-        {
-            Ok(val) => match val.disc() {
-                "Present" => "present".yellow(),
-                "Validated" => "validated".green(),
-                n => format!("<{n}>").cyan(),
+    let core = &mut *context.cli.attach_live_booted(hubris)?;
+    let results = humility_validate::validate_by_index(
+        hubris,
+        core,
+        &devices,
+        std::time::Duration::from_millis(subargs.timeout),
+    )?;
+
+    for (index, r) in devices.into_iter().zip(results) {
+        let device = &hubris.manifest.i2c_devices[index];
+        let result = match r {
+            ValidateResult::Success(s) => match s {
+                ValidateSuccess::Present => "present".yellow(),
+                ValidateSuccess::Validated => "validated".green(),
+                ValidateSuccess::Removed => "removed".blue(),
             },
-            Err(IdolDecodeError::DecodeFailed(e)) => return Err(e.into()),
-            Err(IdolDecodeError::Idol(e)) => match e {
-                IdolError::Named(n) => match n.as_str() {
-                    "NotPresent" => {
-                        if device.removable {
-                            "removed".blue()
-                        } else {
-                            "absent".red()
-                        }
-                    }
-                    "BadValidation" => "failed".red(),
-                    "DeviceTimeout" => "timeout".red(),
-                    "DeviceError" => "error".red(),
-                    "Unavailable" => "unavailable".yellow(),
-                    n => format!("<{n}>").red(),
-                },
-                IdolError::ServerDied(..) => "server died".red(),
-                IdolError::ComplexError(..)
-                | IdolError::UnknownErrorVariant(..) => {
-                    return Err(e).context("unexpected error type");
-                }
+            ValidateResult::Failure(f) => match f {
+                ValidateFailure::Absent => "absent".red(),
+                ValidateFailure::Unavailable => "unavailable".yellow(),
+                ValidateFailure::DeviceError => "error".red(),
+                ValidateFailure::BadValidation => "failed".red(),
+                ValidateFailure::DeviceTimeout => "timeout".red(),
+                ValidateFailure::ServerDied => "server died".red(),
             },
         };
 
@@ -251,7 +228,7 @@ fn validate(
 
         println!(
             "{:2} {:refdes_len$} {:11} {:2} {:2} {:3} 0x{:02x} {:13} {}",
-            ndx,
+            index,
             device.refdes.as_deref().unwrap_or(NO_REFDES),
             result,
             device.controller,

--- a/humility-idol/src/lib.rs
+++ b/humility-idol/src/lib.rs
@@ -100,7 +100,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum IdolErrorType<'a> {
     CLike(&'a HubrisEnum),
     Complex(&'a HubrisEnum),

--- a/humility-validate/Cargo.toml
+++ b/humility-validate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "humility-validate"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+hif.workspace = true
+idol.workspace = true
+thiserror.workspace = true
+
+humility.workspace = true
+humility-hiffy.workspace = true
+humility-idol.workspace = true

--- a/humility-validate/src/lib.rs
+++ b/humility-validate/src/lib.rs
@@ -1,0 +1,247 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Library to validate Hubris devices over I2C
+//!
+//! The main entry point is [`validate_all`].
+#![warn(missing_docs)]
+
+use humility::{core::Core, hubris::HubrisArchive};
+use humility_hiffy::HiffyContext;
+use humility_idol::{HubrisIdol, IdolArgument, IdolDecodeError, IdolError};
+
+/// Successful validation result
+pub enum ValidateSuccess {
+    /// The device is present (and has no associated validation)
+    Present,
+    /// The device is present and validated
+    Validated,
+    /// The device is removable and not present
+    Removed,
+}
+
+/// Failed validation result
+pub enum ValidateFailure {
+    /// The device is not removable and is not present
+    Absent,
+    /// The device's validation routine failed
+    BadValidation,
+    /// The device timed out while validating
+    DeviceTimeout,
+    /// The device encountered another error while validating
+    DeviceError,
+    /// The device NAKed a register request
+    Unavailable,
+    /// The I2C server died while trying to communicate with the device
+    ServerDied,
+}
+
+/// Validation errors which occur at the Humility level
+#[derive(Debug, thiserror::Error)]
+pub enum ValidateError {
+    /// Failure with an unknown variant name
+    #[error(
+        "validate failed and error variant has unknown name `{variant_name}`"
+    )]
+    UnknownFailure {
+        /// Name of the error variant
+        variant_name: String,
+    },
+
+    /// Successful validation with an unknown variant name
+    #[error(
+        "validate succeeded but ok variant has unknown name `{variant_name}`"
+    )]
+    UnknownSuccess {
+        /// Name of the ok variant
+        variant_name: String,
+    },
+
+    /// Decoding the error failed
+    #[error("could not decode the error")]
+    DecodeFailed(#[source] humility_idol::IdolDecodeFailed),
+
+    /// The error was decoded into something other than [`IdolError::Named`]
+    #[error("the error was decoded into an unexpected error type")]
+    UnexpectedErrorType(#[source] humility_idol::IdolError),
+}
+
+/// Error type for things that go wrong when running validation
+///
+/// This error type *does not* capture errors reported by the validation process
+/// itself, which are represented by [`ValidateFailure`].
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Could not build hiffy context
+    #[error("could not build hiffy context")]
+    CouldNotBuildContext(#[source] anyhow::Error),
+
+    /// Could not find `validate_i2c` operation
+    #[error("could not find `validate_i2c` operation")]
+    MissingValidateI2cOp(#[source] anyhow::Error),
+
+    /// Could not pack `validate_i2c` payload
+    #[error("could not pack `validate_i2c` payload")]
+    PayloadPackingFailed(#[source] anyhow::Error),
+
+    /// Could not construct `validate_i2c` call ops
+    #[error("could not construct `validate_i2c` call ops")]
+    CallOpsFailed(#[source] anyhow::Error),
+
+    /// Could not run HIF program
+    #[error("could not run HIF program")]
+    RunFailed(#[source] anyhow::Error),
+
+    /// An error occurred while performing validation on a specific device
+    #[error("validation error")]
+    ValidateError {
+        /// Index of the device where the error occurred
+        device_index: usize,
+        /// Validation error which occurred
+        #[source]
+        err: ValidateError,
+    },
+
+    /// Device index was out of range
+    #[error("invalid device index {device_index} in a list of {count} devices")]
+    InvalidDeviceIndex {
+        /// Invalid device index
+        device_index: usize,
+        /// Number of devices
+        count: usize,
+    },
+}
+
+/// Result of running validation on a particular device
+pub enum ValidateResult {
+    /// The target reported that validation succeeded
+    Success(ValidateSuccess),
+    /// The target reported that validation failed
+    Failure(ValidateFailure),
+}
+
+/// Validates a list of devices by I2C device index
+///
+/// Indices are relative to the
+/// [`i2c_devices`](humility::hubris::HubrisManifest::i2c_devices) field in the
+/// manifest.
+///
+/// Returns a list of one result per item in `devices`
+pub fn validate_by_index(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    devices: &[usize],
+    timeout: std::time::Duration,
+) -> Result<Vec<ValidateResult>, Error> {
+    let mut context = HiffyContext::new(hubris, core, timeout)
+        .map_err(Error::CouldNotBuildContext)?;
+    let op = hubris
+        .get_idol_command("Validate.validate_i2c")
+        .map_err(Error::MissingValidateI2cOp)?;
+    let mut ops = vec![];
+    for dev in devices {
+        let payload = op
+            .payload(&[("index", IdolArgument::Scalar(*dev as u64))])
+            .map_err(Error::PayloadPackingFailed)?;
+        context
+            .idol_call_ops(&op, &payload, &mut ops)
+            .map_err(Error::CallOpsFailed)?;
+    }
+    ops.push(hif::Op::Done);
+    let results =
+        context.run(core, ops.as_slice(), None).map_err(Error::RunFailed)?;
+    let mut out = Vec::with_capacity(devices.len());
+    assert_eq!(
+        results.len(),
+        devices.len(),
+        "result and device count must be equal"
+    );
+    for (r, ndx) in results.into_iter().zip(devices.iter()) {
+        let Some(device) = hubris.manifest.i2c_devices.get(*ndx) else {
+            return Err(Error::InvalidDeviceIndex {
+                device_index: *ndx,
+                count: hubris.manifest.i2c_devices.len(),
+            });
+        };
+        let result = match op.decode::<humility::reflect::Enum>(&r) {
+            Ok(val) => match val.disc() {
+                "Present" => ValidateResult::Success(ValidateSuccess::Present),
+                "Validated" => {
+                    ValidateResult::Success(ValidateSuccess::Validated)
+                }
+                s => {
+                    return Err(Error::ValidateError {
+                        device_index: *ndx,
+                        err: ValidateError::UnknownSuccess {
+                            variant_name: s.to_string(),
+                        },
+                    });
+                }
+            },
+            Err(IdolDecodeError::DecodeFailed(e)) => {
+                return Err(Error::ValidateError {
+                    device_index: *ndx,
+                    err: ValidateError::DecodeFailed(e),
+                });
+            }
+            Err(IdolDecodeError::Idol(e)) => match e {
+                IdolError::Named(n) => match n.as_str() {
+                    "NotPresent" => {
+                        if device.removable {
+                            ValidateResult::Success(ValidateSuccess::Removed)
+                        } else {
+                            ValidateResult::Failure(ValidateFailure::Absent)
+                        }
+                    }
+                    "BadValidation" => {
+                        ValidateResult::Failure(ValidateFailure::BadValidation)
+                    }
+                    "DeviceTimeout" => {
+                        ValidateResult::Failure(ValidateFailure::DeviceTimeout)
+                    }
+                    "DeviceError" => {
+                        ValidateResult::Failure(ValidateFailure::DeviceError)
+                    }
+                    "Unavailable" => {
+                        ValidateResult::Failure(ValidateFailure::Unavailable)
+                    }
+                    n => {
+                        return Err(Error::ValidateError {
+                            device_index: *ndx,
+                            err: ValidateError::UnknownFailure {
+                                variant_name: n.to_string(),
+                            },
+                        });
+                    }
+                },
+                IdolError::ServerDied(..) => {
+                    ValidateResult::Failure(ValidateFailure::ServerDied)
+                }
+                IdolError::ComplexError(..)
+                | IdolError::UnknownErrorVariant(..) => {
+                    return Err(Error::ValidateError {
+                        device_index: *ndx,
+                        err: ValidateError::UnexpectedErrorType(e),
+                    });
+                }
+            },
+        };
+        out.push(result);
+    }
+
+    Ok(out)
+}
+
+/// Validates all available I2C devices
+///
+/// Returns a list of per-device results; devices are ordered based on
+/// [`hubris.manifest.i2c_devices`](humility::hubris::HubrisManifest::i2c_devices)
+pub fn validate_all(
+    hubris: &HubrisArchive,
+    core: &mut dyn Core,
+    timeout: std::time::Duration,
+) -> Result<Vec<ValidateResult>, Error> {
+    let devices = (0..hubris.manifest.i2c_devices.len()).collect::<Vec<_>>();
+    validate_by_index(hubris, core, &devices, timeout)
+}


### PR DESCRIPTION
This PR moves the bulk of `humility-cmd-validate` into a library crate, then uses that library in the `humility validate` subcommand.

It adds strong types for both validation results (`ValidateSuccess` and `ValidateFailure`) and errors.

Everything is documented, enforced with `#![warn(missing_docs)]` at the crate level.  Please run `cargo doc --open -phumility-validate` to check it out!

There's one logic change: if validation of a specific device fails at the Humility level (e.g. it returns an unknown variant tag that we can't decode), we treat that as an overall failure and return `Err(Error::ValidateError { device_index, err })`.  Previously, a subset of Humility-level failures would keep going – but not all of them!  This change makes the behavior more consistent, and draws a clean line between validation failure (reported by the target and mapped to `ValidateFailure`) and Humility-level errors (returned as an `Err(..)`).