### PR TITLE
Use `hubtools` function to get file metadata without extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1345,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1807,8 +1807,8 @@ dependencies = [
 
 [[package]]
 name = "hubtools"
-version = "0.4.8"
-source = "git+https://github.com/oxidecomputer/hubtools.git#5e41fbe7560b27eaa25bce3b322f7a612fac8f41"
+version = "0.4.9"
+source = "git+https://github.com/oxidecomputer/hubtools.git#5ea53d26576c5922534573ffd86d0108058a00e9"
 dependencies = [
  "digest 0.11.2",
  "hex",
@@ -4047,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4845,7 +4845,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5398,7 +5398,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6205,7 +6205,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,7 +2129,6 @@ dependencies = [
  "num-traits",
  "parse_int",
  "zerocopy",
- "zip",
 ]
 
 [[package]]
@@ -2168,7 +2167,6 @@ dependencies = [
  "clap",
  "humility-cli",
  "humility-log",
- "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ rust-version = "1.91" # if this changes, edit ci.yaml as well!
 # `git`-based deps
 gimlet-inspector-protocol = { git = "https://github.com/oxidecomputer/gimlet-inspector-protocol" }
 hif = { git = "https://github.com/oxidecomputer/hif" }
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", version = "0.4.9" }
 humpty = { git = "https://github.com/oxidecomputer/humpty", version = "0.1.5" }
 idol = { git = "https://github.com/oxidecomputer/idolatry.git" }
 idt8a3xxxx = { git = "https://github.com/oxidecomputer/idt8a3xxxx" }

--- a/cmd/dump/Cargo.toml
+++ b/cmd/dump/Cargo.toml
@@ -16,7 +16,6 @@ lzss.workspace = true
 num-traits.workspace = true
 parse_int.workspace = true
 zerocopy.workspace = true
-zip.workspace = true
 
 humility.workspace = true
 humility-cli.workspace = true

--- a/cmd/extract/Cargo.toml
+++ b/cmd/extract/Cargo.toml
@@ -7,7 +7,6 @@ description = "extract all or part of a Hubris archive"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-zip.workspace = true
 
 humility-cli.workspace = true
 humility-log.workspace = true

--- a/cmd/extract/src/lib.rs
+++ b/cmd/extract/src/lib.rs
@@ -134,8 +134,7 @@ use clap::Parser;
 use humility_cli::{ExecutionContext, humility_cmd};
 use humility_log::info;
 use std::fs::File;
-use std::io::Cursor;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 
 #[derive(Parser, Debug)]
 #[clap(name = "extract", about = env!("CARGO_PKG_DESCRIPTION"))]
@@ -157,32 +156,24 @@ fn extract(subargs: ExtractArgs, context: &mut ExecutionContext) -> Result<()> {
     let log = context.log();
 
     if subargs.list {
-        // We convert the archive data back into a `ZipArchive` instead of using
-        // `RawHubrisArchive` functions for speed; the `ZipArchive` can report
-        // file size without uncompressing.
-        let cursor = Cursor::new(archive.zip);
-        let mut archive = zip::ZipArchive::new(cursor)?;
-
         println!("{:>12} NAME", "SIZE");
 
-        for i in 0..archive.len() {
-            let file = archive.by_index(i)?;
-            println!("{:12} {}", file.size(), file.name());
+        for i in 0..archive.file_count()? {
+            let file = archive.file_metadata_by_index(i)?;
+            println!("{:12} {}", file.size, file.name);
         }
 
         return Ok(());
     }
 
     let buffer = if let Some(ref filename) = subargs.file {
-        let cursor = Cursor::new(archive.zip);
-        let mut archive = zip::ZipArchive::new(cursor)?;
         let mut found = vec![];
 
-        for i in 0..archive.len() {
-            let file = archive.by_index(i)?;
+        for i in 0..archive.file_count()? {
+            let file = archive.file_metadata_by_index(i)?;
 
-            if file.name().contains(filename) {
-                found.push((i, file.name().to_string()));
+            if file.name.contains(filename) {
+                found.push((i, file.name));
             }
         }
 
@@ -207,10 +198,7 @@ fn extract(subargs: ExtractArgs, context: &mut ExecutionContext) -> Result<()> {
 
         info!(log, "extracting {} to stdout", found[0].1);
 
-        let mut file = archive.by_index(found[0].0)?;
-
-        let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)?;
+        let (_, buffer) = archive.extract_file_by_index(found[0].0)?;
         buffer
     } else {
         archive.zip.to_vec()

--- a/humility-core/src/hubris.rs
+++ b/humility-core/src/hubris.rs
@@ -1504,10 +1504,8 @@ impl HubrisArchive {
         let mut objects = (0..hubris.file_count()?)
             .into_par_iter()
             .map(|i| -> Result<Option<(usize, String, Vec<u8>)>> {
-                // TODO(matt) once hubtools#65 is merged, this can be made more
-                // efficient; right now, it extracts every file.
-                let (name, data) = hubris.extract_file_by_index(i)?;
-                let path = Path::new(&name);
+                let meta = hubris.file_metadata_by_index(i)?;
+                let path = Path::new(&meta.name);
                 let pieces = path.iter().collect::<Vec<_>>();
 
                 //
@@ -1518,10 +1516,10 @@ impl HubrisArchive {
                     return Ok(None);
                 }
 
-                let filename = Path::new(&name);
+                let (_, data) = hubris.extract_file_by_index(i)?;
                 Ok(Some((
                     i,
-                    filename.file_name().unwrap().to_str().unwrap().to_owned(),
+                    path.file_name().unwrap().to_str().unwrap().to_owned(),
                     data,
                 )))
             })


### PR DESCRIPTION
https://github.com/oxidecomputer/hubtools/pull/65 allows us to get file metadata without extracting the file.

When loading the archive, this can be significant (because the auxiliary flash image is chunky).  On my machine, this yields a 16% improvement in test suite runtime (`cargo test --release`): from 31.4s to 26.1s.

It also lets us hide the `zip` internals in `humility extract`.