### PR TITLE
Build helios package in CI

### DIFF
--- a/.github/buildomat/jobs/build-and-test.sh
+++ b/.github/buildomat/jobs/build-and-test.sh
@@ -18,19 +18,10 @@ export CARGO_INCREMENTAL=0
 
 banner deps
 need=(
-	'/library/libusb'
+	'/ooce/library/libusb-1'
 	'/library/libftdi1'
 )
-missing=()
-for (( i = 0; i < ${#need[@]}; i++ )); do
-	p=${need[$i]}
-	if ! pkg info -q "$p"; then
-		missing+=( "$p" )
-	fi
-done
-if (( ${#missing[@]} > 0 )); then
-	pfexec pkg install -v "${missing[@]}"
-fi
+PKG_SUCCESS_ON_NOP=1 pfexec pkg install -v "${need[@]}"
 pkg list -v "${need[@]}"
 
 cargo --version

--- a/.github/buildomat/jobs/p5p.sh
+++ b/.github/buildomat/jobs/p5p.sh
@@ -1,0 +1,57 @@
+#!/bin/ksh
+#:
+#: name = "humility-p5p"
+#: variety = "basic"
+#: target = "helios-3.0"
+#: rust_toolchain = "stable"
+#: output_rules = [
+#:   "=/out/humility.p5p",
+#:   "=/out/humility.p5p.sha256",
+#: ]
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "humility.p5p"
+#: from_output = "/out/humility.p5p"
+#:
+#: [[publish]]
+#: series = "repo"
+#: name = "humility.p5p.sha256"
+#: from_output = "/out/humility.p5p.sha256"
+#:
+
+set -ex
+
+#
+# Disable incremental builds, as per ".github/workflows/ci.yaml":
+#
+export CARGO_INCREMENTAL=0
+
+#
+# Install the libraries that humility links against. These are required to
+# build the binary, and must also be present so that `pkgdepend resolve` can
+# map the binary's NEEDED libraries to the packages that provide them.
+#
+banner deps
+need=(
+	'/ooce/library/libusb-1'
+	'/library/libftdi1'
+)
+PKG_SUCCESS_ON_NOP=1 pfexec pkg install -v "${need[@]}"
+pkg list -v "${need[@]}"
+
+cargo --version
+rustc --version
+
+#
+# `cargo xtask package` builds the humility binary and produces the p5p.
+#
+banner package
+ptime -m cargo xtask package
+
+banner copy
+pfexec mkdir -p /out
+pfexec chown "$UID" /out
+PKG_NAME="/out/humility.p5p"
+mv pkg/packages/repo/*.p5p "$PKG_NAME"
+sha256sum "$PKG_NAME" > "$PKG_NAME.sha256"

--- a/pkg/.gitignore
+++ b/pkg/.gitignore
@@ -1,0 +1,6 @@
+packages
+proto
+repo
+humility.final.p5m
+humility.generate.p5m
+humility.base.p5m

--- a/pkg/build.sh
+++ b/pkg/build.sh
@@ -1,0 +1,55 @@
+#!/bin/ksh
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# Build a Helios (IPS) package for humility. This is normally invoked via
+# `cargo xtask package`, which builds the binary first; it can also be run
+# directly from the pkg/ directory once target/release/humility exists.
+#
+
+typeset -r PUBLISHER=helios
+typeset -r HELIOS_RELEASE=$(awk -F= '/^VERSION=/{print $2}' /etc/os-release)
+typeset -r COMMIT_COUNT=$(git rev-list --count HEAD)
+typeset -r REPO=packages/repo
+typeset -r BINARY=../target/release/humility
+typeset -ri TAG=0
+set -e
+
+rm -rf proto packages
+rm -f humility.{base,generate,final}.p5m
+
+function fatal {
+	print -u2 "$@"
+	exit 1
+}
+
+# create the proto area
+mkdir -p proto/usr/bin
+[ -x "$BINARY" ] || fatal "$BINARY not found"
+cp "$BINARY" proto/usr/bin/humility
+
+VERSION=$(awk -F\" '/^version = /{print $2; exit}' ../humility-bin/Cargo.toml)
+PKG_VERSION="$VERSION.$COMMIT_COUNT-$HELIOS_RELEASE.$TAG"
+
+# create the package
+sed -e "s/%PUBLISHER%/$PUBLISHER/g" \
+    -e "s/%PKG_VERSION%/$PKG_VERSION/g" \
+    humility.template.p5m | pkgmogrify -v -O humility.base.p5m
+
+pkgdepend generate -d proto humility.base.p5m > humility.generate.p5m
+
+mkdir -p packages
+pkgdepend resolve -d packages -s resolve.p5m humility.generate.p5m
+
+cat humility.base.p5m packages/humility.generate.p5m.resolve.p5m \
+	> humility.final.p5m
+
+pkgrepo create $REPO
+pkgrepo add-publisher -s $REPO $PUBLISHER
+
+pkgsend publish -d proto -s $REPO humility.final.p5m
+pkgrecv -a -d packages/repo/humility-$PKG_VERSION.p5p -s $REPO \
+	-v -m latest '*'
+

--- a/pkg/humility.template.p5m
+++ b/pkg/humility.template.p5m
@@ -1,0 +1,9 @@
+set name=pkg.fmri \
+    value=pkg://%PUBLISHER%/developer/debug/humility@%PKG_VERSION%
+set name=pkg.summary value="Debugger for Hubris"
+set name=info.classification \
+    value=org.opensolaris.category.2008:Development/System
+set name=variant.arch value=i386
+dir  path=usr     owner=root group=sys mode=0755
+dir  path=usr/bin owner=root group=bin mode=0755
+file path=usr/bin/humility owner=root group=bin mode=0755

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -7,12 +7,21 @@ use clap::Parser;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::Write;
+use std::process::Command;
 
 #[derive(Debug, Parser)]
 #[clap(max_term_width = 80, about = "extra tasks to help you work on Hubris")]
 enum Xtask {
     /// Compiles readme
     Readme,
+
+    /// Build the humility binary and produce a Helios (p5p) package.
+    Package {
+        /// Skip building the humility binary; package the existing
+        /// `target/release/humility`.
+        #[arg(long)]
+        skip_build: bool,
+    },
 }
 
 fn make_readme() -> Result<()> {
@@ -108,12 +117,59 @@ fn make_readme() -> Result<()> {
     Ok(())
 }
 
+fn make_package(skip_build: bool) -> Result<()> {
+    use cargo_metadata::MetadataCommand;
+
+    let metadata =
+        MetadataCommand::new().manifest_path("./Cargo.toml").exec().unwrap();
+    let root = metadata.workspace_root;
+
+    if !skip_build {
+        let status = Command::new("cargo")
+            .args(["build", "--release", "-p", "humility-bin"])
+            .current_dir(&root)
+            .status()
+            .context("failed to run `cargo build`")?;
+
+        if !status.success() {
+            bail!("`cargo build --release -p humility-bin` failed");
+        }
+    }
+
+    let pkg_dir = root.join("pkg");
+    let status = Command::new("ksh")
+        .arg("build.sh")
+        .current_dir(&pkg_dir)
+        .status()
+        .context("failed to run pkg/build.sh")?;
+
+    if !status.success() {
+        bail!("pkg/build.sh failed");
+    }
+
+    let repo = pkg_dir.join("packages/repo");
+    for entry in std::fs::read_dir(&repo)
+        .with_context(|| format!("failed to read {repo}"))?
+    {
+        let path = entry?.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("p5p") {
+            println!("Successfully built package {}.", path.display());
+            return Ok(());
+        }
+    }
+
+    bail!("failed to find output package in {repo}");
+}
+
 fn main() -> Result<()> {
     let xtask = Xtask::parse();
 
     match xtask {
         Xtask::Readme => {
             make_readme()?;
+        }
+        Xtask::Package { skip_build } => {
+            make_package(skip_build)?;
         }
     }
 


### PR DESCRIPTION
Build a helios package for humility in CI.
This will be picked up by [grabber](https://github.com/oxidecomputer/lengths-of-wire/tree/main/grabber), that runs on the package server; the resulting package will automatically be published to the repository.