### PR TITLE
Remove `-p archive` fallback

### DIFF
--- a/cmd/probe/src/lib.rs
+++ b/cmd/probe/src/lib.rs
@@ -88,6 +88,7 @@
 
 use anyhow::{Result, bail};
 use clap::Parser;
+use humility::core::Core;
 use humility::hubris::HubrisValidate;
 use humility_arch_arm::ARMRegister;
 use humility_cli::{ExecutionContext, humility_cmd};
@@ -105,7 +106,7 @@ pub struct ProbeArgs {
 #[rustfmt::skip::macros(format)]
 fn probecmd(subargs: ProbeArgs, context: &mut ExecutionContext) -> Result<()> {
     let hubris = context.cli.try_archive()?;
-    let core = &mut *context.cli.attach_probe(hubris.as_ref())?;
+    let core = &mut context.cli.attach_probe(hubris.as_ref())?;
 
     use num_traits::FromPrimitive;
     let mut status = vec![];

--- a/cmd/readvar/src/lib.rs
+++ b/cmd/readvar/src/lib.rs
@@ -38,7 +38,7 @@
 
 use anyhow::{Result, bail};
 use clap::Parser;
-use humility::core::{Core, ProbeError};
+use humility::core::Core;
 use humility::hubris::*;
 use humility_cli::{ExecutionContext, humility_cmd};
 
@@ -61,6 +61,10 @@ pub struct ReadvarArgs {
     /// leave target halted
     #[clap(long)]
     leave_halted: bool,
+
+    /// Read from archive instead of attached target
+    #[clap(long, conflicts_with = "leave_halted", requires = "variable")]
+    archive: bool,
 
     #[clap(conflicts_with = "list")]
     variable: Option<String>,
@@ -130,25 +134,12 @@ fn readvar(subargs: ReadvarArgs, context: &mut ExecutionContext) -> Result<()> {
         n == v || n.ends_with(&suffix)
     }
 
-    // Try to attach to a live system or dump, falling back to an archive core
-    // if that's not possible (which only lets us read flash).
-    let mut core = match context.cli.attach_live_or_dump_match(hubris) {
-        Ok(core) => core,
-        Err(err) => {
-            // Decide whether to warn the user about what happened. If we got
-            // `NoProbeFound` and the user wasn't trying to find a probe, then
-            // we're in the clear; otherwise, print a warning and continue.
-            if err
-                .downcast_ref::<ProbeError>()
-                .is_none_or(|e| !matches!(e, ProbeError::NoProbeFound))
-                && context.cli.probe.is_none()
-            {
-                humility::warn!(
-                    "attaching failed, falling back to archive: {err}"
-                );
-            }
-            humility::core::attach_archive(hubris).map(Box::new)?
-        }
+    // If the user calls out that we should attach to the archive, do that
+    let mut core = if subargs.archive {
+        humility::core::attach_archive(hubris).map(Box::new)?
+    } else {
+        // Otherwise, attach to a live system or dump
+        context.cli.attach_live_or_dump_match(hubris)?
     };
     let core = &mut *core;
 

--- a/cmd/rebootleby/src/lib.rs
+++ b/cmd/rebootleby/src/lib.rs
@@ -87,7 +87,7 @@ fn rebootleby(
     }
 
     let mut core = context.cli.attach_probe(None)?;
-    let mut flash = FlashHack { core: &mut *core };
+    let mut flash = FlashHack { core: &mut core };
 
     humility::msg!("Connected to core.");
 

--- a/cmd/stmsecure/src/lib.rs
+++ b/cmd/stmsecure/src/lib.rs
@@ -303,7 +303,7 @@ fn stmsecure(
     subargs: StmSecureArgs,
     context: &mut ExecutionContext,
 ) -> Result<()> {
-    let core = &mut *context.cli.attach_probe(None)?;
+    let core = &mut context.cli.attach_probe(None)?;
 
     match subargs.cmd {
         StmSecureCmd::Status => stmsecure_status(core),

--- a/cmd/writeword/src/lib.rs
+++ b/cmd/writeword/src/lib.rs
@@ -49,6 +49,7 @@
 
 use anyhow::{Result, bail};
 use clap::Parser;
+use humility::core::Core;
 use humility_cli::{ExecutionContext, humility_cmd};
 
 #[derive(Parser, Debug)]
@@ -68,7 +69,7 @@ fn writeword(
     context: &mut ExecutionContext,
 ) -> Result<()> {
     let hubris = context.cli.try_archive()?;
-    let core = &mut *context.cli.attach_probe(hubris.as_ref())?;
+    let core = &mut context.cli.attach_probe(hubris.as_ref())?;
     if subargs.address & 0b11 != 0 {
         bail!("address must be word aligned");
     }

--- a/humility-bin/tests/cli_tests.rs
+++ b/humility-bin/tests/cli_tests.rs
@@ -34,7 +34,7 @@ impl Kind {
     fn options(&self) -> &'static str {
         match self {
             Kind::Postmortem => "-d",
-            Kind::Archive => "-p archive -a",
+            Kind::Archive => "-a",
             Kind::All => panic!(),
         }
     }
@@ -183,7 +183,7 @@ fn make_all_tests() -> Result<()> {
             Kind::Archive,
             "readvar-tasks",
             "readvar",
-            "HUBRIS_TASK_DESCS",
+            "--archive HUBRIS_TASK_DESCS",
         ),
         Test::witharg(Kind::All, "sensors", "sensors", "--list"),
         Test::witharg(Kind::Postmortem, "sensors-read", "sensors", ""),

--- a/humility-bin/tests/cmd/extract-list/extract-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/extract-list/extract-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip extract --list"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip extract --list"
 

--- a/humility-bin/tests/cmd/extract-list/extract-list.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/extract-list/extract-list.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip extract --list"
+args = "-a build-gimlet-rot-c-image-b.zip extract --list"
 

--- a/humility-bin/tests/cmd/extract-list/extract-list.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/extract-list/extract-list.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip extract --list"
+args = "-a build-sidecar-b-image-default.zip extract --list"
 

--- a/humility-bin/tests/cmd/extract/extract.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/extract/extract.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip extract app.toml"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip extract app.toml"
 

--- a/humility-bin/tests/cmd/extract/extract.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/extract/extract.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip extract app.toml"
+args = "-a build-gimlet-rot-c-image-b.zip extract app.toml"
 

--- a/humility-bin/tests/cmd/extract/extract.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/extract/extract.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip extract app.toml"
+args = "-a build-sidecar-b-image-default.zip extract app.toml"
 

--- a/humility-bin/tests/cmd/hiffy-list/hiffy-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/hiffy-list/hiffy-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip hiffy --list"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip hiffy --list"
 

--- a/humility-bin/tests/cmd/hiffy-list/hiffy-list.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/hiffy-list/hiffy-list.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip hiffy --list"
+args = "-a build-gimlet-rot-c-image-b.zip hiffy --list"
 

--- a/humility-bin/tests/cmd/hiffy-list/hiffy-list.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/hiffy-list/hiffy-list.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip hiffy --list"
+args = "-a build-sidecar-b-image-default.zip hiffy --list"
 

--- a/humility-bin/tests/cmd/manifest/manifest.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip manifest"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip manifest"
 

--- a/humility-bin/tests/cmd/manifest/manifest.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip manifest"
+args = "-a build-gimlet-rot-c-image-b.zip manifest"
 

--- a/humility-bin/tests/cmd/manifest/manifest.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/manifest/manifest.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip manifest"
+args = "-a build-sidecar-b-image-default.zip manifest"
 

--- a/humility-bin/tests/cmd/map/map.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/map/map.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip map"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip map"
 

--- a/humility-bin/tests/cmd/map/map.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/map/map.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip map"
+args = "-a build-gimlet-rot-c-image-b.zip map"
 

--- a/humility-bin/tests/cmd/map/map.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/map/map.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip map"
+args = "-a build-sidecar-b-image-default.zip map"
 

--- a/humility-bin/tests/cmd/readvar-list/readvar-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/readvar-list/readvar-list.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip readvar -l"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip readvar -l"
 

--- a/humility-bin/tests/cmd/readvar-list/readvar-list.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/readvar-list/readvar-list.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip readvar -l"
+args = "-a build-gimlet-rot-c-image-b.zip readvar -l"
 

--- a/humility-bin/tests/cmd/readvar-list/readvar-list.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/readvar-list/readvar-list.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip readvar -l"
+args = "-a build-sidecar-b-image-default.zip readvar -l"
 

--- a/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip readvar HUBRIS_TASK_DESCS"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip readvar --archive HUBRIS_TASK_DESCS"
 

--- a/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip readvar HUBRIS_TASK_DESCS"
+args = "-a build-gimlet-rot-c-image-b.zip readvar --archive HUBRIS_TASK_DESCS"
 

--- a/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/readvar-tasks/readvar-tasks.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip readvar HUBRIS_TASK_DESCS"
+args = "-a build-sidecar-b-image-default.zip readvar --archive HUBRIS_TASK_DESCS"
 

--- a/humility-bin/tests/cmd/sensors/sensors.gimlet-c-dev-image-default-v1.0.2.zip.toml
+++ b/humility-bin/tests/cmd/sensors/sensors.gimlet-c-dev-image-default-v1.0.2.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-c-dev-image-default-v1.0.2.zip sensors --list"
+args = "-a build-gimlet-c-dev-image-default-v1.0.2.zip sensors --list"
 

--- a/humility-bin/tests/cmd/sensors/sensors.gimlet-rot-c-image-b.zip.toml
+++ b/humility-bin/tests/cmd/sensors/sensors.gimlet-rot-c-image-b.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-gimlet-rot-c-image-b.zip sensors --list"
+args = "-a build-gimlet-rot-c-image-b.zip sensors --list"
 

--- a/humility-bin/tests/cmd/sensors/sensors.sidecar-b-image-default.zip.toml
+++ b/humility-bin/tests/cmd/sensors/sensors.sidecar-b-image-default.zip.toml
@@ -6,5 +6,5 @@
 #
 fs.base = "../archives"
 bin.name = "humility"
-args = "-p archive -a build-sidecar-b-image-default.zip sensors --list"
+args = "-a build-sidecar-b-image-default.zip sensors --list"
 

--- a/humility-cli/src/lib.rs
+++ b/humility-cli/src/lib.rs
@@ -173,7 +173,7 @@ impl Cli {
             humility_net_core::attach_net(ip.0.clone()?, hubris, timeout)
                 .map(|b| Box::new(b) as Box<dyn Core>)
         } else {
-            self.attach_probe(hubris)
+            self.attach_probe(hubris).map(|b| Box::new(b) as Box<dyn Core>)
         }?;
         if let Some(validate) = validate {
             let Some(hubris) = hubris else {
@@ -208,30 +208,23 @@ impl Cli {
     pub fn attach_probe(
         &self,
         hubris: Option<&HubrisArchive>,
-    ) -> Result<Box<dyn Core>> {
-        let probe = match self.probe.as_deref() {
-            Some("archive") => {
-                if let Some(hubris) = hubris {
-                    return humility::core::attach_archive(hubris)
-                        .map(|b| Box::new(b) as Box<dyn Core>);
-                } else {
-                    bail!("cannot specify `--probe=archive` with no archive");
-                }
-            }
-            Some(p) => p,
-            None => "auto",
-        };
-
+    ) -> Result<humility_probes_core::ProbeCore> {
+        let probe = self.probe.as_deref().unwrap_or("auto");
         let chip = hubris.and_then(|h| h.chip());
         humility_probes_core::attach_to_chip(probe, chip.as_deref(), self.speed)
-            .map(|b| Box::new(b) as Box<dyn Core>)
     }
 
+    // If the `probes` feature is disabled, then we don't have access to
+    // `ProbeCore`, but we still need to return a concrete type that implements
+    // `Core` (for everything else to typecheck).
+    //
+    // We'll have the signature return an `ArchiveCore` instead, with the
+    // knowledge that it will never actually be used.
     #[cfg(not(feature = "probes"))]
     pub fn attach_probe(
         &self,
         _hubris: Option<&HubrisArchive>,
-    ) -> Result<Box<dyn Core>> {
+    ) -> Result<humility::archive::ArchiveCore> {
         bail!("Did not build with probes!");
     }
 
@@ -255,7 +248,7 @@ impl Cli {
             humility_net_core::attach_net(ip.0.clone()?, hubris, timeout)
                 .map(|b| Box::new(b) as Box<dyn Core>)
         } else {
-            self.attach_probe(hubris)
+            self.attach_probe(hubris).map(|b| Box::new(b) as Box<dyn Core>)
         }?;
         if let Some(validate) = validate {
             let Some(hubris) = hubris else {


### PR DESCRIPTION
(staged on #692)

Previously, if you specified `--probe=archive`, Humility would attach to the archive instead of the probe, even in subcommands which wanted a live system.  This was useful in one case: `readvar` could read variables from flash.

This PR removes the fallback: `attach_probe` now returns a concrete `ProbeCore`, without the `--probe=archive` special case.  As the only user of the old behavior, `humility readvar` grows a new `--archive` flag to compensate.

(This is my new preferred alternative to #694)