### PR TITLE
Remove more probe-specific functions from `Core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ dependencies = [
  "humility-core",
  "humility-hiffy",
  "humility-idol",
+ "humility-probes-core",
  "indicatif",
  "tlvc",
 ]
@@ -1712,6 +1713,7 @@ dependencies = [
  "humility-auxflash",
  "humility-cli",
  "humility-core",
+ "humility-probes-core",
  "idol",
  "log",
  "parse_int",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1167,7 +1167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2581,7 +2581,6 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "measurement-token",
  "multimap",
  "num-derive",
  "num-traits",
@@ -2734,6 +2733,7 @@ dependencies = [
  "humpty",
  "indicatif",
  "log",
+ "measurement-token",
  "num-derive",
  "num-traits",
  "parse_int",
@@ -3527,7 +3527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4272,7 +4272,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4798,7 +4798,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5475,7 +5475,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,7 +586,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1167,7 +1178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2565,6 +2576,7 @@ version = "0.1.0"
 dependencies = [
  "addr2line",
  "anyhow",
+ "auto_impl",
  "bitfield 0.19.4",
  "capstone",
  "clap",
@@ -3527,7 +3539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4272,7 +4284,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4798,7 +4810,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5475,7 +5487,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,6 +188,7 @@ cmd-writeword = { path = "./cmd/writeword", package = "humility-cmd-writeword" }
 # crates.io deps
 addr2line = "0.26"
 anyhow = { version = "1.0.44", features = ["backtrace"] }
+auto_impl = "1.3.0"
 bitfield = "0.19.4"
 byteorder = "1.3.4"
 capstone = "0.14.0"

--- a/cmd/auxflash/Cargo.toml
+++ b/cmd/auxflash/Cargo.toml
@@ -18,3 +18,4 @@ parse_int.workspace = true
 humility.workspace = true
 humility-auxflash.workspace = true
 humility-cli.workspace = true
+humility-probes-core.workspace = true

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -13,8 +13,9 @@ use anyhow::Result;
 use clap::Parser;
 use colored::Colorize;
 use humility_cli::{ExecutionContext, humility_cmd};
+use humility_probes_core::HubrisAttach;
 
-use humility_auxflash::AuxFlashHandler;
+use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
 
 #[derive(Parser, Debug)]
 #[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -101,33 +102,45 @@ fn auxflash(
     context: &mut ExecutionContext,
 ) -> Result<()> {
     let hubris = &context.cli.archive()?;
-    let core = &mut *context.cli.attach_live_booted(hubris)?;
     let timeout = std::time::Duration::from_millis(subargs.timeout);
-    let mut worker = AuxFlashHandler::new(hubris, core, timeout)?;
 
     match subargs.cmd {
-        AuxFlashCommand::Status { verbose } => {
-            auxflash_status(worker, verbose)?;
-        }
-        AuxFlashCommand::Erase { slot } => {
-            worker.slot_erase(slot)?;
-            humility::msg!("done erasing slot {slot}");
-        }
-        AuxFlashCommand::Read { slot, output, count } => {
-            let data = worker.auxflash_read(slot, count)?;
-            std::fs::write(output, data)?;
-        }
-        AuxFlashCommand::Write { slot, input, force } => match input {
-            Some(input) => {
-                let data = std::fs::read(input)?;
-                worker.auxflash_write(slot, &data, force)?;
+        AuxFlashCommand::Status { .. }
+        | AuxFlashCommand::Erase { .. }
+        | AuxFlashCommand::Read { .. } => {
+            let core = &mut *context.cli.attach_live_booted(hubris)?;
+            let mut worker = AuxFlashHandler::new(hubris, &mut *core, timeout)?;
+            match subargs.cmd {
+                AuxFlashCommand::Status { verbose } => {
+                    auxflash_status(worker, verbose)?;
+                }
+                AuxFlashCommand::Erase { slot } => {
+                    worker.slot_erase(slot)?;
+                    humility::msg!("done erasing slot {slot}");
+                }
+                AuxFlashCommand::Read { slot, output, count } => {
+                    let data = worker.auxflash_read(slot, count)?;
+                    std::fs::write(output, data)?;
+                }
+                AuxFlashCommand::Write { .. } => unreachable!(),
             }
-            None => {
-                // If the user didn't specify an image to flash on the
-                // command line, then attempt to pull it from the image.
-                worker.auxflash_write_from_archive(slot, force)?;
+        }
+        AuxFlashCommand::Write { slot, input, force } => {
+            let core = &mut hubris
+                .attach_probe(context.cli.probe.as_deref().unwrap_or("auto"))?;
+            let mut writer = AuxFlashWriter::new(hubris, core, timeout)?;
+            match input {
+                Some(input) => {
+                    let data = std::fs::read(input)?;
+                    writer.auxflash_write(slot, &data, force)?;
+                }
+                None => {
+                    // If the user didn't specify an image to flash on the
+                    // command line, then attempt to pull it from the image.
+                    writer.auxflash_write_from_archive(slot, force)?;
+                }
             }
-        },
+        }
     }
     Ok(())
 }

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -15,7 +15,7 @@ use colored::Colorize;
 use humility_cli::{ExecutionContext, humility_cmd};
 use humility_probes_core::HubrisAttach;
 
-use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
+use humility_auxflash::{AuxFlashHandler, AuxFlashWorker, AuxFlashWriter};
 
 #[derive(Parser, Debug)]
 #[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]

--- a/cmd/auxflash/src/lib.rs
+++ b/cmd/auxflash/src/lib.rs
@@ -15,7 +15,7 @@ use colored::Colorize;
 use humility_cli::{ExecutionContext, humility_cmd};
 use humility_probes_core::HubrisAttach;
 
-use humility_auxflash::{AuxFlashHandler, AuxFlashWorker, AuxFlashWriter};
+use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
 
 #[derive(Parser, Debug)]
 #[clap(name = "auxflash", about = env!("CARGO_PKG_DESCRIPTION"))]

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -22,7 +22,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use humility::{core::Core, hubris::*};
-use humility_auxflash::{AuxFlashHandler, AuxFlashWorker, AuxFlashWriter};
+use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
 use humility_cli::{ExecutionContext, humility_cmd};
 
 #[derive(Parser, Debug)]

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -22,7 +22,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use humility::{core::Core, hubris::*};
-use humility_auxflash::AuxFlashHandler;
+use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
 use humility_cli::{ExecutionContext, humility_cmd};
 
 #[derive(Parser, Debug)]
@@ -267,7 +267,7 @@ fn flashcmd(subargs: FlashArgs, context: &mut ExecutionContext) -> Result<()> {
 
 fn try_program_auxflash(
     hubris: &HubrisArchive,
-    core: &mut dyn Core,
+    core: &mut humility_probes_core::ProbeCore,
 ) -> Result<()> {
     match hubris.read_auxflash_data()? {
         Some(auxflash) => match program_auxflash(hubris, core, &auxflash) {
@@ -286,10 +286,10 @@ fn try_program_auxflash(
 
 fn program_auxflash(
     hubris: &HubrisArchive,
-    core: &mut dyn Core,
+    core: &mut humility_probes_core::ProbeCore,
     data: &[u8],
 ) -> Result<()> {
-    let mut worker = AuxFlashHandler::new(
+    let mut worker = AuxFlashWriter::new(
         hubris,
         core,
         std::time::Duration::from_millis(15_000),

--- a/cmd/flash/src/lib.rs
+++ b/cmd/flash/src/lib.rs
@@ -22,7 +22,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Parser;
 use humility::{core::Core, hubris::*};
-use humility_auxflash::{AuxFlashHandler, AuxFlashWriter};
+use humility_auxflash::{AuxFlashHandler, AuxFlashWorker, AuxFlashWriter};
 use humility_cli::{ExecutionContext, humility_cmd};
 
 #[derive(Parser, Debug)]

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -68,7 +68,6 @@ impl humility::core::Core for DryCore {
     unsupported!(read_reg(_reg: ARMRegister) -> Result<u32>);
     unsupported!(write_reg(_reg: ARMRegister, _value: u32));
     unsupported!(write_word_32(_addr: u32, _data: u32));
-    unsupported!(wait_for_halt(_dur: std::time::Duration));
 
     fn info(&self) -> (String, Option<String>) {
         ("DryCore".to_owned(), None)

--- a/cmd/hydrate/src/lib.rs
+++ b/cmd/hydrate/src/lib.rs
@@ -62,14 +62,12 @@ impl humility::core::Core for DryCore {
     unsupported!(run());
     unsupported!(halt());
     unsupported!(step());
-    unsupported!(reset());
     unsupported!(write_8(_addr: u32, _data: &[u8]));
     unsupported!(op_done());
     unsupported!(op_start());
     unsupported!(read_reg(_reg: ARMRegister) -> Result<u32>);
     unsupported!(write_reg(_reg: ARMRegister, _value: u32));
     unsupported!(write_word_32(_addr: u32, _data: u32));
-    unsupported!(reset_and_halt(_dur: std::time::Duration));
     unsupported!(wait_for_halt(_dur: std::time::Duration));
 
     fn info(&self) -> (String, Option<String>) {

--- a/cmd/reset/src/lib.rs
+++ b/cmd/reset/src/lib.rs
@@ -75,7 +75,7 @@ fn reset(subargs: ResetArgs, context: &mut ExecutionContext) -> Result<()> {
         }
     };
 
-    let mut c: Box<dyn humility::core::Core> = if subargs.soft_reset
+    let r = if subargs.soft_reset
         || matches!(behavior, Behavior::Halt | Behavior::ResetWithHandoff(..))
     {
         let chip = hubris.as_ref().and_then(|h| h.chip()).ok_or_else(|| {
@@ -83,21 +83,29 @@ fn reset(subargs: ResetArgs, context: &mut ExecutionContext) -> Result<()> {
                 "Need a chip to do a soft reset, halt after reset, or handoff"
             )
         })?;
-        humility_probes_core::attach_to_chip(
+        let mut c = humility_probes_core::attach_to_chip(
             probe,
             Some(&chip),
             context.cli.speed,
-        )
-        .map(Box::new)?
+        )?;
+        match behavior {
+            Behavior::Halt => {
+                c.reset_and_halt(std::time::Duration::from_secs(2))
+            }
+            Behavior::ResetWithHandoff(archive) => {
+                c.reset_with_handoff(archive)
+            }
+            Behavior::Reset => c.reset(),
+        }
     } else {
-        humility_probes_core::attach_to_probe(probe, context.cli.speed)
-            .map(Box::new)?
-    };
-
-    let r = match behavior {
-        Behavior::Halt => c.reset_and_halt(std::time::Duration::from_secs(2)),
-        Behavior::ResetWithHandoff(archive) => c.reset_with_handoff(archive),
-        Behavior::Reset => c.reset(),
+        let mut c =
+            humility_probes_core::attach_to_probe(probe, context.cli.speed)?;
+        match behavior {
+            Behavior::Halt | Behavior::ResetWithHandoff(..) => {
+                unreachable!()
+            }
+            Behavior::Reset => c.reset(),
+        }
     };
 
     if r.is_err() {

--- a/humility-auxflash/Cargo.toml
+++ b/humility-auxflash/Cargo.toml
@@ -12,3 +12,4 @@ tlvc.workspace = true
 humility.workspace = true
 humility-hiffy.workspace = true
 humility-idol.workspace = true
+humility-probes-core.workspace = true

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -38,27 +38,12 @@ impl<'a> AuxFlashHandler<'a> {
 
     /// Returns the number of auxflash slots
     pub fn slot_count(&mut self) -> Result<u32> {
-        let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
-        let value =
-            self.context.call::<u32>(self.core, &op, &[], None, None)?;
-        Ok(value)
+        slot_count(self.hubris, &mut self.context, self.core)
     }
 
     /// Returns the active slot, or `None` if there is no active slot
     pub fn active_slot(&mut self) -> Result<Option<u32>> {
-        let op = self
-            .hubris
-            .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-        let value = self.context.call::<u32>(self.core, &op, &[], None, None);
-        match value {
-            Ok(v) => Ok(Some(v)),
-            Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
-                if e == "NoActiveSlot" =>
-            {
-                Ok(None)
-            }
-            Err(e) => Err(e.into()),
-        }
+        active_slot(self.hubris, &mut self.context, self.core)
     }
 
     /// Erases a single auxflash slot
@@ -173,8 +158,7 @@ impl<'a> AuxFlashWriter<'a> {
             }
         }
         if let Some(chck_data) = chck_data
-            && let Ok(Some(chck_slot)) =
-                slot_status(slot, self.hubris, &mut self.context, self.core)
+            && let Ok(Some(chck_slot)) = self.slot_status(slot)
             && chck_data == chck_slot
         {
             humility::msg!("Slot {slot} is already programmed with our data",);
@@ -249,6 +233,24 @@ impl<'a> AuxFlashWriter<'a> {
         humility::msg!("Flashing auxiliary data from the Hubris archive");
         self.auxflash_write(slot, &data, force)
     }
+
+    /// Returns the active slot, or `None` if there is no active slot
+    pub fn active_slot(&mut self) -> Result<Option<u32>> {
+        active_slot(self.hubris, &mut self.context, self.core)
+    }
+
+    /// Returns the number of auxflash slots
+    pub fn slot_count(&mut self) -> Result<u32> {
+        slot_count(self.hubris, &mut self.context, self.core)
+    }
+
+    /// Returns the checksum of an auxflash slot
+    ///
+    /// This is `None` if the checksum is not present (because the slot has been
+    /// erased).
+    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
+        slot_status(slot, self.hubris, &mut self.context, self.core)
+    }
 }
 
 fn slot_status(
@@ -300,4 +302,32 @@ fn slot_size_bytes(hubris: &HubrisArchive) -> Result<usize> {
         .as_ref()
         .map(|i| i.slot_size_bytes())
         .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
+}
+
+fn active_slot(
+    hubris: &HubrisArchive,
+    context: &mut HiffyContext,
+    core: &mut dyn Core,
+) -> Result<Option<u32>> {
+    let op = hubris.get_idol_command("AuxFlash.scan_and_get_active_slot")?;
+    let value = context.call::<u32>(core, &op, &[], None, None);
+    match value {
+        Ok(v) => Ok(Some(v)),
+        Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
+            if e == "NoActiveSlot" =>
+        {
+            Ok(None)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn slot_count(
+    hubris: &HubrisArchive,
+    context: &mut HiffyContext,
+    core: &mut dyn Core,
+) -> Result<u32> {
+    let op = hubris.get_idol_command("AuxFlash.slot_count")?;
+    let value = context.call::<u32>(core, &op, &[], None, None)?;
+    Ok(value)
 }

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -20,56 +20,103 @@ pub struct AuxFlashHandler<'a> {
     context: HiffyContext<'a>,
 }
 
-impl<'a> AuxFlashHandler<'a> {
-    /// Builds a new [`AuxFlashHandler`]
-    pub fn new(
-        hubris: &'a HubrisArchive,
-        core: &'a mut dyn Core,
-        hiffy_timeout: Duration,
-    ) -> Result<Self> {
-        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self { hubris, core, context })
-    }
+/// Trait for common functions on [`AuxFlashHandler`] and [`AuxFlashWriter`]
+///
+/// Each one implements [`get_components`](Self::get_components) then gets a
+/// bunch of other trait functions for free.
+pub trait AuxFlashWorker<'a> {
+    fn get_components(
+        &mut self,
+    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>);
+
+    fn get_archive(&self) -> &HubrisArchive;
 
     /// Returns the auxflash slot size
-    pub fn slot_size_bytes(&self) -> Result<usize> {
-        slot_size_bytes(self.hubris)
+    fn slot_size_bytes(&self) -> Result<usize> {
+        let hubris = self.get_archive();
+        hubris
+            .manifest
+            .auxflash
+            .as_ref()
+            .map(|i| i.slot_size_bytes())
+            .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
     }
 
     /// Returns the number of auxflash slots
-    pub fn slot_count(&mut self) -> Result<u32> {
-        slot_count(self.hubris, &mut self.context, self.core)
+    fn slot_count(&mut self) -> Result<u32> {
+        let (hubris, core, context) = self.get_components();
+        let op = hubris.get_idol_command("AuxFlash.slot_count")?;
+        let value = context.call::<u32>(core, &op, &[], None, None)?;
+        Ok(value)
     }
 
     /// Returns the active slot, or `None` if there is no active slot
-    pub fn active_slot(&mut self) -> Result<Option<u32>> {
-        active_slot(self.hubris, &mut self.context, self.core)
+    fn active_slot(&mut self) -> Result<Option<u32>> {
+        let (hubris, core, context) = self.get_components();
+        let op =
+            hubris.get_idol_command("AuxFlash.scan_and_get_active_slot")?;
+        let value = context.call::<u32>(core, &op, &[], None, None);
+        match value {
+            Ok(v) => Ok(Some(v)),
+            Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
+                if e == "NoActiveSlot" =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Erases a single auxflash slot
-    pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
-        slot_erase(slot, self.hubris, &mut self.context, self.core)
+    fn slot_erase(&mut self, slot: u32) -> Result<()> {
+        let (hubris, core, context) = self.get_components();
+        let op = hubris.get_idol_command("AuxFlash.erase_slot")?;
+        context.call::<()>(
+            core,
+            &op,
+            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+            None,
+            None,
+        )?;
+        Ok(())
     }
 
     /// Returns the checksum of an auxflash slot
     ///
     /// This is `None` if the checksum is not present (because the slot has been
     /// erased).
-    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
-        slot_status(slot, self.hubris, &mut self.context, self.core)
+    fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
+        let (hubris, core, context) = self.get_components();
+        let op = hubris.get_idol_command("AuxFlash.read_slot_chck")?;
+        let value = context.call::<([u8; 32],)>(
+            core,
+            &op,
+            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+            None,
+            None,
+        );
+        match value {
+            Ok(v) => Ok(Some(v.0)),
+            Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
+                if e == "MissingChck" =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Reads some number of bytes from a particular slot
     ///
     /// If `count` is empty, reads the entire slot
-    pub fn auxflash_read(
+    fn auxflash_read(
         &mut self,
         slot: u32,
         count: Option<usize>,
     ) -> Result<Vec<u8>> {
-        let op =
-            self.hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
         let slot_size = self.slot_size_bytes()?;
+        let (hubris, core, context) = self.get_components();
+        let op = hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
 
         let mut out = vec![0u8; count.unwrap_or(slot_size)];
         let bar = ProgressBar::new(0);
@@ -81,8 +128,8 @@ impl<'a> AuxFlashHandler<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            self.context.call::<()>(
-                self.core,
+            context.call::<()>(
+                core,
                 &op,
                 &[
                     ("slot", IdolArgument::Scalar(slot as u64)),
@@ -97,6 +144,29 @@ impl<'a> AuxFlashHandler<'a> {
         bar.finish_and_clear();
 
         Ok(out)
+    }
+}
+
+impl<'a> AuxFlashHandler<'a> {
+    /// Builds a new [`AuxFlashHandler`]
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        core: &'a mut dyn Core,
+        hiffy_timeout: Duration,
+    ) -> Result<Self> {
+        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
+        Ok(Self { hubris, core, context })
+    }
+}
+
+impl<'a> AuxFlashWorker<'a> for AuxFlashHandler<'a> {
+    fn get_components(
+        &mut self,
+    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>) {
+        (self.hubris, self.core, &mut self.context)
+    }
+    fn get_archive(&self) -> &HubrisArchive {
+        self.hubris
     }
 }
 
@@ -175,9 +245,9 @@ impl<'a> AuxFlashWriter<'a> {
         let data_size = self.context.data_size()?;
 
         humility::msg!("erasing slot {slot}");
-        slot_erase(slot, self.hubris, &mut self.context, self.core)?;
+        self.slot_erase(slot)?;
 
-        let slot_size = slot_size_bytes(self.hubris)?;
+        let slot_size = self.slot_size_bytes()?;
         if data.len() > slot_size {
             bail!(
                 "Data is too large ({} bytes, slot size is {} bytes)",
@@ -233,101 +303,15 @@ impl<'a> AuxFlashWriter<'a> {
         humility::msg!("Flashing auxiliary data from the Hubris archive");
         self.auxflash_write(slot, &data, force)
     }
-
-    /// Returns the active slot, or `None` if there is no active slot
-    pub fn active_slot(&mut self) -> Result<Option<u32>> {
-        active_slot(self.hubris, &mut self.context, self.core)
-    }
-
-    /// Returns the number of auxflash slots
-    pub fn slot_count(&mut self) -> Result<u32> {
-        slot_count(self.hubris, &mut self.context, self.core)
-    }
-
-    /// Returns the checksum of an auxflash slot
-    ///
-    /// This is `None` if the checksum is not present (because the slot has been
-    /// erased).
-    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
-        slot_status(slot, self.hubris, &mut self.context, self.core)
-    }
 }
 
-fn slot_status(
-    slot: u32,
-    hubris: &HubrisArchive,
-    context: &mut HiffyContext,
-    core: &mut dyn Core,
-) -> Result<Option<[u8; 32]>> {
-    let op = hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-    let value = context.call::<([u8; 32],)>(
-        core,
-        &op,
-        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-        None,
-        None,
-    );
-    match value {
-        Ok(v) => Ok(Some(v.0)),
-        Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
-            if e == "MissingChck" =>
-        {
-            Ok(None)
-        }
-        Err(e) => Err(e.into()),
+impl<'a> AuxFlashWorker<'a> for AuxFlashWriter<'a> {
+    fn get_components(
+        &mut self,
+    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>) {
+        (self.hubris, self.core, &mut self.context)
     }
-}
-
-pub fn slot_erase(
-    slot: u32,
-    hubris: &HubrisArchive,
-    context: &mut HiffyContext,
-    core: &mut dyn Core,
-) -> Result<()> {
-    let op = hubris.get_idol_command("AuxFlash.erase_slot")?;
-    context.call::<()>(
-        core,
-        &op,
-        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-        None,
-        None,
-    )?;
-    Ok(())
-}
-
-fn slot_size_bytes(hubris: &HubrisArchive) -> Result<usize> {
-    hubris
-        .manifest
-        .auxflash
-        .as_ref()
-        .map(|i| i.slot_size_bytes())
-        .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
-}
-
-fn active_slot(
-    hubris: &HubrisArchive,
-    context: &mut HiffyContext,
-    core: &mut dyn Core,
-) -> Result<Option<u32>> {
-    let op = hubris.get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-    let value = context.call::<u32>(core, &op, &[], None, None);
-    match value {
-        Ok(v) => Ok(Some(v)),
-        Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
-            if e == "NoActiveSlot" =>
-        {
-            Ok(None)
-        }
-        Err(e) => Err(e.into()),
+    fn get_archive(&self) -> &HubrisArchive {
+        self.hubris
     }
-}
-
-fn slot_count(
-    hubris: &HubrisArchive,
-    context: &mut HiffyContext,
-    core: &mut dyn Core,
-) -> Result<u32> {
-    let op = hubris.get_idol_command("AuxFlash.slot_count")?;
-    let value = context.call::<u32>(core, &op, &[], None, None)?;
-    Ok(value)
 }

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -33,12 +33,7 @@ impl<'a> AuxFlashHandler<'a> {
 
     /// Returns the auxflash slot size
     pub fn slot_size_bytes(&self) -> Result<usize> {
-        self.hubris
-            .manifest
-            .auxflash
-            .as_ref()
-            .map(|i| i.slot_size_bytes())
-            .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
+        slot_size_bytes(self.hubris)
     }
 
     /// Returns the number of auxflash slots
@@ -68,15 +63,7 @@ impl<'a> AuxFlashHandler<'a> {
 
     /// Erases a single auxflash slot
     pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
-        let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
-        self.context.call::<()>(
-            self.core,
-            &op,
-            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-            None,
-            None,
-        )?;
-        Ok(())
+        slot_erase(slot, self.hubris, &mut self.context, self.core)
     }
 
     /// Returns the checksum of an auxflash slot
@@ -84,23 +71,7 @@ impl<'a> AuxFlashHandler<'a> {
     /// This is `None` if the checksum is not present (because the slot has been
     /// erased).
     pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
-        let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-        let value = self.context.call::<([u8; 32],)>(
-            self.core,
-            &op,
-            &[("slot", IdolArgument::Scalar(u64::from(slot)))],
-            None,
-            None,
-        );
-        match value {
-            Ok(v) => Ok(Some(v.0)),
-            Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
-                if e == "MissingChck" =>
-            {
-                Ok(None)
-            }
-            Err(e) => Err(e.into()),
-        }
+        slot_status(slot, self.hubris, &mut self.context, self.core)
     }
 
     /// Reads some number of bytes from a particular slot
@@ -141,6 +112,25 @@ impl<'a> AuxFlashHandler<'a> {
         bar.finish_and_clear();
 
         Ok(out)
+    }
+}
+
+/// Handle to write to auxiliary flash
+pub struct AuxFlashWriter<'a> {
+    hubris: &'a HubrisArchive,
+    core: &'a mut humility_probes_core::ProbeCore,
+    context: HiffyContext<'a>,
+}
+
+impl<'a> AuxFlashWriter<'a> {
+    /// Builds a new [`AuxFlashWriter`]
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        core: &'a mut humility_probes_core::ProbeCore,
+        hiffy_timeout: Duration,
+    ) -> Result<Self> {
+        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
+        Ok(Self { hubris, core, context })
     }
 
     /// Writes some number of bytes to a particular slot
@@ -183,7 +173,8 @@ impl<'a> AuxFlashHandler<'a> {
             }
         }
         if let Some(chck_data) = chck_data
-            && let Ok(Some(chck_slot)) = self.slot_status(slot)
+            && let Ok(Some(chck_slot)) =
+                slot_status(slot, self.hubris, &mut self.context, self.core)
             && chck_data == chck_slot
         {
             humility::msg!("Slot {slot} is already programmed with our data",);
@@ -200,9 +191,9 @@ impl<'a> AuxFlashHandler<'a> {
         let data_size = self.context.data_size()?;
 
         humility::msg!("erasing slot {slot}");
-        self.slot_erase(slot)?;
+        slot_erase(slot, self.hubris, &mut self.context, self.core)?;
 
-        let slot_size = self.slot_size_bytes()?;
+        let slot_size = slot_size_bytes(self.hubris)?;
         if data.len() > slot_size {
             bail!(
                 "Data is too large ({} bytes, slot size is {} bytes)",
@@ -258,4 +249,55 @@ impl<'a> AuxFlashHandler<'a> {
         humility::msg!("Flashing auxiliary data from the Hubris archive");
         self.auxflash_write(slot, &data, force)
     }
+}
+
+fn slot_status(
+    slot: u32,
+    hubris: &HubrisArchive,
+    context: &mut HiffyContext,
+    core: &mut dyn Core,
+) -> Result<Option<[u8; 32]>> {
+    let op = hubris.get_idol_command("AuxFlash.read_slot_chck")?;
+    let value = context.call::<([u8; 32],)>(
+        core,
+        &op,
+        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+        None,
+        None,
+    );
+    match value {
+        Ok(v) => Ok(Some(v.0)),
+        Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
+            if e == "MissingChck" =>
+        {
+            Ok(None)
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+pub fn slot_erase(
+    slot: u32,
+    hubris: &HubrisArchive,
+    context: &mut HiffyContext,
+    core: &mut dyn Core,
+) -> Result<()> {
+    let op = hubris.get_idol_command("AuxFlash.erase_slot")?;
+    context.call::<()>(
+        core,
+        &op,
+        &[("slot", IdolArgument::Scalar(u64::from(slot)))],
+        None,
+        None,
+    )?;
+    Ok(())
+}
+
+fn slot_size_bytes(hubris: &HubrisArchive) -> Result<usize> {
+    hubris
+        .manifest
+        .auxflash
+        .as_ref()
+        .map(|i| i.slot_size_bytes())
+        .unwrap_or(Ok(DEFAULT_SLOT_SIZE_BYTES))
 }

--- a/humility-auxflash/src/lib.rs
+++ b/humility-auxflash/src/lib.rs
@@ -14,27 +14,30 @@ const DEFAULT_SLOT_SIZE_BYTES: usize = 2 * 1024 * 1024;
 const READ_CHUNK_SIZE: usize = 256; // limited by HIFFY_SCRATCH_SIZE
 
 /// Handle to interact with auxiliary flash
-pub struct AuxFlashHandler<'a> {
+pub struct GenericAuxFlashHandler<'a, C: Core> {
     hubris: &'a HubrisArchive,
-    core: &'a mut dyn Core,
+    core: C,
     context: HiffyContext<'a>,
 }
 
-/// Trait for common functions on [`AuxFlashHandler`] and [`AuxFlashWriter`]
-///
-/// Each one implements [`get_components`](Self::get_components) then gets a
-/// bunch of other trait functions for free.
-pub trait AuxFlashWorker<'a> {
-    fn get_components(
-        &mut self,
-    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>);
+pub type AuxFlashHandler<'a> = GenericAuxFlashHandler<'a, &'a mut dyn Core>;
+pub type AuxFlashWriter<'a> =
+    GenericAuxFlashHandler<'a, &'a mut humility_probes_core::ProbeCore>;
 
-    fn get_archive(&self) -> &HubrisArchive;
+impl<'a, C: Core> GenericAuxFlashHandler<'a, C> {
+    /// Builds a new auxflash handler
+    pub fn new(
+        hubris: &'a HubrisArchive,
+        mut core: C,
+        hiffy_timeout: Duration,
+    ) -> Result<Self> {
+        let context = HiffyContext::new(hubris, &mut core, hiffy_timeout)?;
+        Ok(Self { hubris, core, context })
+    }
 
     /// Returns the auxflash slot size
-    fn slot_size_bytes(&self) -> Result<usize> {
-        let hubris = self.get_archive();
-        hubris
+    pub fn slot_size_bytes(&self) -> Result<usize> {
+        self.hubris
             .manifest
             .auxflash
             .as_ref()
@@ -43,19 +46,20 @@ pub trait AuxFlashWorker<'a> {
     }
 
     /// Returns the number of auxflash slots
-    fn slot_count(&mut self) -> Result<u32> {
-        let (hubris, core, context) = self.get_components();
-        let op = hubris.get_idol_command("AuxFlash.slot_count")?;
-        let value = context.call::<u32>(core, &op, &[], None, None)?;
+    pub fn slot_count(&mut self) -> Result<u32> {
+        let op = self.hubris.get_idol_command("AuxFlash.slot_count")?;
+        let value =
+            self.context.call::<u32>(&mut self.core, &op, &[], None, None)?;
         Ok(value)
     }
 
     /// Returns the active slot, or `None` if there is no active slot
-    fn active_slot(&mut self) -> Result<Option<u32>> {
-        let (hubris, core, context) = self.get_components();
-        let op =
-            hubris.get_idol_command("AuxFlash.scan_and_get_active_slot")?;
-        let value = context.call::<u32>(core, &op, &[], None, None);
+    pub fn active_slot(&mut self) -> Result<Option<u32>> {
+        let op = self
+            .hubris
+            .get_idol_command("AuxFlash.scan_and_get_active_slot")?;
+        let value =
+            self.context.call::<u32>(&mut self.core, &op, &[], None, None);
         match value {
             Ok(v) => Ok(Some(v)),
             Err(HiffyError::Hiffy(humility_idol::IdolError::Named(e)))
@@ -68,11 +72,10 @@ pub trait AuxFlashWorker<'a> {
     }
 
     /// Erases a single auxflash slot
-    fn slot_erase(&mut self, slot: u32) -> Result<()> {
-        let (hubris, core, context) = self.get_components();
-        let op = hubris.get_idol_command("AuxFlash.erase_slot")?;
-        context.call::<()>(
-            core,
+    pub fn slot_erase(&mut self, slot: u32) -> Result<()> {
+        let op = self.hubris.get_idol_command("AuxFlash.erase_slot")?;
+        self.context.call::<()>(
+            &mut self.core,
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
@@ -85,11 +88,10 @@ pub trait AuxFlashWorker<'a> {
     ///
     /// This is `None` if the checksum is not present (because the slot has been
     /// erased).
-    fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
-        let (hubris, core, context) = self.get_components();
-        let op = hubris.get_idol_command("AuxFlash.read_slot_chck")?;
-        let value = context.call::<([u8; 32],)>(
-            core,
+    pub fn slot_status(&mut self, slot: u32) -> Result<Option<[u8; 32]>> {
+        let op = self.hubris.get_idol_command("AuxFlash.read_slot_chck")?;
+        let value = self.context.call::<([u8; 32],)>(
+            &mut self.core,
             &op,
             &[("slot", IdolArgument::Scalar(u64::from(slot)))],
             None,
@@ -109,14 +111,14 @@ pub trait AuxFlashWorker<'a> {
     /// Reads some number of bytes from a particular slot
     ///
     /// If `count` is empty, reads the entire slot
-    fn auxflash_read(
+    pub fn auxflash_read(
         &mut self,
         slot: u32,
         count: Option<usize>,
     ) -> Result<Vec<u8>> {
         let slot_size = self.slot_size_bytes()?;
-        let (hubris, core, context) = self.get_components();
-        let op = hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
+        let op =
+            self.hubris.get_idol_command("AuxFlash.read_slot_with_offset")?;
 
         let mut out = vec![0u8; count.unwrap_or(slot_size)];
         let bar = ProgressBar::new(0);
@@ -128,8 +130,8 @@ pub trait AuxFlashWorker<'a> {
         bar.set_length(out.len() as u64);
         for (i, chunk) in out.chunks_mut(READ_CHUNK_SIZE).enumerate() {
             let offset = i * READ_CHUNK_SIZE;
-            context.call::<()>(
-                core,
+            self.context.call::<()>(
+                &mut self.core,
                 &op,
                 &[
                     ("slot", IdolArgument::Scalar(slot as u64)),
@@ -147,47 +149,7 @@ pub trait AuxFlashWorker<'a> {
     }
 }
 
-impl<'a> AuxFlashHandler<'a> {
-    /// Builds a new [`AuxFlashHandler`]
-    pub fn new(
-        hubris: &'a HubrisArchive,
-        core: &'a mut dyn Core,
-        hiffy_timeout: Duration,
-    ) -> Result<Self> {
-        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self { hubris, core, context })
-    }
-}
-
-impl<'a> AuxFlashWorker<'a> for AuxFlashHandler<'a> {
-    fn get_components(
-        &mut self,
-    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>) {
-        (self.hubris, self.core, &mut self.context)
-    }
-    fn get_archive(&self) -> &HubrisArchive {
-        self.hubris
-    }
-}
-
-/// Handle to write to auxiliary flash
-pub struct AuxFlashWriter<'a> {
-    hubris: &'a HubrisArchive,
-    core: &'a mut humility_probes_core::ProbeCore,
-    context: HiffyContext<'a>,
-}
-
 impl<'a> AuxFlashWriter<'a> {
-    /// Builds a new [`AuxFlashWriter`]
-    pub fn new(
-        hubris: &'a HubrisArchive,
-        core: &'a mut humility_probes_core::ProbeCore,
-        hiffy_timeout: Duration,
-    ) -> Result<Self> {
-        let context = HiffyContext::new(hubris, core, hiffy_timeout)?;
-        Ok(Self { hubris, core, context })
-    }
-
     /// Writes some number of bytes to a particular slot
     ///
     /// If the slot is already programmed with a matching `CHCK` field, then
@@ -302,16 +264,5 @@ impl<'a> AuxFlashWriter<'a> {
         })?;
         humility::msg!("Flashing auxiliary data from the Hubris archive");
         self.auxflash_write(slot, &data, force)
-    }
-}
-
-impl<'a> AuxFlashWorker<'a> for AuxFlashWriter<'a> {
-    fn get_components(
-        &mut self,
-    ) -> (&HubrisArchive, &mut dyn Core, &mut HiffyContext<'a>) {
-        (self.hubris, self.core, &mut self.context)
-    }
-    fn get_archive(&self) -> &HubrisArchive {
-        self.hubris
     }
 }

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 [dependencies]
 addr2line.workspace = true
 anyhow.workspace = true
+auto_impl.workspace = true
 bitfield.workspace = true
 clap.workspace = true
 gimli.workspace = true

--- a/humility-core/Cargo.toml
+++ b/humility-core/Cargo.toml
@@ -21,7 +21,6 @@ idol.workspace = true
 indexmap.workspace = true
 indicatif.workspace = true
 log.workspace = true
-measurement-token.workspace = true
 multimap.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true

--- a/humility-core/src/archive.rs
+++ b/humility-core/src/archive.rs
@@ -69,14 +69,6 @@ impl Core for ArchiveCore {
         bail!("can't step an archive");
     }
 
-    fn reset(&mut self) -> Result<()> {
-        bail!("cannot reset an archive");
-    }
-
-    fn reset_and_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot reset an archive");
-    }
-
     fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
         bail!("cannot wait for halt of an archive");
     }

--- a/humility-core/src/archive.rs
+++ b/humility-core/src/archive.rs
@@ -68,8 +68,4 @@ impl Core for ArchiveCore {
     fn step(&mut self) -> Result<()> {
         bail!("can't step an archive");
     }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot wait for halt of an archive");
-    }
 }

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -12,6 +12,7 @@ use std::str;
 use std::time::Duration;
 use thiserror::Error;
 
+#[auto_impl::auto_impl(&mut)] // adds `impl<C: Core> Core for &mut C`
 pub trait Core {
     fn info(&self) -> (String, Option<String>);
 

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -56,35 +56,6 @@ pub trait Core {
         Ok(u64::from_le_bytes(buf))
     }
 
-    /// Reset the chip
-    fn reset(&mut self) -> Result<()>;
-
-    /// Reset the chip and halt afterwards. Requires a timeout to wait for
-    /// halt
-    fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()>;
-
-    /// Reset the chip, with special handling for measurement handoff
-    ///
-    /// If this image uses handoff to send a measurement token between the RoT
-    /// and SP, this won't work with a debugger physically attached.  To prevent
-    /// the SP from resetting itself, we write a different token which skips
-    /// this reboot loop.  The memory address and token values are pulled from
-    /// the `measurement-token` crate in `lpc55_support`, which is also used in
-    /// the SP firmware.
-    fn reset_with_handoff(&mut self, hubris: &HubrisArchive) -> Result<()> {
-        if hubris.wants_reset_handoff_token() {
-            self.reset_and_halt(std::time::Duration::from_millis(25))?;
-            crate::msg!("skipping measurement token handoff");
-            self.write_word_32(
-                measurement_token::SP_ADDR as u32,
-                measurement_token::SKIP,
-            )?;
-            self.run()
-        } else {
-            self.reset()
-        }
-    }
-
     /// Called before starting a series of operations.  May halt the target if
     /// the target does not allow operations while not halted.  Should not be
     /// intermixed with [`halt`]/[`run`].

--- a/humility-core/src/core.rs
+++ b/humility-core/src/core.rs
@@ -70,9 +70,6 @@ pub trait Core {
         Ok(())
     }
 
-    /// Wait `duration` seconds for the targe to halt.
-    fn wait_for_halt(&mut self, dur: std::time::Duration) -> Result<()>;
-
     /// Send over network, if applicable
     fn send(&self, _buf: &[u8], _agent: NetAgent) -> Result<usize> {
         bail!("cannot send over network");

--- a/humility-core/src/dump.rs
+++ b/humility-core/src/dump.rs
@@ -202,14 +202,6 @@ impl Core for DumpCore {
         true
     }
 
-    fn reset(&mut self) -> Result<()> {
-        bail!("Reset is not supported on a dump");
-    }
-
-    fn reset_and_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("Reset is not supported on a dump");
-    }
-
     fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
         bail!("Wait for halt is not supported on a dump");
     }

--- a/humility-core/src/dump.rs
+++ b/humility-core/src/dump.rs
@@ -201,8 +201,4 @@ impl Core for DumpCore {
     fn is_dump(&self) -> bool {
         true
     }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("Wait for halt is not supported on a dump");
-    }
 }

--- a/humility-dump-agent/src/lib.rs
+++ b/humility-dump-agent/src/lib.rs
@@ -348,14 +348,6 @@ impl Core for DumpAgentCore {
         bail!("can't step over dump agent");
     }
 
-    fn reset(&mut self) -> Result<()> {
-        bail!("cannot reset over dump agent");
-    }
-
-    fn reset_and_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot reset over dump agent");
-    }
-
     fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
         bail!("cannot wait for halt over dump agent");
     }

--- a/humility-dump-agent/src/lib.rs
+++ b/humility-dump-agent/src/lib.rs
@@ -347,10 +347,6 @@ impl Core for DumpAgentCore {
     fn step(&mut self) -> Result<()> {
         bail!("can't step over dump agent");
     }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot wait for halt over dump agent");
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -367,10 +367,6 @@ impl Core for NetCore {
     fn step(&mut self) -> Result<()> {
         bail!("can't step over network");
     }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot wait for halt over network");
-    }
 }
 
 pub fn attach_net(

--- a/humility-net-core/src/lib.rs
+++ b/humility-net-core/src/lib.rs
@@ -368,14 +368,6 @@ impl Core for NetCore {
         bail!("can't step over network");
     }
 
-    fn reset(&mut self) -> Result<()> {
-        bail!("cannot reset over network");
-    }
-
-    fn reset_and_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("cannot reset over network");
-    }
-
     fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
         bail!("cannot wait for halt over network");
     }

--- a/humility-probes-core/Cargo.toml
+++ b/humility-probes-core/Cargo.toml
@@ -8,14 +8,15 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 humpty.workspace = true
-
-humility.workspace = true
-humility-arch-arm.workspace = true
 indicatif.workspace = true
 log.workspace = true
+measurement-token.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 parse_int.workspace = true
 probe-rs.workspace = true
-thiserror.workspace = true
 rusb.workspace = true
+thiserror.workspace = true
+
+humility.workspace = true
+humility-arch-arm.workspace = true

--- a/humility-probes-core/src/probe_rs.rs
+++ b/humility-probes-core/src/probe_rs.rs
@@ -215,16 +215,6 @@ impl Core for ProbeCore {
 
         Ok(())
     }
-
-    fn wait_for_halt(&mut self, dur: std::time::Duration) -> Result<()> {
-        if !self.halted {
-            let mut core = self.session.core(0)?;
-            core.wait_for_core_halted(dur)?;
-            self.halted = true;
-        }
-
-        Ok(())
-    }
 }
 
 impl ProbeCore {

--- a/humility-probes-core/src/probe_rs.rs
+++ b/humility-probes-core/src/probe_rs.rs
@@ -204,20 +204,6 @@ impl Core for ProbeCore {
         Ok(())
     }
 
-    fn reset(&mut self) -> Result<()> {
-        let mut core = self.session.core(0)?;
-        core.reset()?;
-        self.halted = false;
-        Ok(())
-    }
-
-    fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()> {
-        let mut core = self.session.core(0)?;
-        core.reset_and_halt(dur)?;
-        self.halted = true;
-        Ok(())
-    }
-
     fn op_start(&mut self) -> Result<()> {
         self.halt()?;
 
@@ -327,6 +313,45 @@ impl ProbeCore {
             bail!("Flash loading failed {:?}", e);
         };
 
+        Ok(())
+    }
+
+    /// Reset the chip, with special handling for measurement handoff
+    ///
+    /// If this image uses handoff to send a measurement token between the RoT
+    /// and SP, this won't work with a debugger physically attached.  To prevent
+    /// the SP from resetting itself, we write a different token which skips
+    /// this reboot loop.  The memory address and token values are pulled from
+    /// the `measurement-token` crate in `lpc55_support`, which is also used in
+    /// the SP firmware.
+    pub fn reset_with_handoff(
+        &mut self,
+        hubris: &humility::hubris::HubrisArchive,
+    ) -> Result<()> {
+        if hubris.wants_reset_handoff_token() {
+            self.reset_and_halt(std::time::Duration::from_millis(25))?;
+            crate::msg!("skipping measurement token handoff");
+            self.write_word_32(
+                measurement_token::SP_ADDR as u32,
+                measurement_token::SKIP,
+            )?;
+            self.run()
+        } else {
+            self.reset()
+        }
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        let mut core = self.session.core(0)?;
+        core.reset()?;
+        self.halted = false;
+        Ok(())
+    }
+
+    pub fn reset_and_halt(&mut self, dur: std::time::Duration) -> Result<()> {
+        let mut core = self.session.core(0)?;
+        core.reset_and_halt(dur)?;
+        self.halted = true;
         Ok(())
     }
 }

--- a/humility-probes-core/src/unattached.rs
+++ b/humility-probes-core/src/unattached.rs
@@ -71,10 +71,6 @@ impl Core for UnattachedCore {
     fn step(&mut self) -> Result<()> {
         bail!("Core::step unimplemented when unattached!");
     }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("Waiting and halting on an unattched chip isn't available!");
-    }
 }
 
 impl UnattachedCore {

--- a/humility-probes-core/src/unattached.rs
+++ b/humility-probes-core/src/unattached.rs
@@ -72,7 +72,13 @@ impl Core for UnattachedCore {
         bail!("Core::step unimplemented when unattached!");
     }
 
-    fn reset(&mut self) -> Result<()> {
+    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
+        bail!("Waiting and halting on an unattched chip isn't available!");
+    }
+}
+
+impl UnattachedCore {
+    pub fn reset(&mut self) -> Result<()> {
         self.probe.target_reset_assert()?;
 
         // The closest available documentation on hold time is
@@ -83,13 +89,5 @@ impl Core for UnattachedCore {
         self.probe.target_reset_deassert()?;
 
         Ok(())
-    }
-
-    fn reset_and_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("Can't reset and halt for an unattached chip");
-    }
-
-    fn wait_for_halt(&mut self, _dur: std::time::Duration) -> Result<()> {
-        bail!("Waiting and halting on an unattched chip isn't available!");
     }
 }


### PR DESCRIPTION
This PR removes `reset`, `reset_and_halt`, and `wait_for_halt` from the `Core` trait.  These functions are only implemented on `ProbeCore` (and `UnattachedCore::reset`), so removing them from the trait lets us be more precise with our APIs.

(`wait_for_halt` is not used anywhere, so it's been fully deleted).

The only tricky part is `AuxFlashHandler`, which only _sometimes_ needs a full `ProbeCore` – basically only when writing.  I added a new `struct AuxFlashWriter`, then an `AuxFlashWorker` trait to unify common functions (e.g. getting slot count, and active slot).  This is a bit annoying, but minimizes boilerplate; I couldn't find a way to write a type which accepts either a `&mut dyn Core` or a concrete `C: Core` without replumbing everything.