### PR TITLE
Shrink `hiffy` network packets to avoid fragmentation

### DIFF
--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -1681,8 +1681,11 @@ impl<'a, 'b> HiffyWrite<'a, 'b> {
                     Var::Text => ops.write_text,
                     Var::Data => ops.write_data,
                 };
-                // Chosen to be smaller than packet size
+                // Packets are sized based on the rx buffer size, then clamped
+                // to a conservative MTU to avoid packet fragmentation (which
+                // is not handled by the Hubris netstack).
                 let Some(chunk_size) = buf_size
+                    .min(&1024)
                     .checked_sub(std::mem::size_of::<hiffy::RpcHeader>())
                 else {
                     bail!("buffer size {buf_size} is smaller than `RpcHeader`");


### PR DESCRIPTION
https://github.com/oxidecomputer/hubris/issues/2551 was due to a 2233-byte UDP payload being fragmented across two packets:

```
ETHER:  ----- Ether Header -----
ETHER:
ETHER:  Packet 465 arrived at 15:08:24.38397
ETHER:  Packet size = 1294 bytes
ETHER:  Destination = a8:40:25:4:e:82,
ETHER:  Source      = 0:e:c6:2c:bb:12,
ETHER:  Ethertype = 86DD (IPv6)
ETHER:
IPv6:   ----- IPv6 Header -----
IPv6:
IPv6:   Version = 6
IPv6:   Traffic Class = 0
IPv6:   Flow label = 0x0
IPv6:   Payload length = 1240
IPv6:   Next Header = 44 (IPv6-Frag)
IPv6:   Hop Limit = 60
IPv6:   Source address = fe80::20e:c6ff:fe2c:bb12
IPv6:   Destination address = fe80::aa40:25ff:fe04:e82
IPv6:
IPv6-Frag:  ----- IPv6 Fragment Header -----
IPv6-Frag:
IPv6-Frag:  Next Header = 17 (UDP)
IPv6-Frag:  Fragment Offset = 0
IPv6-Frag:  More Fragments Flag = true
IPv6-Frag:  Identification = 11340704
IPv6-Frag:
UDP:  ----- UDP Header -----
UDP:
UDP:  Source port = 64877
UDP:  Destination port = 11115
UDP:  Length = 2233 (Not all data contained in this fragment)
UDP:  Checksum = 951E
UDP:

ETHER:  ----- Ether Header -----
ETHER:
ETHER:  Packet 466 arrived at 15:08:24.38398
ETHER:  Packet size = 1063 bytes
ETHER:  Destination = a8:40:25:4:e:82,
ETHER:  Source      = 0:e:c6:2c:bb:12,
ETHER:  Ethertype = 86DD (IPv6)
ETHER:
IPv6:   ----- IPv6 Header -----
IPv6:
IPv6:   Version = 6
IPv6:   Traffic Class = 0
IPv6:   Flow label = 0x0
IPv6:   Payload length = 1009
IPv6:   Next Header = 44 (IPv6-Frag)
IPv6:   Hop Limit = 60
IPv6:   Source address = fe80::20e:c6ff:fe2c:bb12
IPv6:   Destination address = fe80::aa40:25ff:fe04:e82
IPv6:
IPv6-Frag:  ----- IPv6 Fragment Header -----
IPv6-Frag:
IPv6-
```

The SP replies with "what the heck"
```
ETHER:  ----- Ether Header -----
ETHER:
ETHER:  Packet 467 arrived at 15:08:24.38500
ETHER:  Packet size = 1294 bytes
ETHER:  Destination = 0:e:c6:2c:bb:12,
ETHER:  Source      = a8:40:25:4:e:82,
ETHER:  Ethertype = 86DD (IPv6)
ETHER:
IPv6:   ----- IPv6 Header -----
IPv6:
IPv6:   Version = 6
IPv6:   Traffic Class = 0
IPv6:   Flow label = 0x0
IPv6:   Payload length = 1240
IPv6:   Next Header = 58 (ICMPv6)
IPv6:   Hop Limit = 64
IPv6:   Source address = fe80::aa40:25ff:fe04:e82
IPv6:   Destination address = fe80::20e:c6ff:fe2c:bb12
IPv6:
ICMPv6:  ----- ICMPv6 Header -----
ICMPv6:
ICMPv6:  Type = 4 (Parameter problem)
ICMPv6:  Code = 1 (Unrecognized next header type)
ICMPv6:  Checksum = a72d
ICMPv6:  Ptr = 40
ICMPv6:
```

This PR adds a maximum single packet size of 1024 bytes.  This revealed a Hubris issue (https://github.com/oxidecomputer/hubris/pull/2554), but with both fixed, I can do `pmbus -s` over the network without any problems.