### PR TITLE
Drop to line-tables-only for debug in new `binrelease` profile

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --profile binrelease
 
       - name: Upload Release
-        run: gh release upload --repo oxidecomputer/humility nightly --clobber target/release/humility
+        run: gh release upload --repo oxidecomputer/humility nightly --clobber target/binrelease/humility
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,10 @@ zip = "8.6.0"
 [profile.release]
 debug = true
 
+[profile.binrelease]
+inherits = "release"
+debug = "line-tables-only"
+
 [profile.ci]
 inherits = "release"
 debug = false


### PR DESCRIPTION
This allows for retaining panic messages and backtraces, without retaining all debuginfo. On linux, this is a significant size savings, 516.1MiB -> 181.4MiB, and also is a bit quicker to build, about 2m10s vs 2m41s on my Ryzen 1700X system.

This is an opt-in change, as it requires --profile binrelease, but this new profile is used for the nightly workflow, meaning that CI will pull this instead of the --release binary.

This should only be a functional change if anyone is trying to debug humility itself, e.g. using `gdb`.

I've seen some CI failures when pulling this file, and it might be due to the size (I have no proof of this):

https://github.com/oxidecomputer/hubris/actions/runs/29899522236/job/88859630586

We might want to do something similar for whatever gets packaged for illumos as well, or we could consider making this the default for the `release` profile.

Docs for `debug`: https://doc.rust-lang.org/cargo/reference/profiles.html#debug, discussing `line-tables-only`.