### PR TITLE
Bump our probe-rs fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,6 +232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-udev"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a45f9771ced8a774de5e5ebffbe520f52e3943bf5a9a6baa3a5d14a5de1afe6"
+
+[[package]]
 name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1766,12 +1772,16 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hidapi"
-version = "1.4.1"
-source = "git+https://github.com/oxidecomputer/hidapi-rs?branch=oxide-stable#69f84deac74461bfc08adefd1feb8abe4fcdda26"
+version = "2.6.6"
+source = "git+https://github.com/oxidecomputer/hidapi-rs?branch=oxide-v2.6.6#74fcda94106181a4dca32370727b794011489afd"
 dependencies = [
+ "basic-udev",
  "cc",
+ "cfg-if",
  "libc",
+ "nix 0.30.1",
  "pkg-config",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1875,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "humility-bin"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -3368,12 +3378,22 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.4.3",
+]
+
+[[package]]
+name = "io-kit-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.5.0",
 ]
 
 [[package]]
@@ -3681,6 +3701,15 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -3845,6 +3874,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4016,7 +4056,7 @@ dependencies = [
  "core-foundation-sys",
  "devinfo",
  "futures-core",
- "io-kit-sys",
+ "io-kit-sys 0.5.0",
  "libc",
  "linux-raw-sys",
  "log",
@@ -4446,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "probe-rs"
 version = "0.31.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#c4680958c3d2faa94447cdad42013ddd5dac9b74"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#91d027e2bd786a4ec14e3b8bf3345ec52d08ca33"
 dependencies = [
  "anyhow",
  "async-io",
@@ -4471,6 +4511,7 @@ dependencies = [
  "scroll",
  "serde",
  "serde_yaml",
+ "serialport",
  "thiserror 2.0.18",
  "tracing",
  "uf2-decode",
@@ -4480,7 +4521,7 @@ dependencies = [
 [[package]]
 name = "probe-rs-target"
 version = "0.31.0"
-source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#c4680958c3d2faa94447cdad42013ddd5dac9b74"
+source = "git+https://github.com/oxidecomputer/probe-rs.git?branch=oxide_v0.31.0#91d027e2bd786a4ec14e3b8bf3345ec52d08ca33"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
@@ -4875,7 +4916,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5103,6 +5144,23 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serialport"
+version = "4.7.1-alpha.0"
+source = "git+https://github.com/oxidecomputer/serialport-rs?branch=illumos-support-4.7.1#8d0fd3a8a226b9160dc6c11f15235e5455bcbdb5"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys 0.4.1",
+ "mach2 0.4.3",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "winapi",
 ]
 
 [[package]]
@@ -5428,7 +5486,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5858,6 +5916,15 @@ name = "uf2-decode"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca77d41ab27e3fa45df42043f96c79b80c6d8632eed906b54681d8d47ab00623"
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/humility-bin/Cargo.toml
+++ b/humility-bin/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "humility-bin"
 edition.workspace = true
-version = "0.13.2"
+version = "0.13.3"
 license = "MPL-2.0"
 
 [build-dependencies]

--- a/humility-bin/tests/cmd/chip.trycmd
+++ b/humility-bin/tests/cmd/chip.trycmd
@@ -13,7 +13,7 @@ For more information, try '--help'.
 
 ```
 $ humility --chip this-can-be-anything -V
-humility 0.13.2 
+humility 0.13.3 
 
 ```
 
@@ -28,7 +28,7 @@ For more information, try '--help'.
 
 ```
 $ humility -c apx432 -V
-humility 0.13.2 
+humility 0.13.3 
 
 ```
 

--- a/humility-bin/tests/cmd/version.trycmd
+++ b/humility-bin/tests/cmd/version.trycmd
@@ -2,7 +2,7 @@ Long version flag:
 
 ```
 $ humility --version
-humility 0.13.2 
+humility 0.13.3 
 
 ```
 
@@ -10,6 +10,6 @@ Short version flag:
 
 ```
 $ humility -V
-humility 0.13.2 
+humility 0.13.3 
 
 ```


### PR DESCRIPTION
This brings in a newer hidapi-rs and serialport. There were compilation problems for some cases when using the older version.