### PR TITLE
Fix PMBus backend selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,6 +2934,8 @@ dependencies = [
  "humility-idol",
  "idol",
  "postcard",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,6 +2440,7 @@ dependencies = [
  "indexmap 2.14.0",
  "parse_int",
  "pmbus",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -1996,13 +1996,16 @@ just PMBus devices.)
 selected by the `--agent` command-line argument.
 
 - `--agent=i2c` uses direct construction and execution of raw I2C commands.
-  This only works when connected to the target via a debugger.
+  This works when connected to the target via a debugger, or when the target
+  has a `hiffy` task with the `net` feature enabled
 - `--agent=idol` uses Idol operations, which can be executed over the
   network.  This could also be used (in theory) when connected with a
-  debugger; in practice, the Idol operations have a larger encoding compared
-  to raw I2C operations, so the HIF program may not fit.
-- `--agent=auto` (the default) selects `i2c` if we're connected with a
-  debugger or `idol` if we're connected over the network.
+  debugger or when using the `hiffy` + `net` backend; in practice, the Idol
+  operations have a larger encoding compared to raw I2C operations, so the
+  HIF program may not fit.
+- `--agent=auto` (the default) selects `i2c` if we're either connected with a
+  debugger or support the `hiffy` + `net` backend, or `idol` if we're
+  connected over the network.
 
 In practice, allowing `humility pmbus` to select the agent is almost always
 what you want.

--- a/cmd/pmbus/Cargo.toml
+++ b/cmd/pmbus/Cargo.toml
@@ -12,6 +12,7 @@ hif.workspace = true
 indexmap.workspace = true
 parse_int.workspace = true
 pmbus.workspace = true
+thiserror.workspace = true
 
 humility.workspace = true
 humility-cli.workspace = true

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1955,15 +1955,19 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
         I2c,
         Idol,
         IdolWarn(&'static str),
-        Bail(&'static str),
+        Bail(anyhow::Error),
     }
 
     // ...and a couple of constant texts that we may use for warnings/errors
     const TOO_BIG: &str = "idol interface may use too much program text when \
         using the `hiffy` task for execution; consider selecting the `i2c` \
         agent instead";
-    const NO_NET: &str = "cannot use `i2c` agent over the network without \
-        network-enabled hiffy";
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(
+        "cannot use `i2c` agent over the network without network-enabled hiffy"
+    )]
+    struct NoNet;
 
     // Now: choose your fighter!
     let choice = match (&subargs.agent, context.backend()) {
@@ -1972,13 +1976,13 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
         // we have `net` support in the `hiffy` task.  It also produces shorter
         // program text, which matters because the program executes on the
         // target system.
-        (Agent::Auto, HiffyBackend::Debugger) => Choice::I2c,
-        (Agent::Auto, HiffyBackend::NetHiffy) => Choice::I2c,
-        (Agent::I2c, HiffyBackend::Debugger) => Choice::I2c,
-        (Agent::I2c, HiffyBackend::NetHiffy) => Choice::I2c,
+        (
+            Agent::Auto | Agent::I2c,
+            HiffyBackend::Debugger | HiffyBackend::NetHiffy,
+        ) => Choice::I2c,
 
         // The `I2cWorker` cannot be used with the UDP RPC backend.
-        (Agent::I2c, HiffyBackend::NetUdpRpc) => Choice::Bail(NO_NET),
+        (Agent::I2c, HiffyBackend::NetUdpRpc) => Choice::Bail(NoNet.into()),
 
         // An `IdolWorker` constructs a HIF program which uses only `SEND` calls
         // to call Idol APIs in the `power` task.  This takes up more space in
@@ -1986,10 +1990,13 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
         // which only has the `udprpc` task.  In such a situation, the HIF
         // program is run on the host computer, so the additional program text
         // doesn't make a difference.
-        (Agent::Auto, HiffyBackend::NetUdpRpc) => Choice::Idol,
-        (Agent::Idol, HiffyBackend::NetUdpRpc) => Choice::Idol,
-        (Agent::Idol, HiffyBackend::Debugger) => Choice::IdolWarn(TOO_BIG),
-        (Agent::Idol, HiffyBackend::NetHiffy) => Choice::IdolWarn(TOO_BIG),
+        (Agent::Auto | Agent::Idol, HiffyBackend::NetUdpRpc) => Choice::Idol,
+
+        // If someone manually chooses the `IdolWorker` in a context where the
+        // HIF program is run on the target device, then we print a warning.
+        (Agent::Idol, HiffyBackend::Debugger | HiffyBackend::NetHiffy) => {
+            Choice::IdolWarn(TOO_BIG)
+        }
     };
 
     // We've finished planning, now start doing.
@@ -2000,7 +2007,7 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
             warn!(log, "{wrn}");
             Box::new(IdolWorker::new(hubris, core, context)?)
         }
