### PR TITLE
Only `load` with a probe

### DIFF
--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -77,7 +77,7 @@ pub struct FlashArgs {
 /// otherwise.
 fn validate(
     hubris: &HubrisArchive,
-    core: &mut dyn humility::core::Core,
+    core: &mut humility_probes_core::ProbeCore,
     subargs: &FlashArgs,
 ) -> Result<()> {
     let r = get_image_state(
@@ -211,12 +211,11 @@ fn flashcmd(subargs: FlashArgs, context: &mut ExecutionContext) -> Result<()> {
     };
 
     humility::msg!("attaching with chip set to {chip:x?}");
-    let mut c = humility_probes_core::attach_for_flashing(
+    let core = &mut humility_probes_core::attach_for_flashing(
         probe,
         &chip,
         context.cli.speed,
     )?;
-    let core = c.as_mut();
 
     validate(hubris, core, &subargs)?;
     if subargs.check {

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -62,7 +62,6 @@ impl humility::core::Core for DryCore {
     unsupported!(run());
     unsupported!(halt());
     unsupported!(step());
-    unsupported!(load(_path: &std::path::Path));
     unsupported!(reset());
     unsupported!(write_8(_addr: u32, _data: &[u8]));
     unsupported!(op_done());

--- a/cmd/map/src/lib.rs
+++ b/cmd/map/src/lib.rs
@@ -73,7 +73,7 @@ fn mapcmd(_args: MapArgs, context: &mut ExecutionContext) -> Result<()> {
     let hubris = &context.cli.archive()?;
 
     // Use an archive core to easily read from flash
-    let core = &mut *humility::core::attach_archive(hubris)?;
+    let core = &mut humility::core::attach_archive(hubris)?;
     let regions = hubris.regions(core)?;
 
     println!(

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -147,7 +147,7 @@ fn readvar(subargs: ReadvarArgs, context: &mut ExecutionContext) -> Result<()> {
                     "attaching failed, falling back to archive: {err}"
                 );
             }
-            humility::core::attach_archive(hubris)?
+            humility::core::attach_archive(hubris).map(Box::new)?
         }
     };
     let core = &mut *core;

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -87,7 +87,8 @@ fn reset(subargs: ResetArgs, context: &mut ExecutionContext) -> Result<()> {
             probe,
             Some(&chip),
             context.cli.speed,
-        )?
+        )
+        .map(Box::new)?
     } else {
         humility_probes_core::attach_to_probe(probe, context.cli.speed)?
     };

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -75,7 +75,7 @@ fn reset(subargs: ResetArgs, context: &mut ExecutionContext) -> Result<()> {
         }
     };
 
-    let mut c = if subargs.soft_reset
+    let mut c: Box<dyn humility::core::Core> = if subargs.soft_reset
         || matches!(behavior, Behavior::Halt | Behavior::ResetWithHandoff(..))
     {
         let chip = hubris.as_ref().and_then(|h| h.chip()).ok_or_else(|| {
@@ -90,7 +90,8 @@ fn reset(subargs: ResetArgs, context: &mut ExecutionContext) -> Result<()> {
         )
         .map(Box::new)?
     } else {
-        humility_probes_core::attach_to_probe(probe, context.cli.speed)?
+        humility_probes_core::attach_to_probe(probe, context.cli.speed)
+            .map(Box::new)?
     };
 
     let r = match behavior {

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -222,6 +222,7 @@ impl Cli {
 
         let chip = hubris.and_then(|h| h.chip());
         humility_probes_core::attach_to_chip(probe, chip.as_deref(), self.speed)
+            .map(|b| Box::new(b) as Box<dyn Core>)
     }
 
     #[cfg(not(feature = "probes"))]

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -171,6 +171,7 @@ impl Cli {
             };
             let timeout = Duration::from_millis(self.timeout as u64);
             humility_net_core::attach_net(ip.0.clone()?, hubris, timeout)
+                .map(|b| Box::new(b) as Box<dyn Core>)
         } else {
             self.attach_probe(hubris)
         }?;
@@ -211,7 +212,8 @@ impl Cli {
         let probe = match self.probe.as_deref() {
             Some("archive") => {
                 if let Some(hubris) = hubris {
-                    return humility::core::attach_archive(hubris);
+                    return humility::core::attach_archive(hubris)
+                        .map(|b| Box::new(b) as Box<dyn Core>);
                 } else {
                     bail!("cannot specify `--probe=archive` with no archive");
                 }
@@ -243,16 +245,18 @@ impl Cli {
         validate: Option<HubrisValidate>,
     ) -> Result<Box<dyn Core>> {
         let mut core = if let Some(dump) = &self.dump {
-            humility::core::attach_dump(dump)?
+            humility::core::attach_dump(dump)
+                .map(|b| Box::new(b) as Box<dyn Core>)
         } else if let Some(ip) = &self.ip {
             let Some(hubris) = hubris else {
                 bail!("cannot connect over the network without archive");
             };
             let timeout = Duration::from_millis(self.timeout as u64);
-            humility_net_core::attach_net(ip.0.clone()?, hubris, timeout)?
+            humility_net_core::attach_net(ip.0.clone()?, hubris, timeout)
+                .map(|b| Box::new(b) as Box<dyn Core>)
         } else {
-            self.attach_probe(hubris)?
-        };
+            self.attach_probe(hubris)
+        }?;
         if let Some(validate) = validate {
             let Some(hubris) = hubris else {
                 bail!("cannot validate without Hubris archive");
@@ -290,7 +294,7 @@ impl Cli {
     /// Attaches to a dump
     ///
     /// Reads from the `--dump` argument to pick a target file
-    pub fn attach_dump(&self) -> Result<Box<dyn Core>> {
+    pub fn attach_dump(&self) -> Result<humility::dump::DumpCore> {
         let core = if let Some(dump) = &self.dump {
             humility::core::attach_dump(dump)?
         } else {

--- a/humility-core/src/archive.rs
+++ b/humility-core/src/archive.rs
@@ -7,7 +7,6 @@ use crate::hubris::HubrisArchive;
 use crate::hubris::HubrisFlashMap;
 use anyhow::{Result, anyhow, bail};
 use humility_arch_arm::ARMRegister;
-use std::path::Path;
 
 pub struct ArchiveCore {
     flash: HubrisFlashMap,
@@ -68,10 +67,6 @@ impl Core for ArchiveCore {
 
     fn step(&mut self) -> Result<()> {
         bail!("can't step an archive");
-    }
-
-    fn load(&mut self, _path: &Path) -> Result<()> {
-        bail!("cannot load flash to an archive");
     }
 
     fn reset(&mut self) -> Result<()> {

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -123,16 +123,16 @@ pub enum NetAgent {
     Hiffy,
 }
 
-pub fn attach_dump(dump: &str) -> Result<Box<dyn Core>> {
+pub fn attach_dump(dump: &str) -> Result<DumpCore> {
     let core = DumpCore::new(dump)?;
     crate::msg!("attached to dump");
-    Ok(Box::new(core))
+    Ok(core)
 }
 
-pub fn attach_archive(hubris: &HubrisArchive) -> Result<Box<dyn Core>> {
+pub fn attach_archive(hubris: &HubrisArchive) -> Result<ArchiveCore> {
     let core = ArchiveCore::new(hubris)?;
     crate::msg!("attached to archive");
-    Ok(Box::new(core))
+    Ok(core)
 }
 
 pub const CORE_MAX_READSIZE: usize = 65536; // 64K ought to be enough for anyone

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -8,7 +8,6 @@ use crate::archive::ArchiveCore;
 use crate::dump::DumpCore;
 use crate::hubris::*;
 use humility_arch_arm::ARMRegister;
-use std::path::Path;
 use std::str;
 use std::time::Duration;
 use thiserror::Error;
@@ -56,11 +55,6 @@ pub trait Core {
         self.read_8(addr, &mut buf)?;
         Ok(u64::from_le_bytes(buf))
     }
-
-    ///
-    /// Called to load a flash image.
-    ///
-    fn load(&mut self, path: &Path) -> Result<()>;
 
     /// Reset the chip
     fn reset(&mut self) -> Result<()>;

--- a/humility-core/src/dump.rs
+++ b/humility-core/src/dump.rs
@@ -11,7 +11,6 @@ use num_traits::FromPrimitive;
 use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
 
 pub struct DumpCore {
     contents: Vec<u8>,
@@ -201,10 +200,6 @@ impl Core for DumpCore {
 
     fn is_dump(&self) -> bool {
         true
-    }
-
-    fn load(&mut self, _path: &Path) -> Result<()> {
-        bail!("Flash loading is not supported on a dump");
     }
 
     fn reset(&mut self) -> Result<()> {

--- a/humility-dump-agent/src/lib.rs
+++ b/humility-dump-agent/src/lib.rs
@@ -28,7 +28,6 @@ use indicatif::{HumanBytes, HumanDuration, ProgressBar, ProgressStyle};
 use num_traits::FromPrimitive;
 use std::{
     collections::{BTreeMap, HashMap},
-    path::Path,
     time::Instant,
 };
 use zerocopy::FromBytes;
@@ -347,10 +346,6 @@ impl Core for DumpAgentCore {
 
     fn step(&mut self) -> Result<()> {
         bail!("can't step over dump agent");
-    }
-
-    fn load(&mut self, _path: &Path) -> Result<()> {
-        bail!("cannot load flash over dump agent");
     }
 
     fn reset(&mut self) -> Result<()> {

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -27,7 +27,6 @@ use humility_dump_agent::{
 };
 use std::{
     net::{ToSocketAddrs, UdpSocket},
-    path::Path,
     time::Duration,
 };
 
@@ -367,10 +366,6 @@ impl Core for NetCore {
 
     fn step(&mut self) -> Result<()> {
         bail!("can't step over network");
-    }
-
-    fn load(&mut self, _path: &Path) -> Result<()> {
-        bail!("cannot load flash over network");
     }
 
     fn reset(&mut self) -> Result<()> {

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -385,8 +385,8 @@ pub fn attach_net(
     ip: ScopedV6Addr,
     hubris: &HubrisArchive,
     timeout: Duration,
-) -> Result<Box<dyn Core>> {
+) -> Result<NetCore> {
     let core = NetCore::new(ip, hubris, timeout)?;
     msg!("connecting to {ip}");
-    Ok(Box::new(core))
+    Ok(core)
 }

--- a/humility-probes-core/src/lib.rs
+++ b/humility-probes-core/src/lib.rs
@@ -6,7 +6,7 @@ use ::probe_rs::{
     DebugProbeError, DebugProbeInfo, DebugProbeSelector, Probe,
     ProbeCreationError,
 };
-use humility::core::{Core, ProbeError};
+use humility::core::ProbeError;
 
 use anyhow::{Result, anyhow, bail};
 use humility::msg;
@@ -113,7 +113,7 @@ fn open_probe<T: Into<DebugProbeSelector> + Clone>(
 pub fn attach_to_probe(
     probe: &str,
     speed_khz: Option<u32>,
-) -> Result<Box<dyn Core>> {
+) -> Result<UnattachedCore> {
     let (probe, index) = parse_probe(probe);
 
     match probe {
@@ -123,13 +123,13 @@ pub fn attach_to_probe(
             let probe = open_probe(&probe_info, speed_khz)?;
 
             crate::msg!("Opened probe {}", probe_info.identifier);
-            Ok(Box::new(unattached::UnattachedCore::new(
+            Ok(UnattachedCore::new(
                 probe,
                 probe_info.identifier.clone(),
                 probe_info.vendor_id,
                 probe_info.product_id,
                 probe_info.serial_number,
-            )))
+            ))
         }
         "auto" => attach_to_probe("usb", speed_khz),
         _ => match TryInto::<DebugProbeSelector>::try_into(probe) {
@@ -142,9 +142,7 @@ pub fn attach_to_probe(
                 let name = probe.get_name();
 
                 crate::msg!("Opened {vidpid} via {name}");
-                Ok(Box::new(unattached::UnattachedCore::new(
-                    probe, name, vid, pid, serial,
-                )))
+                Ok(UnattachedCore::new(probe, name, vid, pid, serial))
             }
             Err(_) => Err(anyhow!("unrecognized probe: {}", probe)),
         },

--- a/humility-probes-core/src/lib.rs
+++ b/humility-probes-core/src/lib.rs
@@ -14,6 +14,9 @@ use humility::msg;
 mod probe_rs;
 mod unattached;
 
+pub use probe_rs::ProbeCore;
+pub use unattached::UnattachedCore;
+
 fn parse_probe(probe: &str) -> (&str, Option<usize>) {
     if probe.contains('-') {
         let str = probe.to_owned();
@@ -153,7 +156,7 @@ pub fn attach_to_chip(
     probe: &str,
     chip: Option<&str>,
     speed_khz: Option<u32>,
-) -> Result<Box<dyn Core>> {
+) -> Result<probe_rs::ProbeCore> {
     let (probe, index) = parse_probe(probe);
 
     match probe {
@@ -178,14 +181,14 @@ pub fn attach_to_chip(
 
             crate::msg!("attached via {name}");
 
-            Ok(Box::new(probe_rs::ProbeCore::new(
+            Ok(probe_rs::ProbeCore::new(
                 session,
                 probe_info.identifier.clone(),
                 probe_info.vendor_id,
                 probe_info.product_id,
                 probe_info.serial_number,
                 can_flash,
-            )))
+            ))
         }
         "auto" => attach_to_chip("usb", chip, speed_khz),
 
@@ -211,9 +214,9 @@ pub fn attach_to_chip(
 
                 crate::msg!("attached to {vidpid} via {name}");
 
-                Ok(Box::new(probe_rs::ProbeCore::new(
+                Ok(probe_rs::ProbeCore::new(
                     session, name, vid, pid, serial, can_flash,
-                )))
+                ))
             }
             Err(_) => Err(anyhow!("unrecognized probe: {probe}")),
         },
@@ -224,7 +227,7 @@ pub fn attach_for_flashing(
     probe: &str,
     chip: &str,
     speed_khz: Option<u32>,
-) -> Result<Box<dyn Core>> {
+) -> Result<probe_rs::ProbeCore> {
     attach_to_chip(probe, Some(chip), speed_khz)
 }
 
@@ -237,15 +240,15 @@ pub trait HubrisAttach {
     /// hubris archive and that the archive matches the image
     /// id present on target. If no chip is is present in the archive
     /// this will still attach.
-    fn attach_probe(&self, probe: &str) -> Result<Box<dyn Core>>;
+    fn attach_probe(&self, probe: &str) -> Result<probe_rs::ProbeCore>;
 }
 
 impl HubrisAttach for humility::hubris::HubrisArchive {
-    fn attach_probe(&self, probe: &str) -> Result<Box<dyn Core>> {
+    fn attach_probe(&self, probe: &str) -> Result<probe_rs::ProbeCore> {
         let mut core = attach_to_chip(probe, self.chip().as_deref(), None)?;
 
         self.validate(
-            &mut *core,
+            &mut core,
             humility::hubris::HubrisValidate::ArchiveMatch,
         )?;
 

--- a/humility-probes-core/src/probe_rs.rs
+++ b/humility-probes-core/src/probe_rs.rs
@@ -204,7 +204,45 @@ impl Core for ProbeCore {
         Ok(())
     }
 
-    fn load(&mut self, path: &Path) -> Result<()> {
+    fn reset(&mut self) -> Result<()> {
+        let mut core = self.session.core(0)?;
+        core.reset()?;
+        self.halted = false;
+        Ok(())
+    }
+
+    fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()> {
+        let mut core = self.session.core(0)?;
+        core.reset_and_halt(dur)?;
+        self.halted = true;
+        Ok(())
+    }
+
+    fn op_start(&mut self) -> Result<()> {
+        self.halt()?;
+
+        Ok(())
+    }
+
+    fn op_done(&mut self) -> Result<()> {
+        self.run()?;
+
+        Ok(())
+    }
+
+    fn wait_for_halt(&mut self, dur: std::time::Duration) -> Result<()> {
+        if !self.halted {
+            let mut core = self.session.core(0)?;
+            core.wait_for_core_halted(dur)?;
+            self.halted = true;
+        }
+
+        Ok(())
+    }
+}
+
+impl ProbeCore {
+    pub fn load(&mut self, path: &Path) -> Result<()> {
         #[derive(Debug, Default)]
         struct LoadProgress {
             /// total bytes that need to be erased
@@ -288,41 +326,6 @@ impl Core for ProbeCore {
         ) {
             bail!("Flash loading failed {:?}", e);
         };
-
-        Ok(())
-    }
-    fn reset(&mut self) -> Result<()> {
-        let mut core = self.session.core(0)?;
-        core.reset()?;
-        self.halted = false;
-        Ok(())
-    }
-
-    fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()> {
-        let mut core = self.session.core(0)?;
-        core.reset_and_halt(dur)?;
-        self.halted = true;
-        Ok(())
-    }
-
-    fn op_start(&mut self) -> Result<()> {
-        self.halt()?;
-
-        Ok(())
-    }
-
-    fn op_done(&mut self) -> Result<()> {
-        self.run()?;
-
-        Ok(())
-    }
-
-    fn wait_for_halt(&mut self, dur: std::time::Duration) -> Result<()> {
-        if !self.halted {
-            let mut core = self.session.core(0)?;
-            core.wait_for_core_halted(dur)?;
-            self.halted = true;
-        }
 
         Ok(())
     }

--- a/humility-probes-core/src/unattached.rs
+++ b/humility-probes-core/src/unattached.rs
@@ -5,7 +5,6 @@
 use anyhow::{Result, bail};
 use humility::core::Core;
 use humility_arch_arm::ARMRegister;
-use std::path::Path;
 
 pub struct UnattachedCore {
     pub probe: probe_rs::Probe,
@@ -71,10 +70,6 @@ impl Core for UnattachedCore {
 
     fn step(&mut self) -> Result<()> {
         bail!("Core::step unimplemented when unattached!");
-    }
-
-    fn load(&mut self, _path: &Path) -> Result<()> {
-        bail!("Core::load unimplemented when unattached!");
     }
 
     fn reset(&mut self) -> Result<()> {


### PR DESCRIPTION
`Core::load` is only implemented for `ProbeCore`; all other cores just `bail!`.  This PR removes it from the trait and moves it to a function on `ProbeCore`.

We then change the return type of unambiguous attachment functions to be a specific core type, instead of a `Box<dyn Core>`.  In cases where we need the type-erased box, it's easy to convert further down the line, but I think that library functions should defer type-erasing until it's actually needed.

(This is a building block for a `humility-flash` library crate)