### PR TITLE
Set rustfmt edition and style_edition for consistency

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,7 @@
 max_width = 80
 use_small_heuristics = "max"
+edition = "2024"
+style_edition = "2024"
 
 # Unfortunately, this feature is only available on nightly. :|  Without it,
 # comments can be of arbitrary width (!) so they need to be manually verified.


### PR DESCRIPTION
This is equivalent to this hubris PR: https://github.com/oxidecomputer/hubris/pull/2525

Before, running `rustfmt` on an individual file (eg. via an editor plugin) would sometimes produce different formatting than running `cargo fmt` on the whole workspace. That seems to be because `cargo fmt` infers the `edition` and `style_edition`  from Cargo.toml, but `rustfmt` needs them to be set explicitly in .rustfmt.toml.

Here's a specific formatting difference in case anyone's curious or wants to test it. 

`rustfmt` (before this PR):
```
use foo::{a::C, B};
```
`cargo fmt` (always), and `rustfmt` (after this PR):
```
use foo::{B, a::C};
```

So to be clear, this PR does not change the output of `cargo fmt`. The only downside I know of is that if we bump the edition of the workspace, we'll need to remember to bump it in .rustfmt.toml too.