### PR TITLE
cmd/readmem: bail on u32 address overflow in --file path

### DIFF
--- a/cmd/readmem/src/lib.rs
+++ b/cmd/readmem/src/lib.rs
@@ -206,15 +206,25 @@ fn readmem(subargs: ReadmemArgs, context: &mut ExecutionContext) -> Result<()> {
         }
     };
 
+    // line 208 (blank)
     if addr & (size - 1) as u32 != 0 {
         bail!("address must be {}-byte aligned", size);
     }
 
     if let Some(file) = subargs.file {
+        let len32 = u32::try_from(length)
+            .ok()
+            .and_then(|l| addr.checked_add(l))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "address 0x{:08x} + length {} overflows a 32-bit address",
+                    addr,
+                    length
+                )
+            })?;
         let mut f = std::fs::File::create(&file)?;
         let mut bytes = vec![0u8; max];
-        for (i, addr) in (addr..addr + (length as u32)).step_by(max).enumerate()
-        {
+        for (i, addr) in (addr..len32).step_by(max).enumerate() {
             let buf = &mut bytes[..std::cmp::min(max, length - (i * max))];
             core.read_8(addr, buf)?;
             f.write_all(buf)?;
@@ -222,7 +232,6 @@ fn readmem(subargs: ReadmemArgs, context: &mut ExecutionContext) -> Result<()> {
         info!(log, "Wrote {} bytes to {:?}", length, file);
         return Ok(());
     }
-
     if length > max {
         bail!("cannot read more than {} bytes", max);
     }

--- a/humility-hexdump/src/lib.rs
+++ b/humility-hexdump/src/lib.rs
@@ -142,3 +142,44 @@ impl Default for Dumper {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// dump() computes the first-line offset as `addr & (width - 1)`.
+    /// Verify that a non-zero starting address correctly places data
+    /// at the right column in the first row (i.e. offset = addr % 16).
+    #[test]
+    fn dump_offset_from_address() {
+        // addr = 0x13: offset within a 16-byte row = 3
+        // only 1 byte of data — should not panic
+        let mut d = Dumper::new();
+        d.header = false;
+        d.ascii = false;
+        // Exercise path: offs = 0x13 & 0x0f = 3, lim = min(16-3, 1) = 1
+        d.dump(&[0xAB], 0x13);
+    }
+
+    /// When addr is at the very end of the u32 address space and the byte
+    /// slice is exactly 1 byte, dump() must not overflow the addr arithmetic.
+    #[test]
+    fn dump_high_address_single_byte() {
+        let mut d = Dumper::new();
+        d.header = false;
+        d.ascii = false;
+        // offs = 0xFFFFFFFF & 0x0F = 15; lim = min(16-15, 1) = 1; no wrapping
+        d.dump(&[0xFF], 0xFFFF_FFFF);
+    }
+
+    /// Verify that a multi-chunk dump (more than one 16-byte row) advances
+    /// addr correctly between rows without wrapping.
+    #[test]
+    fn dump_multirow_addr_advance() {
+        let mut d = Dumper::new();
+        d.header = false;
+        d.ascii = false;
+        // addr = 0, 32 bytes → 2 rows; addr increments by 16 between rows
+        d.dump(&[0u8; 32], 0x0);
+    }
+}


### PR DESCRIPTION
On the `--file` path, the address range is computed as:

    addr..addr + (length as u32)

Both `addr` and the result are `u32`. If `addr + length` exceeds `0xFFFF_FFFF`, the addition wraps silently in release builds, producing an end value smaller than the start. This makes `Range<u32>` empty, the loop never executes, and the output file is created with zero bytes — while the CLI logs "Wrote N bytes to ..." as if everything succeeded.

This is not a theoretical edge case. Cortex-M peripherals commonly live at high addresses (`0xFFFF_0000`, `0xE000_0000`, etc.). Reading more bytes than the gap between the start address and `0xFFFFFFFF` is enough to trigger it. For example:

    humility readmem --file out.bin 0xFFFF0000 131072

`0xFFFF_0000 + 131072` wraps to `0x0001_0000`. The loop runs zero iterations. `out.bin` is empty. The user sees no error.

The non-file path is already protected against oversized reads by the `length > max` guard at line 226. The file path has no equivalent guard, and that is what this PR fixes.

The fix computes the end address with `u32::try_from` + `checked_add` and bails with a clear error if either overflows, before the file is created or any loop runs.