### PR TITLE
Bump `tlvc` and make `VpdError` more idiomatic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5031,10 +5031,11 @@ dependencies = [
 
 [[package]]
 name = "tlvc"
-version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/tlvc#2f69360ddcb07ad6072cb720bb1fac9f58a2ddec"
+version = "0.4.1"
+source = "git+https://github.com/oxidecomputer/tlvc#7a96eab94c8aec9120412d8601ffd68853957da3"
 dependencies = [
  "crc",
+ "thiserror 2.0.18",
  "zerocopy",
  "zerocopy-derive",
 ]
@@ -5042,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "tlvc-text"
 version = "0.4.0"
-source = "git+https://github.com/oxidecomputer/tlvc#2f69360ddcb07ad6072cb720bb1fac9f58a2ddec"
+source = "git+https://github.com/oxidecomputer/tlvc#7a96eab94c8aec9120412d8601ffd68853957da3"
 dependencies = [
  "ron 0.8.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ measurement-token = { git = "https://github.com/oxidecomputer/lpc55_support", de
 pmbus = { git = "https://github.com/oxidecomputer/pmbus" }
 serialport = { git = "https://github.com/jgallagher/serialport-rs", branch = "illumos-support" }
 spd = { git = "https://github.com/oxidecomputer/spd" }
-tlvc = { git = "https://github.com/oxidecomputer/tlvc", version = "0.4.0" }
+tlvc = { git = "https://github.com/oxidecomputer/tlvc", version = "0.4.1" }
 tlvc-text = { git = "https://github.com/oxidecomputer/tlvc", version = "0.4.0" }
 turin-post-decoder = { git = "https://github.com/oxidecomputer/turin-post-decoder" }
 vsc7448-info = { git = "https://github.com/oxidecomputer/vsc7448.git" }

--- a/humility-vpd-lib/src/lib.rs
+++ b/humility-vpd-lib/src/lib.rs
@@ -37,8 +37,8 @@ pub enum VpdError {
         err: std::io::Error,
     },
     /// TLV reading issue
-    #[error("tlvc: {0:?}")]
-    Tlvc(TlvcReadError<core::convert::Infallible>),
+    #[error("tlvc read error")]
+    Tlvc(#[from] TlvcReadError<core::convert::Infallible>),
     /// VPD region was never programmed
     #[error("VPD region is unprogrammed")]
     Unprogrammed,
@@ -452,7 +452,7 @@ fn vpd_slurp(
     // First, read in enough to read just the header.
     let mut vpd = vpd_read_at(core, context, &op, target, 0)?;
 
-    let reader = tlvc::TlvcReader::begin(&vpd[..]).map_err(VpdError::Tlvc)?;
+    let reader = tlvc::TlvcReader::begin(&vpd[..])?;
 
     // If this isn't a header, see if it's all 0xff -- in which case we
     // will suggest that the part is unprogrammed.


### PR DESCRIPTION
Per https://github.com/oxidecomputer/humility/pull/670#discussion_r3274415262, now that https://github.com/oxidecomputer/tlvc/pull/12 is merged, we can make the error more idiomatic.