-        Choice::Bail(err) => bail!(err),
+        Choice::Bail(err) => return Err(err),
     };
 
     if subargs.summarize {

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -176,13 +176,16 @@
 //! selected by the `--agent` command-line argument.
 //!
 //! - `--agent=i2c` uses direct construction and execution of raw I2C commands.
-//!   This only works when connected to the target via a debugger.
+//!   This works when connected to the target via a debugger, or when the target
+//!   has a `hiffy` task with the `net` feature enabled
 //! - `--agent=idol` uses Idol operations, which can be executed over the
 //!   network.  This could also be used (in theory) when connected with a
-//!   debugger; in practice, the Idol operations have a larger encoding compared
-//!   to raw I2C operations, so the HIF program may not fit.
-//! - `--agent=auto` (the default) selects `i2c` if we're connected with a
-//!   debugger or `idol` if we're connected over the network.
+//!   debugger or when using the `hiffy` + `net` backend; in practice, the Idol
+//!   operations have a larger encoding compared to raw I2C operations, so the
+//!   HIF program may not fit.
+//! - `--agent=auto` (the default) selects `i2c` if we're either connected with a
+//!   debugger or support the `hiffy` + `net` backend, or `idol` if we're
+//!   connected over the network.
 //!
 //! In practice, allowing `humility pmbus` to select the agent is almost always
 //! what you want.
@@ -1456,14 +1459,7 @@ struct I2cWorker<'a> {
 }
 
 impl<'a> I2cWorker<'a> {
-    fn new(
-        hubris: &'a HubrisArchive,
-        core: &'a mut dyn Core,
-        timeout: u64,
-        log: &Logger,
-    ) -> Result<Self> {
-        let timeout = std::time::Duration::from_millis(timeout);
-        let context = HiffyContext::new(hubris, core, timeout, log)?;
+    fn new(core: &'a mut dyn Core, context: HiffyContext<'a>) -> Result<Self> {
         let read_func = context.get_function("I2cRead", 7)?;
         let write_func = context.get_function("I2cWrite", 8)?;
         Ok(Self { core, context, read_func, write_func, ops: vec![] })
@@ -1642,11 +1638,8 @@ impl<'a> IdolWorker<'a> {
     fn new(
         hubris: &'a HubrisArchive,
         core: &'a mut dyn Core,
-        timeout: u64,
-        log: &Logger,
+        context: HiffyContext<'a>,
     ) -> Result<Self> {
-        let timeout = std::time::Duration::from_millis(timeout);
-        let context = HiffyContext::new(hubris, core, timeout, log)?;
         let write_set = hubris.get_idol_command("Power.raw_pmbus_set")?;
         let write_byte =
             hubris.get_idol_command("Power.raw_pmbus_write_byte")?;
@@ -1946,34 +1939,58 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
 
     let core = &mut *context.cli.attach_live_booted(hubris)?;
 
-    let timeout = subargs.timeout;
+    let timeout = std::time::Duration::from_millis(subargs.timeout);
 
     // Pick an implementation based on our flags and core state
+    //
+    // This is a little subtle, and requires knowing the difference between the
+    // two worker types:
+    //
+    // - An `I2cWorker` constructs a HIF program which calls I2C read and write
+    //   APIs directly.  This works when a debugger is attached, or when we have
+    //   `net` support in the `hiffy` task.  It also produces shorter program
+    //   text, which matters because the program executes on the target system.
+    // - An `IdolWorker` constructs a HIF program which uses only `SEND` calls
+    //   to call Idol APIs in the `power` task.  This takes up more space in HIF
+    //   program text, but can be invoked over the network in a system which
+    //   only has the `udprpc` task.  In such a situation, the HIF program is
+    //   run on the host computer, so the additional program text doesn't make a
+    //   difference.
+    //
+    //  We ask the `HiffyContext` which backend it plans to use, then select the
+    //  worker (and warn / bail) appropriately.
+    let context = HiffyContext::new(hubris, core, timeout, log)?;
     let mut worker: Box<dyn PmbusWorker> = match subargs.agent {
-        Agent::Auto => {
-            if core.is_net() {
-                Box::new(IdolWorker::new(hubris, core, timeout, log)?)
-            } else {
-                Box::new(I2cWorker::new(hubris, core, timeout, log)?)
+        Agent::Auto => match context.backend() {
+            HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
+                Box::new(I2cWorker::new(core, context)?)
             }
-        }
-        Agent::I2c => {
-            if core.is_net() {
-                bail!("cannot use I2C agent over the network");
-            } else {
-                Box::new(I2cWorker::new(hubris, core, timeout, log)?)
+            HiffyBackend::NetUdpRpc => {
+                Box::new(IdolWorker::new(hubris, core, context)?)
             }
-        }
+        },
+        Agent::I2c => match context.backend() {
+            HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
+                Box::new(I2cWorker::new(core, context)?)
+            }
+            HiffyBackend::NetUdpRpc => bail!(
+                "cannot use `i2c` agent over the network \
+                 without network-enabled hiffy"
+            ),
+        },
         Agent::Idol => {
-            if !core.is_net() {
-                warn!(
-                    log,
-                    "idol interface may use too much program text when \
-                     connected via debugger; \
-                     consider using the i2c core instead"
-                );
+            match context.backend() {
+                HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
+                    warn!(
+                        log,
+                        "idol interface may use too much program text when \
+                         using the `hiffy` task for execution; \
+                         consider selecting the `i2c` agent instead"
+                    );
+                }
+                HiffyBackend::NetUdpRpc => (),
             }
-            Box::new(IdolWorker::new(hubris, core, timeout, log)?)
+            Box::new(IdolWorker::new(hubris, core, context)?)
         }
     };
 

--- a/cmd/pmbus/src/lib.rs
+++ b/cmd/pmbus/src/lib.rs
@@ -1941,57 +1941,66 @@ fn pmbus(subargs: PmbusArgs, context: &mut ExecutionContext) -> Result<()> {
 
     let timeout = std::time::Duration::from_millis(subargs.timeout);
 
+    let context = HiffyContext::new(hubris, core, timeout, log)?;
+
     // Pick an implementation based on our flags and core state
     //
     // This is a little subtle, and requires knowing the difference between the
-    // two worker types:
+    // two worker types. We ask the `HiffyContext` which backend it plans to
+    // use, then select the worker (and warn / bail) appropriately.
     //
-    // - An `I2cWorker` constructs a HIF program which calls I2C read and write
-    //   APIs directly.  This works when a debugger is attached, or when we have
-    //   `net` support in the `hiffy` task.  It also produces shorter program
-    //   text, which matters because the program executes on the target system.
-    // - An `IdolWorker` constructs a HIF program which uses only `SEND` calls
-    //   to call Idol APIs in the `power` task.  This takes up more space in HIF
-    //   program text, but can be invoked over the network in a system which
-    //   only has the `udprpc` task.  In such a situation, the HIF program is
-    //   run on the host computer, so the additional program text doesn't make a
-    //   difference.
-    //
-    //  We ask the `HiffyContext` which backend it plans to use, then select the
-    //  worker (and warn / bail) appropriately.
-    let context = HiffyContext::new(hubris, core, timeout, log)?;
-    let mut worker: Box<dyn PmbusWorker> = match subargs.agent {
-        Agent::Auto => match context.backend() {
-            HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
-                Box::new(I2cWorker::new(core, context)?)
-            }
-            HiffyBackend::NetUdpRpc => {
-                Box::new(IdolWorker::new(hubris, core, context)?)
-            }
-        },
-        Agent::I2c => match context.backend() {
-            HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
-                Box::new(I2cWorker::new(core, context)?)
-            }
-            HiffyBackend::NetUdpRpc => bail!(
-                "cannot use `i2c` agent over the network \
-                 without network-enabled hiffy"
-            ),
-        },
-        Agent::Idol => {
-            match context.backend() {
-                HiffyBackend::Debugger | HiffyBackend::NetHiffy => {
-                    warn!(
-                        log,
-                        "idol interface may use too much program text when \
-                         using the `hiffy` task for execution; \
-                         consider selecting the `i2c` agent instead"
-                    );
-                }
-                HiffyBackend::NetUdpRpc => (),
-            }
+    // This is a small helper enum to help separate "planning" and "doing"
+    // stages...
+    enum Choice {
+        I2c,
+        Idol,
+        IdolWarn(&'static str),
+        Bail(&'static str),
+    }
+
+    // ...and a couple of constant texts that we may use for warnings/errors
+    const TOO_BIG: &str = "idol interface may use too much program text when \
+        using the `hiffy` task for execution; consider selecting the `i2c` \
+        agent instead";
+    const NO_NET: &str = "cannot use `i2c` agent over the network without \
+        network-enabled hiffy";
+
+    // Now: choose your fighter!
+    let choice = match (&subargs.agent, context.backend()) {
+        // An `I2cWorker` constructs a HIF program which calls I2C read and
+        // write APIs directly.  This works when a debugger is attached, or when
+        // we have `net` support in the `hiffy` task.  It also produces shorter
+        // program text, which matters because the program executes on the
+        // target system.
+        (Agent::Auto, HiffyBackend::Debugger) => Choice::I2c,
+        (Agent::Auto, HiffyBackend::NetHiffy) => Choice::I2c,
+        (Agent::I2c, HiffyBackend::Debugger) => Choice::I2c,
+        (Agent::I2c, HiffyBackend::NetHiffy) => Choice::I2c,
+
+        // The `I2cWorker` cannot be used with the UDP RPC backend.
+        (Agent::I2c, HiffyBackend::NetUdpRpc) => Choice::Bail(NO_NET),
+
+        // An `IdolWorker` constructs a HIF program which uses only `SEND` calls
+        // to call Idol APIs in the `power` task.  This takes up more space in
+        // HIF program text, but can be invoked over the network in a system
+        // which only has the `udprpc` task.  In such a situation, the HIF
+        // program is run on the host computer, so the additional program text
+        // doesn't make a difference.
+        (Agent::Auto, HiffyBackend::NetUdpRpc) => Choice::Idol,
+        (Agent::Idol, HiffyBackend::NetUdpRpc) => Choice::Idol,
+        (Agent::Idol, HiffyBackend::Debugger) => Choice::IdolWarn(TOO_BIG),
+        (Agent::Idol, HiffyBackend::NetHiffy) => Choice::IdolWarn(TOO_BIG),
+    };
+
+    // We've finished planning, now start doing.
+    let mut worker: Box<dyn PmbusWorker> = match choice {
+        Choice::I2c => Box::new(I2cWorker::new(core, context)?),
+        Choice::Idol => Box::new(IdolWorker::new(hubris, core, context)?),
+        Choice::IdolWarn(wrn) => {
+            warn!(log, "{wrn}");
             Box::new(IdolWorker::new(hubris, core, context)?)
         }
+        Choice::Bail(err) => bail!(err),
     };
 
     if subargs.summarize {

--- a/humility-hiffy/Cargo.toml
+++ b/humility-hiffy/Cargo.toml
@@ -8,6 +8,8 @@ anyhow.workspace = true
 hif.workspace = true
 idol.workspace = true
 postcard.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 zerocopy.workspace = true
 

--- a/humility-hiffy/src/lib.rs
+++ b/humility-hiffy/src/lib.rs
@@ -77,6 +77,9 @@ impl<'a> HiffyVars<'a> {
     }
 }
 
+#[derive(strum_macros::EnumDiscriminants)]
+#[strum_discriminants(name(HiffyBackend))]
+#[strum_discriminants(vis(pub))]
 enum HiffyImpl<'a> {
     /// We are physically attached with a debugger
     Debugger(HiffyVars<'a>),
@@ -1444,6 +1447,11 @@ impl<'a> HiffyContext<'a> {
             }
             idol::IdolDecodeError::Idol(v) => HiffyError::Hiffy(v),
         })
+    }
+
+    /// Returns the backend that will be used to execute HIF programs
+    pub fn backend(&self) -> HiffyBackend {
+        (&self.hiffy).into()
     }
 }
 


### PR DESCRIPTION
(There's a new big block comment that explains what's going on, so you may want to go read that)

Previously, we would always select the `IdolWorker` PMBus agent when network connected.  This is fine for the `udprpc` backend, where the HIF program is executed on the host computer and so the additional overhead of Idol IPC doesn't matter.  

However, the introduction of the `hiffy`+`net` backend means that we would (1) select the `IdolWorker` agent, because the system is network-connected then (2) use the `hiffy` backend, executing the larger programs on the SP.  This is not ideal!

This PR teaches the `pmbus` crate about the different `HiffyContext` backends, so that it can make smarter choices.